### PR TITLE
Refactor tagged unions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -277,7 +277,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol unionShape(UnionShape shape) {
-        return addSmithyImport(createObjectSymbolBuilder(shape)).build();
+        return createObjectSymbolBuilder(shape).build();
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
@@ -42,34 +42,3 @@ export namespace DocumentType {
   export type Structure = { [member: string]: Value };
   export interface List extends Array<Value> {}
 }
-
-/**
- * Contains an unknown variant for a tagged union.
- *
- * This type allows tagged unions to not lose unknown data encountered
- * when deserializing types.
- */
-export interface UnknownVariant {
-  /**
-   * A tuple containing the name of the unknown tag followed by the
-   * value of the unknown tag.
-   */
-  $unknown?: [string, any];
-}
-
-/**
- * Represents a tagged union where only one member of an object can be
- * specified at any given time.
- *
- * Unknown variant tags are always stored in the `$unknown` property
- * defined by the [[UnknownVariant]] interface.
- */
-export type TaggedUnion<T> = TaggedUnionHelper<T>;
-
-type TaggedUnionHelper<_T, T = UnknownVariant & _T> =
-  Pick<T, Exclude<keyof T, keyof T>>
-  & { [K in keyof T]-?: ExactlyOne<T, K> }[keyof T];
-
-type ExactlyOne<T, K extends keyof T> =
-  Required<Pick<T, K>>
-  & Partial<Record<Exclude<keyof T, K>, undefined>>;


### PR DESCRIPTION
This refactors tagged unions so that they now support recursive union
shapes. Previously, the TaggedUnion type we used would create a shape
that used dependent types, which meant it didn't support the kinds of
recursive interfaces we were generating. We now generate all
permutations of a union where only the specific value is set to
something and every other value is set to "never".

This change also makes unions function exactly like structures so that
it's backward compatible to change a structure to a union after GA
(e.g., if a team forgets to do this or an automatic conversion doesn't
detect a union initially).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
