### PR TITLE
Add fixes for symbols and errors

### DIFF
--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -69,7 +69,9 @@ structure CityCoordinates {
 structure NoSuchResource {
     /// The type of resource that was not found.
     @required
-    resourceType: String
+    resourceType: String,
+
+    message: String,
 }
 
 // The paginated trait indicates that the operation may

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -17,12 +17,8 @@ package software.amazon.smithy.typescript.codegen;
 
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
-import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider;
-import software.amazon.smithy.codegen.core.ReservedWords;
-import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Plugin to trigger TypeScript code generation.
@@ -58,19 +54,6 @@ public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
      * @return Returns the created provider.
      */
     public static SymbolProvider createSymbolProvider(Model model, String rootNamespace, String targetNamespace) {
-        SymbolVisitor symbolProvider = new SymbolVisitor(model, rootNamespace, targetNamespace);
-
-        // Load reserved words from a new-line delimited file.
-        ReservedWords reservedWords = new ReservedWordsBuilder()
-                .loadWords(TypeScriptCodegenPlugin.class.getResource("reserved-words.txt"))
-                .build();
-
-        return ReservedWordSymbolProvider.builder()
-                .nameReservedWords(reservedWords)
-                .symbolProvider(symbolProvider)
-                // Only escape words when the symbol has a namespace. This
-                // prevents escaping intentional references to reserved words.
-                .escapePredicate((shape, symbol) -> !StringUtils.isEmpty(symbol.getNamespace()))
-                .build();
+        return new SymbolVisitor(model, rootNamespace, targetNamespace);
     }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/shapeTypes.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/shapeTypes.ts
@@ -30,9 +30,9 @@ export class SmithyException extends Error implements SmithyStructure {
     name: string;
     service: string;
     fault: "client" | "server";
-    message?: string;
+    message?: string | undefined;
   }) {
-    super(args.message);
+    super(args.message || "");
     this.$id = args.id;
     this.name = args.name;
     this.$service = args.service;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -1,0 +1,62 @@
+package software.amazon.smithy.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+
+public class CodegenVisitorTest {
+    @Test
+    public void properlyGeneratesEmptyMessageMemberOfException() {
+        testErrorStructureCodegen("error-test-empty.smithy");
+    }
+
+    @Test
+    public void properlyGeneratesOptionalMessageMemberOfException() {
+        testErrorStructureCodegen("error-test-optional-message.smithy");
+    }
+
+    @Test
+    public void properlyGeneratesRequiredMessageMemberOfException() {
+        testErrorStructureCodegen("error-test-required-message.smithy");
+    }
+
+    public void testErrorStructureCodegen(String file) {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource(file))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                                  .withMember("service", Node.from("smithy.example#Example"))
+                                  .withMember("package", Node.from("example"))
+                                  .withMember("packageVersion", Node.from("1.0.0"))
+                                  .build())
+                .build();
+
+        new TypeScriptCodegenPlugin().execute(context);
+        String contents = manifest.getFileString("/types/smithy/example/index.ts").get();
+
+        assertThat(contents, containsString("export class Err extends $SmithyException {\n"
+                                            + "  constructor(args: {\n"
+                                            + "    $service: string;\n"
+                                            + "    message?: string;\n"
+                                            + "  }) {\n"
+                                            + "    super({\n"
+                                            + "      message: args.message || \"\",\n"
+                                            + "      id: \"smithy.example#Err\",\n"
+                                            + "      name: \"Err\",\n"
+                                            + "      fault: \"client\",\n"
+                                            + "      service: args.$service,\n"
+                                            + "    });\n"
+                                            + "  }\n"
+                                            + "}"));
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
@@ -44,6 +44,15 @@ public class ImportDeclarationsTest {
     }
 
     @Test
+    public void relativizesImportsWithTrailingFilename() {
+        ImportDeclarations declarations = new ImportDeclarations("foo/bar/index");
+        declarations.addImport("Baz", "", "./shared/shapeTypes");
+        String result = declarations.toString();
+
+        assertThat(result, containsString("import { Baz } from \"../../../shared/shapeTypes\";"));
+    }
+
+    @Test
     public void automaticallyCorrectsBasePath() {
         ImportDeclarations declarations = new ImportDeclarations("/foo/bar");
         declarations.addImport("Baz", "", "./foo/bar/bam/qux");

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-empty.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-empty.smithy
@@ -1,0 +1,11 @@
+namespace smithy.example
+
+service Example {
+    version: "1.0.0",
+    operations: [DoSomething]
+}
+
+operation DoSomething() errors [Err]
+
+@error("client")
+structure Err {}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-optional-message.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-optional-message.smithy
@@ -1,0 +1,13 @@
+namespace smithy.example
+
+service Example {
+    version: "1.0.0",
+    operations: [DoSomething]
+}
+
+operation DoSomething() errors [Err]
+
+@error("client")
+structure Err {
+    message: String,
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-required-message.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-required-message.smithy
@@ -1,0 +1,14 @@
+namespace smithy.example
+
+service Example {
+    version: "1.0.0",
+    operations: [DoSomething]
+}
+
+operation DoSomething() errors [Err]
+
+@error("client")
+structure Err {
+    @required
+    message: String,
+}


### PR DESCRIPTION
1. Reserved words are now escaped in the symbol visitor to account for
   escaping reserved words in symbol references (like a list of Record
   becomes "Array<_Record>".
2. Error structures now normalize the "message" member regardless of the
   model. This prevents typing issues with super.
3. "message" is no longer generated as a property of SmithyException
   subtypes.
4. Fixed a bug in how relative module imports were handled and
   simplified turning module names into file names. Now the module name
   of shapes that are generated always contains "index" to fix
   relativizing imports.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
