### PR TITLE
fix protocol path in CodegenVisitor

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -430,7 +430,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 for (ProtocolGenerator generator : integration.getProtocolGenerators()) {
                     if (protocolsTrait.hasProtocol(generator.getName())) {
                         LOGGER.info("Generating serde for protocol " + generator.getName() + " on " + shape.getId());
-                        String fileRoot = "protocol/" + ProtocolGenerator.getSanitizedName(generator.getName());
+                        String fileRoot = "protocols/" + ProtocolGenerator.getSanitizedName(generator.getName());
                         String namespace = "./" + fileRoot;
                         TypeScriptWriter writer = new TypeScriptWriter(namespace);
                         ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();


### PR DESCRIPTION
Update "protocol" path to "protocols", matching path used in CommandGenerator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
