### PR TITLE
Use name instead of ID and clean up JS

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -75,7 +75,7 @@ final class StructureGenerator implements Runnable {
      * import * as _smithy from "../lib/smithy";
      *
      * export interface Person {
-     *   __type?: "smithy.example#Person";
+     *   __type?: "Person";
      *   name: string | undefined;
      *   age?: number | null;
      * }
@@ -104,7 +104,7 @@ final class StructureGenerator implements Runnable {
             writer.openBlock("export interface $L extends $L {", symbol.getName(), extendsFrom);
         }
 
-        writer.write("__type?: $S;", shape.getId());
+        writer.write("__type?: $S;", shape.getId().getName());
         StructuredMemberWriter config = new StructuredMemberWriter(
                 model, symbolProvider, shape.getAllMembers().values());
         config.writeMembers(writer, shape);
@@ -135,16 +135,14 @@ final class StructureGenerator implements Runnable {
      * import * as _smithy from "../lib/smithy";
      *
      * export interface NoSuchResource extends _smithy.SmithyException {
-     *   __type: "smithy.example#NoSuchResource";
-     *   $name: "NoSuchResource";
+     *   __type: "NoSuchResource";
      *   $fault: "client";
      *   resourceType: string | undefined;
      * }
      *
      * export namespace Person {
-     *   export const ID = "smithy.example#NoSuchResource";
      *   export function isa(o: any): o is NoSuchResource {
-     *     return _smithy.isa(o, ID);
+     *     return _smithy.isa(o, "NoSuchResource");
      *   }
      * }
      * }</pre>
@@ -154,8 +152,7 @@ final class StructureGenerator implements Runnable {
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.writeShapeDocs(shape);
         writer.openBlock("export interface $L extends _smithy.SmithyException {", symbol.getName());
-        writer.write("__type: $S;", shape.getId());
-        writer.write("$$name: $S;", shape.getId().getName());
+        writer.write("__type: $S;", shape.getId().getName());
         writer.write("$$fault: $S;", errorTrait.getValue());
         StructuredMemberWriter config = new StructuredMemberWriter(
                 model, symbolProvider, shape.getAllMembers().values());
@@ -168,9 +165,8 @@ final class StructureGenerator implements Runnable {
     private void renderStructureNamespace() {
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
-            writer.write("export const ID = $S;", shape.getId());
             writer.openBlock("export function isa(o: any): o is $L {", "}", symbol.getName(), () -> {
-                writer.write("return _smithy.isa(o, ID);");
+                writer.write("return _smithy.isa(o, $S);", shape.getId().getName());
             });
         });
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -61,7 +61,7 @@ import software.amazon.smithy.utils.StringUtils;
  * export namespace Attacker {
  *   export const ID = "smithy.example#Attacker";
  *   interface $Base {
- *     __type?: "smithy.example#Attacker",
+ *     __type?: "Attacker",
  *   }
  *   export interface LionMember extends $Base {
  *     lion: Lion;
@@ -154,7 +154,7 @@ final class UnionGenerator implements Runnable {
 
     private void writeUnionMemberInterfaces() {
         writer.openBlock("interface $$Base {", "}", () -> {
-            writer.write("__type?: $S;", shape.getId());
+            writer.write("__type?: $S;", shape.getId().getName());
         });
 
         for (MemberShape member : shape.getAllMembers().values()) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -617,7 +617,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("let data: any = await parseBody(output.body, context)");
             writer.openBlock("let contents: $L = {", "};", outputType, () -> {
                 writer.write("$$metadata: deserializeMetadata(output),");
-                writer.write("__type: $S,", operation.getOutput().get().toString());
+                writer.write("__type: $S,", operation.getOutput().get().getName());
             });
             readHeaders(context, operation, bindingIndex);
             readResponseBody(context, operation, bindingIndex);
@@ -718,8 +718,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "): $T => {", "};", methodName, symbol, () -> {
             // Initial contents of the error.
             writer.openBlock("let contents: $T = {", "};", symbol, () -> {
-                writer.write("__type: $S,", shape.getId().toString());
-                writer.write("$$name: $S,", shape.getId().getName());
+                writer.write("__type: $S,", shape.getId().getName());
                 writer.write("$$fault: $S,", shape.getTrait(ErrorTrait.class).get().getValue());
             });
             // Read additional modeled content.
@@ -830,7 +829,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      *       break;
      *     default:
      *       response = {
-     *         __type: "com.smithy.example#UnknownError",
+     *         __type: "UnknownError",
      *         $name: "UnknownError",
      *         $fault: "client",
      *       };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/smithy.ts
@@ -11,7 +11,7 @@ export function isa<T>(o: any, ...ids: string[]): o is T {
  */
 export interface SmithyException {
   /**
-   * The shape ID of the exception.
+   * The shape ID name of the exception.
    */
   readonly __type: string;
 
@@ -19,11 +19,6 @@ export interface SmithyException {
    * Whether the client or server are at fault.
    */
   readonly $fault: "client" | "server";
-
-  /**
-   * The name of the error.
-   */
-  readonly $name: string;
 
   /**
    * The service that encountered the exception.
@@ -36,7 +31,7 @@ export interface SmithyException {
  */
 export namespace DocumentType {
   export type Value = Scalar | Structure | List;
-  export type Scalar = string | number | boolean | null | Uint8Array | Date;
+  export type Scalar = string | number | boolean | null;
   export type Structure = { [member: string]: Value };
   export interface List extends Array<Value> {}
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -14,8 +14,7 @@ public class StructureGeneratorTest {
     public void properlyGeneratesEmptyMessageMemberOfException() {
         testErrorStructureCodegen("error-test-empty.smithy",
                                   "export interface Err extends _smithy.SmithyException {\n"
-                                  + "  __type: \"smithy.example#Err\";\n"
-                                  + "  $name: \"Err\";\n"
+                                  + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "}");
     }
@@ -24,8 +23,7 @@ public class StructureGeneratorTest {
     public void properlyGeneratesOptionalMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-message.smithy",
                                   "export interface Err extends _smithy.SmithyException {\n"
-                                  + "  __type: \"smithy.example#Err\";\n"
-                                  + "  $name: \"Err\";\n"
+                                  + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message?: string;\n"
                                   + "}");
@@ -35,8 +33,7 @@ public class StructureGeneratorTest {
     public void properlyGeneratesRequiredMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-message.smithy",
                                   "export interface Err extends _smithy.SmithyException {\n"
-                                  + "  __type: \"smithy.example#Err\";\n"
-                                  + "  $name: \"Err\";\n"
+                                  + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message: string | undefined;\n"
                                   + "}");
@@ -63,9 +60,8 @@ public class StructureGeneratorTest {
 
         assertThat(contents, containsString(expectedType));
         assertThat(contents, containsString("namespace Err {\n"
-                                            + "  export const ID = \"smithy.example#Err\";\n"
                                             + "  export function isa(o: any): o is Err {\n"
-                                            + "    return _smithy.isa(o, ID);\n"
+                                            + "    return _smithy.isa(o, \"Err\");\n"
                                             + "  }\n"
                                             + "}"));
     }


### PR DESCRIPTION
This commit updates the __type property of generated structures to use
the shape ID name value rather than the entire shape ID. This makes it
easier to work with the value, doesn't expose the entire ID since we
don't need the entire ID in any AWS protocols, and we can always add
__namespace as a separate property later if we need it. Because __type
is now the same as what was previously $name, I've removed $name.

This change required some tweaks to smithy.ts, including removing $name
from SmithyException, updating the documentation of __type in
SmithyException. While I was already editing that file, I also removed
dates and binary values from DocumentType (they aren't necessary and
really they shouldn't be supported until we have a use case).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
