### PR TITLE
Make runtime client plugins more flexible

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -92,7 +92,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     LOGGER.info(() -> "Adding TypeScriptIntegration: " + integration.getClass().getName());
                     integrations.add(integration);
                     integration.getClientPlugins().forEach(runtimePlugin -> {
-                        LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin.getSymbol());
+                        LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
                         runtimePlugins.add(runtimePlugin);
                     });
                 });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -15,74 +15,607 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
-import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.PackageJsonGenerator;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.StringUtils;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
- * Represents a runtime plugin.
+ * Represents a runtime plugin for a client that hooks into various aspects
+ * of TypeScript code generation, including adding configuration settings
+ * to clients and middleware plugins to both clients and commands.
  *
- * <p>These runtime plugins are found and applied at runtime to generated
- * clients and servers.
- *
- * <p>Plugins are assumed to take the form of a namespace named after the
- * plugin, with optional features based on feature flags defined in this
- * interface.
- *
- * <p>If the plugin has configuration (that is, {@link #hasConfig()} returns
- * true, then the plugin must define a {@code Input} and {@code Resolved}
- * interface.
- *
- * <p>If the plugin has middleware (that is, {@link #hasMiddleware()} returns
- * true, then the plugin must define a method that returns the middleware
- * of the plugin to apply to a middleware stack.
- *
- * <p>If the plugin needs custom logic when it is destroyed (that is,
- * {@link #hasDestroy()} returns true, then the plugin must define a
- * {@code destroy} method that takes the client as input.
+ * <p>These runtime client plugins are registered through the
+ * {@link TypeScriptIntegration} SPI and applied to the code generator at
+ * build-time.
  */
-public interface RuntimeClientPlugin {
-    /**
-     * Provides the name, namespace, any required imports, and any required
-     * dependencies of the plugin.
-     *
-     * @return Returns the symbol used to reference the plugin.
-     */
-    SymbolReference getSymbol();
+public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientPlugin> {
 
-    /**
-     * Returns true if the plugin has configuration to resolve.
-     *
-     * @return Returns true if there is configuration.
-     */
-    boolean hasConfig();
+    private final SymbolReference inputConfig;
+    private final SymbolReference resolvedConfig;
+    private final SymbolReference resolveFunction;
+    private final SymbolReference pluginFunction;
+    private final SymbolReference destroyFunction;
+    private final BiPredicate<Model, ServiceShape> servicePredicate;
+    private final OperationPredicate operationPredicate;
 
-    /**
-     * Returns true if the plugin has middleware to add to the middleware stack.
-     *
-     * @return Returns true if there is middleware.
-     */
-    boolean hasMiddleware();
+    private RuntimeClientPlugin(Builder builder) {
+        inputConfig = builder.inputConfig;
+        resolvedConfig = builder.resolvedConfig;
+        resolveFunction = builder.resolveFunction;
+        pluginFunction = builder.pluginFunction;
+        destroyFunction = builder.destroyFunction;
+        operationPredicate = builder.operationPredicate;
+        servicePredicate = builder.servicePredicate;
 
-    /**
-     * Returns true if the plugin has state that needs to be destroyed when the
-     * client is destroyed.
-     *
-     * @return Returns true if there is a destroy method.
-     */
-    default boolean hasDestroy() {
-        return false;
+        boolean allNull = (inputConfig == null) && (resolvedConfig == null) && (resolveFunction == null);
+        boolean allSet = (inputConfig != null) && (resolvedConfig != null) && (resolveFunction != null);
+        if (!(allNull || allSet)) {
+            throw new IllegalStateException(
+                    "If any of inputConfig, resolvedConfig, or resolveFunction are set, then all of "
+                    + "inputConfig, resolvedConfig, and resolveFunction must be set: inputConfig: "
+                    + inputConfig + ", resolvedConfig: " + resolvedConfig + ", resolveFunction: " + resolveFunction);
+        }
+
+        if (destroyFunction != null && resolvedConfig == null) {
+            throw new IllegalStateException("resolvedConfig must be set if destroyFunction is set");
+        }
+    }
+
+    @FunctionalInterface
+    public interface OperationPredicate {
+        /**
+         * Tests if middleware is applied to an individual operation.
+         *
+         * @param model Model the operation belongs to.
+         * @param service Service the operation belongs to.
+         * @param operation Operation to test.
+         * @return Returns true if middleware should be applied to the operation.
+         */
+        boolean test(Model model, ServiceShape service, OperationShape operation);
     }
 
     /**
-     * Returns the list of operations that this customization applies to.
+     * Gets the optionally present symbol reference that points to the
+     * <em>Input configuration interface</em> for the plugin.
      *
-     * <p>An empty return value (the default) means that the plugin applies
-     * to the client and therefore all commands.
+     * <p>If the plugin has input, then it also must define a
+     * <em>resolved interface</em>, and a <em>resolve function</em>.
      *
-     * @return Returns the names of the operations the customization applies to.
+     * <pre>{@code
+     * export interface FooConfigInput {
+     *     // ...
+     * }
+     *
+     * export interface FooConfigResolved {
+     *     // ...
+     * }
+     *
+     * export function resolveFooConfig(config: FooConfigInput): FooConfigResolved {
+     *     return {
+     *         ...input,
+     *         // more properties...
+     *     };
+     * }
+     * }</pre>
+     *
+     * @return Returns the optionally present input interface symbol.
+     * @see #getResolvedConfig()
+     * @see #getResolveFunction()
      */
-    default Set<String> getOperationNames() {
-        return Collections.emptySet();
+    public Optional<SymbolReference> getInputConfig() {
+        return Optional.ofNullable(inputConfig);
+    }
+
+    /**
+     * Gets the optionally present symbol reference that points to the
+     * <em>Resolved configuration interface</em> for the plugin.
+     *
+     * <p>If the plugin has a resolved config, then it also must define
+     * an <em>input interface</em>, and a <em>resolve function</em>.
+     *
+     * @return Returns the optionally present resolved interface symbol.
+     * @see #getInputConfig()
+     * @see #getResolveFunction()
+     */
+    public Optional<SymbolReference> getResolvedConfig() {
+        return Optional.ofNullable(resolvedConfig);
+    }
+
+    /**
+     * Gets the optionally present symbol reference that points to the
+     * function that converts the input configuration type into the
+     * resolved configuration type.
+     *
+     * <p>If the plugin has a resolve function, then it also must define a
+     * <em>resolved interface</em> and a <em>resolve function</em>.
+     * The referenced function must accept the input type of the plugin
+     * as the first positional argument and return the resolved interface
+     * as the return value.
+     *
+     * @return Returns the optionally present resolve function.
+     * @see #getInputConfig()
+     * @see #getResolvedConfig()
+     */
+    public Optional<SymbolReference> getResolveFunction() {
+        return Optional.ofNullable(resolveFunction);
+    }
+
+    /**
+     * Gets the optionally present symbol reference that points to the
+     * function that injects plugin middleware into the middleware stack
+     * of a client or command at runtime.
+     *
+     * <p>If the plugin has middleware, then the plugin must define a method
+     * that takes the plugin's Resolved configuration as the first argument
+     * and returns a {@code Pluggable<any, any>}.
+     *
+     * <pre>{@code
+     * export function getFooPlugin(
+     *   config: FooConfigResolved
+     * ): Pluggable<any, any> => ({
+     *   applyToStack: clientStack => {
+     *     // add or remove middleware from the stack.
+     *   }
+     * });
+     * }</pre>
+     *
+     * @return Returns the optionally present plugin function.
+     */
+    public Optional<SymbolReference> getPluginFunction() {
+        return Optional.ofNullable(pluginFunction);
+    }
+
+    /**
+     * Gets the optionally present symbol reference that points to the
+     * function that is used to clean up any resources when a client is
+     * destroyed.
+     *
+     * <p>The referenced method is expected to take a resolved
+     * configuration interface and destroy any necessary values
+     * (for example, close open connections, deallocate resources, etc).
+     *
+     * <pre>{@code
+     * export function destroyFooConfig(config: FooConfigResolved): void {
+     *   // destroy configuration values here...
+     * }
+     * }</pre>
+     *
+     * @return Returns the optionally present destroy function.
+     */
+    public Optional<SymbolReference> getDestroyFunction() {
+        return Optional.ofNullable(destroyFunction);
+    }
+
+    /**
+     * Returns true if this plugin applies to the given service.
+     *
+     * <p>By default, a plugin applies to all services but not to specific
+     * commands. You an configure a plugin to apply only to a subset of
+     * services (for example, only apply to a known service or a service
+     * with specific traits) or to no services at all (for example, if
+     * the plugin is meant to by command-specific and not on every
+     * command executed by the service).
+     *
+     * @param model The model the service belongs to.
+     * @param service Service shape to test against.
+     * @return Returns true if the plugin is applied to the given service.
+     * @see #matchesOperation(Model, ServiceShape, OperationShape)
+     */
+    public boolean matchesService(Model model, ServiceShape service) {
+        return servicePredicate.test(model, service);
+    }
+
+    /**
+     * Returns true if this plugin applies to the given operation.
+     *
+     * @param model Model the operation belongs to.
+     * @param service Service the operation belongs to.
+     * @param operation Operation to test against.
+     * @return Returns true if the plugin is applied to the given operation.
+     * @see #matchesService(Model, ServiceShape)
+     */
+    public boolean matchesOperation(Model model, ServiceShape service, OperationShape operation) {
+        return operationPredicate.test(model, service, operation);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = builder()
+                .inputConfig(inputConfig)
+                .resolvedConfig(resolvedConfig)
+                .resolveFunction(resolveFunction)
+                .pluginFunction(pluginFunction)
+                .destroyFunction(destroyFunction);
+
+        // Set these directly since their setters have mutual side-effects.
+        builder.operationPredicate = operationPredicate;
+        builder.servicePredicate = servicePredicate;
+
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return "RuntimeClientPlugin{"
+               + "inputConfig=" + inputConfig
+               + ", resolvedConfig=" + resolvedConfig
+               + ", resolveFunction=" + resolveFunction
+               + ", pluginFunction=" + pluginFunction
+               + ", destroyFunction=" + destroyFunction
+               + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof RuntimeClientPlugin)) {
+            return false;
+        }
+
+        RuntimeClientPlugin that = (RuntimeClientPlugin) o;
+        return Objects.equals(inputConfig, that.inputConfig)
+               && Objects.equals(resolvedConfig, that.resolvedConfig)
+               && Objects.equals(resolveFunction, that.resolveFunction)
+               && Objects.equals(pluginFunction, that.pluginFunction)
+               && Objects.equals(destroyFunction, that.destroyFunction)
+               && servicePredicate.equals(that.servicePredicate)
+               && operationPredicate.equals(that.operationPredicate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inputConfig, resolvedConfig, resolveFunction, pluginFunction, destroyFunction);
+    }
+
+    /**
+     * Builds an {@code RuntimePlugin}.
+     */
+    public static final class Builder implements SmithyBuilder<RuntimeClientPlugin> {
+        private SymbolReference inputConfig;
+        private SymbolReference resolvedConfig;
+        private SymbolReference resolveFunction;
+        private SymbolReference pluginFunction;
+        private SymbolReference destroyFunction;
+        private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
+        private OperationPredicate operationPredicate = (model, service, operation) -> false;
+
+        @Override
+        public RuntimeClientPlugin build() {
+            return new RuntimeClientPlugin(this);
+        }
+
+        /**
+         * Sets the symbol reference used to configure a client input configuration.
+         *
+         * <p>If this is set, then both {@link #resolvedConfig} and
+         * {@link #resolveFunction} must also be set.
+         *
+         * @param inputConfig Input configuration symbol to set.
+         * @return Returns the builder.
+         * @see #getInputConfig()
+         */
+        public Builder inputConfig(SymbolReference inputConfig) {
+            this.inputConfig = inputConfig;
+            return this;
+        }
+
+        /**
+         * Sets the symbol used to configure a client input configuration.
+         *
+         * <p>If this is set, then both {@link #resolvedConfig} and
+         * {@link #resolveFunction} must also be set.
+         *
+         * @param inputConfig Input configuration symbol to set.
+         * @return Returns the builder.
+         * @see #getInputConfig()
+         */
+        public Builder inputConfig(Symbol inputConfig) {
+            return inputConfig(SymbolReference.builder().symbol(inputConfig).build());
+        }
+
+        /**
+         * Sets the symbol refernece used to configure a client resolved configuration.
+         *
+         * <p>If this is set, then both {@link #resolveFunction} and
+         * {@link #inputConfig} must also be set.
+         *
+         * @param resolvedConfig Resolved configuration symbol to set.
+         * @return Returns the builder.
+         * @see #getResolvedConfig()
+         */
+        public Builder resolvedConfig(SymbolReference resolvedConfig) {
+            this.resolvedConfig = resolvedConfig;
+            return this;
+        }
+
+        /**
+         * Sets the symbol used to configure a client resolved configuration.
+         *
+         * <p>If this is set, then both {@link #resolveFunction} and
+         * {@link #inputConfig} must also be set.
+         *
+         * @param resolvedConfig Resolved configuration symbol to set.
+         * @return Returns the builder.
+         * @see #getResolvedConfig()
+         */
+        public Builder resolvedConfig(Symbol resolvedConfig) {
+            return resolvedConfig(SymbolReference.builder().symbol(resolvedConfig).build());
+        }
+
+        /**
+         * Sets the symbol reference that is invoked in order to convert the
+         * input symbol type to a resolved symbol type.
+         *
+         * <p>If this is set, then both {@link #resolvedConfig} and
+         * {@link #inputConfig} must also be set.
+         *
+         * @param resolveFunction Function used to convert input to resolved.
+         * @return Returns the builder.
+         * @see #getResolveFunction()
+         */
+        public Builder resolveFunction(SymbolReference resolveFunction) {
+            this.resolveFunction = resolveFunction;
+            return this;
+        }
+
+        /**
+         * Sets the symbol that is invoked in order to convert the
+         * input symbol type to a resolved symbol type.
+         *
+         * <p>If this is set, then both {@link #resolvedConfig} and
+         * {@link #inputConfig} must also be set.
+         *
+         * @param resolveFunction Function used to convert input to resolved.
+         * @return Returns the builder.
+         * @see #getResolveFunction()
+         */
+        public Builder resolveFunction(Symbol resolveFunction) {
+            return resolveFunction(SymbolReference.builder().symbol(resolveFunction).build());
+        }
+
+        /**
+         * Sets a function symbol reference used to configure clients and
+         * commands to use a specific middleware function.
+         *
+         * @param pluginFunction Plugin function symbol to invoke.
+         * @return Returns the builder.
+         * @see #getPluginFunction()
+         */
+        public Builder pluginFunction(SymbolReference pluginFunction) {
+            this.pluginFunction = pluginFunction;
+            return this;
+        }
+
+        /**
+         * Sets a function symbol used to configure clients and commands to
+         * use a specific middleware function.
+         *
+         * @param pluginFunction Plugin function symbol to invoke.
+         * @return Returns the builder.
+         * @see #getPluginFunction()
+         */
+        public Builder pluginFunction(Symbol pluginFunction) {
+            return pluginFunction(SymbolReference.builder().symbol(pluginFunction).build());
+        }
+
+        /**
+         * Sets a function symbol reference to call from a client in the
+         * {@code destroy} function of a TypeScript client.
+         *
+         * <p>The referenced function takes the resolved configuration
+         * type as the first argument. {@link #resolvedConfig} must be
+         * configured if {@code destroyFunction} is set.
+         *
+         * @param destroyFunction Function to invoke from a client.
+         * @return Returns the builder.
+         * @see #getDestroyFunction()
+         */
+        public Builder destroyFunction(SymbolReference destroyFunction) {
+            this.destroyFunction = destroyFunction;
+            return this;
+        }
+
+        /**
+         * Sets a function symbol to call from a client in the {@code destroy}
+         * function of a TypeScript client.
+         *
+         * <p>The referenced function takes the resolved configuration
+         * type as the first argument. {@link #resolvedConfig} must be
+         * configured if {@code destroyFunction} is set.
+         *
+         * @param destroyFunction Function to invoke from a client.
+         * @return Returns the builder.
+         * @see #getDestroyFunction()
+         */
+        public Builder destroyFunction(Symbol destroyFunction) {
+            return destroyFunction(SymbolReference.builder().symbol(destroyFunction).build());
+        }
+
+        /**
+         * Sets a predicate that determines if the plugin applies to a
+         * specific operation.
+         *
+         * <p>When this method is called, the {@code servicePredicate} is
+         * automatically configured to return false for every service.
+         *
+         * <p>By default, a plugin applies globally to a service, which thereby
+         * applies to every operation when the middleware stack is copied.
+         *
+         * @param operationPredicate Operation matching predicate.
+         * @return Returns the builder.
+         * @see #servicePredicate(BiPredicate)
+         */
+        public Builder operationPredicate(OperationPredicate operationPredicate) {
+            this.operationPredicate = Objects.requireNonNull(operationPredicate);
+            servicePredicate = (model, service) -> false;
+            return this;
+        }
+
+        /**
+         * Configures a predicate that makes a plugin only apply to a set of
+         * operations that match one or more of the set of given shape names,
+         * and ensures that the plugin is not applied globally to services.
+         *
+         * <p>By default, a plugin applies globally to a service, which thereby
+         * applies to every operation when the middleware stack is copied.
+         *
+         * @param operationNames Set of operation names.
+         * @return Returns the builder.
+         */
+        public Builder appliesOnlyToOperations(Set<String> operationNames) {
+            operationPredicate((model, service, operation) -> operationNames.contains(operation.getId().getName()));
+            return servicePredicate((model, service) -> false);
+        }
+
+        /**
+         * Configures a predicate that applies the plugin to a service if the
+         * predicate matches a given model and service.
+         *
+         * <p>When this method is called, the {@code operationPredicate} is
+         * automatically configured to return false for every operation,
+         * causing the plugin to only apply to services and not to individual
+         * operations.
+         *
+         * <p>By default, a plugin applies globally to a service, which
+         * thereby applies to every operation when the middleware stack is
+         * copied. Setting a custom service predicate is useful for plugins
+         * that should only be applied to specific services or only applied
+         * at the operation level.
+         *
+         * @param servicePredicate Service predicate.
+         * @return Returns the builder.
+         * @see #operationPredicate(OperationPredicate)
+         */
+        public Builder servicePredicate(BiPredicate<Model, ServiceShape> servicePredicate) {
+            this.servicePredicate = Objects.requireNonNull(servicePredicate);
+            operationPredicate = (model, service, operation) -> false;
+            return this;
+        }
+
+        /**
+         * Configures various aspects of the builder based on naming conventions
+         * defined by the provided {@link Convention} values.
+         *
+         * <p>If no {@code conventions} are provided, a default value of
+         * {@link Convention#HAS_CONFIG} and {@link Convention#HAS_MIDDLEWARE}
+         * is used.
+         *
+         * @param packageName The name of the package to use as an import and
+         *   add as a dependency for each generated symbol
+         *   (for example, "foo/baz").
+         * @param version The version number to use in the symbol dependencies.
+         *   (for example, "1.0.0").
+         * @param pluginName The name of the plugin that is used when generating
+         *   symbol names for each {@code convention}. (for example, "Foo").
+         * @param conventions Conventions to use when configuring the builder.
+         * @return Returns the builder.
+         */
+        public Builder withConventions(
+                String packageName,
+                String version,
+                String pluginName,
+                Convention... conventions
+        ) {
+            pluginName = StringUtils.capitalize(pluginName);
+
+            if (conventions.length == 0) {
+                conventions = Convention.DEFAULT;
+            }
+
+            for (Convention convention : conventions) {
+                switch (convention) {
+                    case HAS_CONFIG:
+                        inputConfig(Convention.createSymbol(packageName, version, pluginName + "InputConfig"));
+                        resolvedConfig(Convention.createSymbol(packageName, version, pluginName + "ResolvedConfig"));
+                        resolveFunction(Convention.createSymbol(
+                                packageName, version, "resolve" + pluginName + "Config"));
+                        break;
+                    case HAS_MIDDLEWARE:
+                        pluginFunction(Convention.createSymbol(packageName, version, "get" + pluginName + "Plugin"));
+                        break;
+                    case HAS_DESTROY:
+                        destroyFunction(Convention.createSymbol(packageName, version, "destroy" + pluginName));
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Unexpected switch case: " + convention);
+                }
+            }
+
+            return this;
+        }
+    }
+
+    /**
+     * Conventions used in {@link Builder#withConventions}.
+     */
+    public enum Convention {
+        /**
+         * Whether or not to generate a configuration Input type, Resolved type,
+         * and resolveConfig function.
+         *
+         * <p>Passing this enum to {@link Builder#withConventions} will cause
+         * the client to resolve configuration using a function named
+         * {@code "resolve" + pluginName + "Config"} (e.g., "resolveFooConfig"),
+         * use an input type named {@code pluginName + "InputConfig"}
+         * (e.g., "FooInputConfig"), and a resolved type named
+         * {@code pluginName + "ResolvedConfig"} (e.g., "FooResolvedConfig").
+         *
+         * @see #getInputConfig()
+         * @see #getResolvedConfig()
+         * @see #getResolveFunction()
+         */
+        HAS_CONFIG,
+
+        /**
+         * Whether or not the plugin applies middleware.
+         *
+         * <p>Passing this enum to {@link Builder#withConventions} will
+         * cause matching clients and commands to call a function name
+         * {@code "get" + pluginName + "Plugin"} to apply middleware
+         * (e.g., "getFooPlugin"). The referenced function is expected
+         * to accept a resolved configuration type and return a
+         * TypeScript {@code Pluggable}.
+         *
+         * @see #getPluginFunction()
+         */
+        HAS_MIDDLEWARE,
+
+        /**
+         * Whether or not the plugin has a destroy method.
+         *
+         * <p>Passing this enum to {@code withConventions} will cause matching
+         * clients to invoke a method named {@code "destroy" + pluginName}
+         * in the {@code destroy} method of the client (e.g., "destroyFoo").
+         * The referenced function is expected to accept the resolved
+         * configuration type of the plugin.
+         *
+         * @see #getDestroyFunction()
+         */
+        HAS_DESTROY;
+
+        private static final Convention[] DEFAULT = {HAS_CONFIG, HAS_MIDDLEWARE};
+
+        private static Symbol createSymbol(String packageName, String version, String name) {
+            return Symbol.builder()
+                    .namespace(packageName, "/")
+                    .name(name)
+                    .addDependency(PackageJsonGenerator.NORMAL_DEPENDENCY, packageName, version)
+                    .build();
+        }
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -1,0 +1,125 @@
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+
+public class RuntimeClientPluginTest {
+    @Test
+    public void allowsAllServicesByDefault() {
+        ServiceShape service = ServiceShape.builder().id("a.b#C").version("123").build();
+        OperationShape operation = OperationShape.builder().id("a.b#Operation").build();
+        Model model = Model.assembler()
+                .addShapes(service, operation)
+                .assemble()
+                .unwrap();
+        RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
+                .servicePredicate((m, s) -> s.getId().getName().equals("C"))
+                .build();
+
+        assertThat(plugin.matchesService(model, service), equalTo(true));
+        assertThat(plugin.matchesOperation(model, service, operation), equalTo(false));
+    }
+
+    @Test
+    public void allowsConfigurableOperationsPredicate() {
+        ServiceShape service = ServiceShape.builder().id("a.b#C").version("123").build();
+        OperationShape operation1 = OperationShape.builder().id("a.b#D").build();
+        OperationShape operation2 = OperationShape.builder().id("a.b#E").build();
+        Model model = Model.assembler()
+                .addShapes(service, operation1, operation2)
+                .assemble()
+                .unwrap();
+        RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
+                .operationPredicate((m, s, o) -> o.getId().getName().equals("D"))
+                .build();
+
+        assertThat(plugin.matchesOperation(model, service, operation1), equalTo(true));
+        assertThat(plugin.matchesOperation(model, service, operation2), equalTo(false));
+        assertThat(plugin.matchesService(model, service), equalTo(false));
+    }
+
+    @Test
+    public void allowsConfigurableServicePredicate() {
+        ServiceShape service1 = ServiceShape.builder().id("a.b#C").version("123").build();
+        ServiceShape service2 = ServiceShape.builder().id("a.b#D").version("123").build();
+        OperationShape operation = OperationShape.builder().id("a.b#Operation").build();
+        Model model = Model.assembler()
+                .addShapes(service1, service2, operation)
+                .assemble()
+                .unwrap();
+        RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
+                .servicePredicate((m, s) -> s.getId().getName().equals("C"))
+                .build();
+
+        assertThat(plugin.matchesService(model, service1), equalTo(true));
+        assertThat(plugin.matchesService(model, service2), equalTo(false));
+        assertThat(plugin.matchesOperation(model, service1, operation), equalTo(false));
+        assertThat(plugin.matchesOperation(model, service2, operation), equalTo(false));
+    }
+
+    @Test
+    public void configuresWithDefaultConventions() {
+        RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
+                .withConventions("foo/baz", "1.0.0", "Foo")
+                .build();
+
+        assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
+        assertThat(plugin.getInputConfig().get().getSymbol().getName(), equalTo("FooInputConfig"));
+
+        assertThat(plugin.getResolvedConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
+        assertThat(plugin.getResolvedConfig().get().getSymbol().getName(), equalTo("FooResolvedConfig"));
+
+        assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
+        assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
+
+        assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
+        assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));
+
+        assertThat(plugin.getInputConfig().get().getSymbol().getDependencies().get(0).getPackageName(),
+                   equalTo("foo/baz"));
+        assertThat(plugin.getResolvedConfig().get().getSymbol().getDependencies().get(0).getPackageName(),
+                   equalTo("foo/baz"));
+        assertThat(plugin.getResolveFunction().get().getSymbol().getDependencies().get(0).getPackageName(),
+                   equalTo("foo/baz"));
+        assertThat(plugin.getPluginFunction().get().getSymbol().getDependencies().get(0).getPackageName(),
+                   equalTo("foo/baz"));
+
+        assertThat(plugin.getInputConfig().get().getSymbol().getDependencies().get(0).getVersion(),
+                   equalTo("1.0.0"));
+        assertThat(plugin.getResolvedConfig().get().getSymbol().getDependencies().get(0).getVersion(),
+                   equalTo("1.0.0"));
+        assertThat(plugin.getResolveFunction().get().getSymbol().getDependencies().get(0).getVersion(),
+                   equalTo("1.0.0"));
+        assertThat(plugin.getPluginFunction().get().getSymbol().getDependencies().get(0).getVersion(),
+                   equalTo("1.0.0"));
+    }
+
+    @Test
+    public void allConfigSymbolsMustBeSetIfAnyAreSet() {
+        Assertions.assertThrows(IllegalStateException.class, () -> RuntimeClientPlugin.builder()
+                .inputConfig(Symbol.builder().namespace("foo", "/").name("abc").build()).build());
+    }
+
+    @Test
+    public void destroyFunctionRequiresResolvedConfig() {
+        Assertions.assertThrows(IllegalStateException.class, () -> RuntimeClientPlugin.builder()
+                .withConventions("foo/baz", "1.0.0", "Foo", RuntimeClientPlugin.Convention.HAS_DESTROY)
+                .build());
+    }
+
+    @Test
+    public void convertsToBuilder() {
+        RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
+                .withConventions("foo/baz", "1.0.0", "Foo")
+                .build();
+
+        assertThat(plugin.toBuilder().build(), equalTo(plugin));
+    }
+}


### PR DESCRIPTION
Runtime client plugins now refer to each part of the plugin using symbol
references rather than just naming conventions. This allows different
aspects of the plugins to span different packages and naming formats.
Methods are provided on the Builder class for a RuntimeClientPlugin to
generate symbol references based on recommended naming conventions
(e.g., "getFooPlugin", "resolveFooConfig", "FooInputConfig",
"FooResolvedConfig", "destroyFooConfig").

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
