### PR TITLE
Base64 and serde plugin function name update

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -129,7 +129,7 @@ final class CommandGenerator implements Runnable {
 
     private void generateCommandMiddlewareResolver(String configType) {
         Symbol serde = Symbol.builder()
-                .name("serdePlugin")
+                .name("getSerdePlugin")
                 .namespace("@aws-sdk/middleware-serde", "/")
                 .addDependency(TypeScriptDependencies.MIDDLEWARE_SERDE)
                 .build();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -415,7 +415,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case DOCUMENT:
             case QUERY:
                 // Encode these to base64.
-                return "context.base64Encoder.toBase64(" + dataSource + ")";
+                return "context.base64Encoder(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected blob binding location `" + bindingType + "`");
         }
@@ -778,7 +778,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case HEADER:
             case DOCUMENT:
                 // Decode these from base64.
-                return "context.base64Decoder.fromBase64(" + dataSource + ")";
+                return "context.base64Decoder(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected blob binding location `" + bindingType + "`");
         }


### PR DESCRIPTION
* Use base64 encoder and decoder functions directly.
* update naming to ``getSerdePlugin``

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
