### PR TITLE
Move back to interfaces

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ImportDeclarations.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ImportDeclarations.java
@@ -63,18 +63,26 @@ final class ImportDeclarations {
         if (!imports.isEmpty()) {
             for (Map.Entry<String, Map<String, String>> entry : imports.entrySet()) {
                 String module = entry.getKey();
-                Map<String, String> imports = entry.getValue();
+                Map<String, String> moduleImports = entry.getValue();
 
-                if (imports.size() == 1) {
-                    Map.Entry<String, String> singleEntry = imports.entrySet().iterator().next();
-                    result.append("import { ")
-                            .append(createImportStatement(singleEntry))
-                            .append(" } from \"")
-                            .append(module)
-                            .append("\";\n");
+                if (moduleImports.size() == 1) {
+                    Map.Entry<String, String> singleEntry = moduleImports.entrySet().iterator().next();
+                    if (singleEntry.getValue().equals("*")) {
+                        result.append("import ")
+                                .append(createImportStatement(singleEntry))
+                                .append(" from \"")
+                                .append(module)
+                                .append("\";\n");
+                    } else {
+                        result.append("import { ")
+                                .append(createImportStatement(singleEntry))
+                                .append(" } from \"")
+                                .append(module)
+                                .append("\";\n");
+                    }
                 } else {
                     result.append("import {\n");
-                    for (Map.Entry<String, String> importEntry : imports.entrySet()) {
+                    for (Map.Entry<String, String> importEntry : moduleImports.entrySet()) {
                         result.append("  ");
                         result.append(createImportStatement(importEntry));
                         result.append(",\n");

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
@@ -1,19 +1,21 @@
+export const TYPE = "__type";
+
 /**
- * Type that is implemented by all Smithy structures.
+ * Checks if the given value is a Smithy structure of the given type.
  */
-export interface SmithyStructure {
-  $id: string;
+export function isa<T>(o: any, ...ids: string[]): o is T {
+  return typeof o === "object" && TYPE in o && ids.indexOf(o[TYPE]) > -1;
 }
 
 /**
- * Type that is extended by all Smithy shapes marked with the
+ * Type that is implemented by all Smithy shapes marked with the
  * error trait.
  */
-export class SmithyException extends Error implements SmithyStructure {
+export interface SmithyException {
   /**
    * The shape ID of the exception.
    */
-  readonly $id: string;
+  readonly __type: string;
 
   /**
    * Whether the client or server are at fault.
@@ -21,23 +23,14 @@ export class SmithyException extends Error implements SmithyStructure {
   readonly $fault: "client" | "server";
 
   /**
+   * The name of the error.
+   */
+  readonly $name: string;
+
+  /**
    * The service that encountered the exception.
    */
-  readonly $service: string;
-
-  constructor(args: {
-    id: string;
-    name: string;
-    service: string;
-    fault: "client" | "server";
-    message?: string | undefined;
-  }) {
-    super(args.message || "");
-    this.$id = args.id;
-    this.name = args.name;
-    this.$service = args.service;
-    this.$fault = args.fault;
-  }
+  readonly $service?: string;
 }
 
 /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ImportDeclarationsTest.java
@@ -80,4 +80,15 @@ public class ImportDeclarationsTest {
 
         assertThat(result, containsString("import { SharedThing } from \"../../shared/types\";"));
     }
+
+    @Test
+    public void canImportStarImport() {
+        ImportDeclarations declarations = new ImportDeclarations("/foo/bar");
+        declarations.addImport("*", "_baz", "@types/foo");
+        declarations.addImport("*", "*", "@types/other");
+        String result = declarations.toString();
+
+        assertThat(result, containsString("import * as _baz from \"@types/foo\";"));
+        assertThat(result, containsString("import * from \"@types/other\";"));
+    }
 }


### PR DESCRIPTION
This updates the generator to use interfaces for structures. Since we
are now shading types across namespaces into a single namespace, we know
that we are operating in a "closed world", meaning we know at build-time
every type that can possibly be used by a client. Therefore, we can
generate methods that determine if a given type is an instance of
another type or a subtype of it by checking for an optional "__type"
property that contains a shape ID.

This has the advantage of reduced JavaScript artifacts and more
ergonomic code. It does have a minor drawback in that developers will
need to use custom "isa" functions and will need to include the "__type"
property when defining subtypes.

When generating (de)serializers, we can take into account the shape targeted
by members to fall back to a default known type when __type isn't present.
This means that developers will need to include the "__type" property
any time they want to send a type over the wire as a subtype.

If/when inhertance is added to Smithy, each generated interface for a
structure will become two exported types: one for the interface itself,
and one that's a union of the interface and all direct children. All
references to the shape will refer to the union type, but developers can
interact with the explicit type directly if needed (e.g., $Foo would be
the explicit type and Foo would be a union of $Foo and its children).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
