### PR TITLE
generate shapes in models dir

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -357,6 +357,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             return name + "Client.ts";
         }
 
-        return "types/" + namespace.replace(".", "/") + ".ts";
+        return "models/" + namespace.replace(".", "/") + ".ts";
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -59,7 +59,7 @@ public class CodegenVisitorTest {
                 .build();
 
         new TypeScriptCodegenPlugin().execute(context);
-        String contents = manifest.getFileString("/types/smithy/example/index.ts").get();
+        String contents = manifest.getFileString("/models/smithy/example/index.ts").get();
 
         assertThat(contents, containsString(expectedType));
         assertThat(contents, containsString("namespace Err {\n"

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -23,7 +23,7 @@ public class SymbolProviderTest {
         assertThat(symbol.getName(), equalTo("Hello"));
         assertThat(symbol.getNamespace(), equalTo("com/foo/baz/index"));
         assertThat(symbol.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol.getDefinitionFile(), equalTo("types/com/foo/baz/index.ts"));
+        assertThat(symbol.getDefinitionFile(), equalTo("models/com/foo/baz/index.ts"));
     }
 
     @Test
@@ -38,12 +38,12 @@ public class SymbolProviderTest {
         assertThat(symbol1.getName(), equalTo("Hello"));
         assertThat(symbol1.getNamespace(), equalTo("ec2/index"));
         assertThat(symbol1.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol1.getDefinitionFile(), equalTo("types/ec2/index.ts"));
+        assertThat(symbol1.getDefinitionFile(), equalTo("models/ec2/index.ts"));
 
         assertThat(symbol2.getName(), equalTo("Hello"));
         assertThat(symbol2.getNamespace(), equalTo("ec2/baz/index"));
         assertThat(symbol2.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol2.getDefinitionFile(), equalTo("types/ec2/baz/index.ts"));
+        assertThat(symbol2.getDefinitionFile(), equalTo("models/ec2/baz/index.ts"));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class SymbolProviderTest {
         assertThat(symbol1.getName(), equalTo("Hello"));
         assertThat(symbol1.getNamespace(), equalTo("cloudwatchEvents/index"));
         assertThat(symbol1.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol1.getDefinitionFile(), equalTo("types/cloudwatchEvents/index.ts"));
+        assertThat(symbol1.getDefinitionFile(), equalTo("models/cloudwatchEvents/index.ts"));
     }
 
     @Test


### PR DESCRIPTION
moves generated shapes from /types to /models

clears the way for typings to be hosted in /types per tsconfig changes in https://github.com/awslabs/smithy-typescript/pull/7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
