### PR TITLE
Update to SerdeContext

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
@@ -96,6 +96,7 @@ public final class ApplicationProtocol {
             ServiceShape service,
             Collection<TypeScriptIntegration> integrations
     ) {
+        // TODO If we're going to need to resolve this more than once, store it.
         List<String> resolvedProtocols = settings.resolveServiceProtocols(service);
         // Get the list of protocol generators that have implementations from the service.
         List<ProtocolGenerator> generators = integrations.stream()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -189,7 +189,7 @@ public final class TypeScriptSettings {
     /**
      * Gets the explicitly configured list of protocols to generate.
      *
-     * <p>Every returned protocol must utilize compatibke application protocols.
+     * <p>Every returned protocol must utilize compatible application protocols.
      *
      * @return Returns the configured list of protocols or an empty list.
      */

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -89,7 +89,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("SerializerUtils", "SerializerUtils", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
         writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
         // e.g., serializeAws_restJson1_1ExecuteStatement
         String serializerMethodName = "serialize" + ProtocolGenerator.getSanitizedName(getName()) + symbol.getName();
@@ -99,7 +99,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("export function $L(\n"
                          + "  input: $L,\n"
-                         + "  utils: SerializerUtils\n"
+                         + "  context: SerdeContext\n"
                          + "): $T {", "}", serializerMethodName, inputType, requestType, () -> {
             List<HttpBinding> labelBindings = writeRequestLabels(context, operation, bindingIndex, trait);
             List<HttpBinding> queryBindings = writeRequestQueryString(context, operation, bindingIndex);
@@ -107,7 +107,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             List<HttpBinding> documentBindings = writeRequestBody(context, operation, bindingIndex);
 
             writer.openBlock("return new $T({", "});", requestType, () -> {
-                writer.write("...utils.endpoint,");
+                writer.write("...context.endpoint,");
                 writer.write("protocol: \"https\",");
                 writer.write("method: $S,", trait.getMethod());
                 if (labelBindings.isEmpty()) {
@@ -310,7 +310,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the response type is imported.
         writer.addUseImports(responseType);
-        writer.addImport("DeserializerUtils", "DeserializerUtils", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
         // e.g., deserializeAws_restJson1_1ExecuteStatement
         String methodName = "deserialize" + ProtocolGenerator.getSanitizedName(getName()) + symbol.getName();
 
@@ -320,7 +320,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("export function $L(\n"
                          + "  output: $T,\n"
-                         + "  utils: DeserializerUtils\n"
+                         + "  context: SerdeContext\n"
                          + "): Promise<$L> {", "}", methodName, responseType, outputType, () -> {
             // TODO: Check status code to create appropriate error type or response type.
             writeHeaders(context, operation, bindingIndex);


### PR DESCRIPTION
Updates the generator to use the `SerdeContext` instead of distinct utils.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
