### PR TITLE
Refactor HTTP protocol generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -246,6 +246,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                         String namespace = "./" + fileRoot;
                         TypeScriptWriter writer = new TypeScriptWriter(namespace);
                         ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();
+                        context.setProtocolName(generator.getName());
                         context.setIntegrations(integrations);
                         context.setModel(model);
                         context.setService(shape);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate member values for aggregate types deserialized from documents.
+ *
+ * The standard implementations are as follows; these implementations may be
+ * overridden unless otherwise specified.
+ *
+ * <ul>
+ *   <li>Blob: base64 decoded.</li>
+ *   <li>BigInteger: converted to JS BigInt.</li>
+ *   <li>BigDecimal: converted to Big via {@code big.js}.</li>
+ *   <li>Timestamp: converted to JS Date.</li>
+ *   <li>Service, Operation, Resource, Member: not deserializable from documents. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: delegated to a deserialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: unmodified.</li>
+ * </ul>
+ *
+ * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
+ */
+public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
+    private final Format defaultTimestampFormat;
+    private final GenerationContext context;
+    private final String dataSource;
+
+    /**
+     * Constructor.
+     *
+     * @param context The generation context.
+     * @param dataSource The in-code location of the data to provide an output of
+     *                   ({@code output.foo}, {@code entry}, etc.)
+     * @param defaultTimestampFormat The default timestamp format used in absence
+     *                               of a TimestampFormat trait.
+     */
+    public DocumentMemberDeserVisitor(
+            GenerationContext context,
+            String dataSource,
+            Format defaultTimestampFormat
+    ) {
+        this.context = context;
+        this.dataSource = dataSource;
+        this.defaultTimestampFormat = defaultTimestampFormat;
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return "context.base64Decoder(" + dataSource + ")";
+    }
+
+    @Override
+    public String booleanShape(BooleanShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String byteShape(ByteShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String shortShape(ShortShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String integerShape(IntegerShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String longShape(LongShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String floatShape(FloatShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String doubleShape(DoubleShape shape) {
+        return deserializeUnmodified();
+    }
+
+    @Override
+    public String stringShape(StringShape shape) {
+        return deserializeUnmodified();
+    }
+
+    private String deserializeUnmodified() {
+        return dataSource;
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        return "BigInt(" + dataSource + ")";
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        context.getWriter().addImport("Big", "__Big", "big.js");
+        return "__Big(" + dataSource + ")";
+    }
+
+    @Override
+    public final String operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String memberShape(MemberShape shape) {
+        throw new CodegenException("Member shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public String timestampShape(TimestampShape shape) {
+        return getTimestampDeserializedWithFormat(shape, defaultTimestampFormat);
+    }
+
+    public String getTimestampDeserializedWithFormat(TimestampShape shape, Format format) {
+        String modifiedSource;
+        switch (format) {
+            case DATE_TIME:
+            case HTTP_DATE:
+                modifiedSource = dataSource;
+                break;
+            case EPOCH_SECONDS:
+                // Account for seconds being sent over the wire in some cases where milliseconds are required.
+                modifiedSource = dataSource + " % 1 != 0 ? Math.round(" + dataSource + " * 1000) : " + dataSource;
+                break;
+            default:
+                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
+        }
+
+        return "new Date(" + modifiedSource + ")";
+    }
+
+    @Override
+    public final String documentShape(DocumentShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    @Override
+    public final String listShape(ListShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    @Override
+    public final String mapShape(MapShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    @Override
+    public final String setShape(SetShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    @Override
+    public final String structureShape(StructureShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    @Override
+    public final String unionShape(UnionShape shape) {
+        return getDelegateDeserializer(shape);
+    }
+
+    private String getDelegateDeserializer(Shape shape) {
+        // Use the shape for the function name.
+        Symbol symbol = context.getSymbolProvider().toSymbol(shape);
+        return ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
+                + "(" + dataSource + ", context)";
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.knowledge.HttpBinding.Location;
+import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate member values for aggregate types serialized in documents.
+ *
+ * The standard implementations are as follows; these implementations may be
+ * overridden unless otherwise specified.
+ *
+ * <ul>
+ *   <li>Blob: base64 encoded.</li>
+ *   <li>BigInteger, BigDecimal: converted to strings to maintain precision.</li>
+ *   <li>Timestamp: converted to a representation based on the specified format.</li>
+ *   <li>Service, Operation, Resource, Member: not serializable in documents. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: delegated to a serialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: unmodified.</li>
+ * </ul>
+ *
+ * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
+ */
+public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
+    private final Format defaultTimestampFormat;
+    private final GenerationContext context;
+    private final String dataSource;
+
+    /**
+     * Constructor.
+     *
+     * @param context The generation context.
+     * @param dataSource The in-code location of the data to provide an input of
+     *                   ({@code input.foo}, {@code entry}, etc.)
+     * @param defaultTimestampFormat The default timestamp format used in absence
+     *                               of a TimestampFormat trait.
+     */
+    public DocumentMemberSerVisitor(
+            GenerationContext context,
+            String dataSource,
+            Format defaultTimestampFormat
+    ) {
+        this.context = context;
+        this.dataSource = dataSource;
+        this.defaultTimestampFormat = defaultTimestampFormat;
+    }
+
+    @Override
+    public String blobShape(BlobShape shape) {
+        return "context.base64Encoder(" + dataSource + ")";
+    }
+
+    @Override
+    public String booleanShape(BooleanShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String byteShape(ByteShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String shortShape(ShortShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String integerShape(IntegerShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String longShape(LongShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String floatShape(FloatShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String doubleShape(DoubleShape shape) {
+        return serializeUnmodified();
+    }
+
+    @Override
+    public String stringShape(StringShape shape) {
+        return serializeUnmodified();
+    }
+
+    private String serializeUnmodified() {
+        return dataSource;
+    }
+
+    private String serializeBigNumber() {
+        return dataSource + ".toString()";
+    }
+
+    @Override
+    public String bigIntegerShape(BigIntegerShape shape) {
+        return serializeBigNumber();
+    }
+
+    @Override
+    public String bigDecimalShape(BigDecimalShape shape) {
+        return serializeBigNumber();
+    }
+
+    @Override
+    public final String operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final String memberShape(MemberShape shape) {
+        throw new CodegenException("Member shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public String timestampShape(TimestampShape shape) {
+        HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
+        Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
+        return getTimestampSerializedWithFormat(shape, format);
+    }
+
+    public String getTimestampSerializedWithFormat(TimestampShape shape, Format format) {
+        switch (format) {
+            case DATE_TIME:
+                return dataSource + ".toISOString()";
+            case EPOCH_SECONDS:
+                return "Math.round(" + dataSource + ".getTime() / 1000)";
+            case HTTP_DATE:
+                return dataSource + ".toUTCString()";
+            default:
+                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
+        }
+    }
+
+    @Override
+    public final String documentShape(DocumentShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    @Override
+    public final String listShape(ListShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    @Override
+    public final String mapShape(MapShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    @Override
+    public final String setShape(SetShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    @Override
+    public final String structureShape(StructureShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    @Override
+    public final String unionShape(UnionShape shape) {
+        return getDelegateSerializer(shape);
+    }
+
+    private String getDelegateSerializer(Shape shape) {
+        // Use the shape for the function name.
+        Symbol symbol = context.getSymbolProvider().toSymbol(shape);
+        return ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName())
+                + "(" + dataSource + ", context)";
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate deserialization functions for shapes in protocol document bodies.
+ *
+ * Visitor methods for aggregate types are final and will generate functions that dispatch
+ * their loading from the body to the matching abstract method. The {@link DocumentMemberDeserVisitor}
+ * is provided to reduce the effort of this implementation by providing the default strategies
+ * for deserializing content from aggregate type members.
+ *
+ * Visitor methods for all other types will default to not generating deserialization
+ * functions. This may be overwritten by downstream implementations if the protocol requires
+ * more complex deserialization strategies for those types.
+ *
+ * This class reduces the effort necessary to build protocol implementations, specifically when
+ * implementing {@link HttpBindingProtocolGenerator#generateDocumentShapeDeserializers(GenerationContext, Set)}.
+ *
+ * Implementations of this class independent of protocol documents are also possible.
+ *
+ * The standard implementation is as follows; no assumptions are made about the protocol
+ * being generated for.
+ *
+ * <ul>
+ *   <li>Service, Operation, Resource: no function generated. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: generates a deserialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: no function generated. <b>May be overridden.</b></li>
+ * </ul>
+ */
+public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Void> {
+    private final GenerationContext context;
+
+    public DocumentShapeDeserVisitor(GenerationContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    @Override
+    protected Void getDefault(Shape shape) {
+        return null;
+    }
+
+    /**
+     * Writes the code needed to deserialize a collection in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the CollectionShape {@code shape} parameter from an input
+     * deserialized by {@code deserializeOutputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * list ParameterList {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code output: any}: a value for the CollectionShape shape parameter deserialized from the document.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code Array&lt;Parameter&gt;} return type.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * return (output || []).map((entry: any) =>
+     *   deserializeAws_restJson1_1Parameter(entry, context)
+     * );
+     * }</pre>
+     *
+     * <p>{@code Set} types will be generated appropriately for signatures when given.
+     *
+     * @param context The generation context.
+     * @param shape The collection shape being generated.
+     */
+    protected abstract void deserializeCollection(GenerationContext context, CollectionShape shape);
+
+    /**
+     * Writes the code needed to deserialize a document in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the DocumentShape {@code shape} parameter from an input
+     * deserialized by {@code deserializeDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * document FooDocument
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code output: any}: a value for the DocumentShape shape parameter deserialized from the document.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies a {@code FooDocument} return type.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * return JSON.parse(output);
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The document shape being generated.
+     */
+    protected abstract void deserializeDocument(GenerationContext context, DocumentShape shape);
+
+    /**
+     * Writes the code needed to deserialize a map in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the MapShape {@code shape} parameter from an input
+     * deserialized by {@code deserializeOutputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * map FieldMap {
+     *     key: String,
+     *     value: Field
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code output: any}: a value for the MapShape shape parameter deserialized from the document.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies a {@code { [key: string]: Field }} return type.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * let mapParams: any = {};
+     * Object.keys(output).forEach(key => {
+     *   mapParams[key] = deserializeAws_restJson1_1Field(output[key], context);
+     * });
+     * return mapParams;
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The map shape being generated.
+     */
+    protected abstract void deserializeMap(GenerationContext context, MapShape shape);
+
+    /**
+     * Writes the code needed to deserialize a structure in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the StructureShape {@code shape} parameter from an input
+     * deserialized by {@code deserializeOutputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * structure Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code output: any}: a value for the StructureShape shape parameter deserialized from the document.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies a {@code Field} return.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * let contents: any = {
+     *   __type: "Field",
+     *   fooValue: undefined,
+     *   barValue: undefined,
+     * };
+     * if (output.fooValue !== undefined) {
+     *   contents.fooValue = deserializeAws_restJson1_1Foo(output.fooValue, context);
+     * }
+     * if (output.barValue !== undefined) {
+     *   contents.barValue = output.barValue;
+     * }
+     * return contents;
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The structure shape being generated.
+     */
+    protected abstract void deserializeStructure(GenerationContext context, StructureShape shape);
+
+    /**
+     * Writes the code needed to deserialize a union in the document of a response.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns the type generated for the UnionShape {@code shape} parameter from an input
+     * deserialized by {@code deserializeOutputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * union Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code output: any}: a value for the UnionShape shape parameter deserialized from the document.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies a {@code Field} return type.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * if (output.fooValue !== undefined) {
+     *   return {
+     *     fooValue: deserializeAws_restJson1_1Foo(output.fooValue, context)
+     *   };
+     * }
+     * if (output.barValue !== undefined) {
+     *   return {
+     *     barValue: output.barValue
+     *   };
+     * }
+     * return { $unknown: output[Object.keys(output)[0]] };
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The union shape being generated.
+     */
+    protected abstract void deserializeUnion(GenerationContext context, UnionShape shape);
+
+    /**
+     * Generates a function for serializing the input shape, dispatching the body generation
+     * to the supplied function.
+     *
+     * @param shape The shape to generate a serializer for.
+     * @param functionBody An implementation that will generate a function body to
+     *                     serialize the shape.
+     */
+    protected final void generateDeserFunction(
+            Shape shape,
+            BiConsumer<GenerationContext, Shape> functionBody
+    ) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        TypeScriptWriter writer = context.getWriter();
+
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        // Use the shape name for the function name.
+        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName());
+
+        writer.addImport(symbol, symbol.getName());
+        writer.openBlock("const $L = (\n"
+                       + "  output: any,\n"
+                       + "  context: SerdeContext\n"
+                       + "): $L => {", "}", methodName, symbol.getName(), () -> functionBody.accept(context, shape));
+        writer.write("");
+    }
+
+    @Override
+    public final Void operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    /**
+     * Dispatches to create the body of map shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * document FooDocument
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1FooDocument = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): FooDocument => {
+     *   return JSON.parse(output);
+     * }
+     * }</pre>
+     * @param shape The map shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void documentShape(DocumentShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeDocument(c, s.asDocumentShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of list shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * list ParameterList {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1ParameterList = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): Array<Parameter> => {
+     *   return (output || []).map((entry: any) =>
+     *     deserializeAws_restJson1_1Parameter(entry, context)
+     *   );
+     * }
+     * }</pre>
+     *
+     * @param shape The list shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void listShape(ListShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeCollection(c, s.asListShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of map shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * map FieldMap {
+     *     key: String,
+     *     value: Field
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1FieldMap = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): { [key: string]: Field } => {
+     *   let mapParams: any = {};
+     *   Object.keys(output).forEach(key => {
+     *     mapParams[key] = deserializeAws_restJson1_1Field(output[key], context);
+     *   });
+     *   return mapParams;
+     * }
+     * }</pre>
+     * @param shape The map shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void mapShape(MapShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeMap(c, s.asMapShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of set shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * set ParameterSet {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1ParameterSet = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): Set<Parameter> => {
+     *   return (output || []).map((entry: any) =>
+     *     deserializeAws_restJson1_1Parameter(entry, context)
+     *   );
+     * }
+     * }</pre>
+     *
+     * @param shape The set shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void setShape(SetShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeCollection(c, s.asSetShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of structure shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * structure Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1Field = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): Field => {
+     *   let field: any = {
+     *     __type: "Field",
+     *     fooValue: undefined,
+     *     barValue: undefined,
+     *   };
+     *   if (output.fooValue !== undefined) {
+     *     field.fooValue = deserializeAws_restJson1_1Foo(output.fooValue, context);
+     *   }
+     *   if (output.barValue !== undefined) {
+     *     field.barValue = output.barValue;
+     *   }
+     *   return field;
+     * }
+     * }</pre>
+     *
+     * @param shape The structure shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void structureShape(StructureShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeStructure(c, s.asStructureShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of union shape deserialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * union Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a deserializer</p>
+     *
+     * <pre>{@code
+     * const deserializeAws_restJson1_1Field = (
+     *   output: any,
+     *   context: SerdeContext
+     * ): Field => {
+     *   if (output.fooValue !== undefined) {
+     *     return {
+     *       fooValue: deserializeAws_restJson1_1Foo(output.fooValue, context)
+     *     };
+     *   }
+     *   if (output.barValue !== undefined) {
+     *     return {
+     *       barValue: output.barValue
+     *     };
+     *   }
+     *   return { $unknown: output[Object.keys(output)[0]] };
+     * }
+     * }</pre>
+     *
+     * @param shape The union shape to generate deserialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void unionShape(UnionShape shape) {
+        generateDeserFunction(shape, (c, s) -> deserializeUnion(c, s.asUnionShape().get()));
+        return null;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Visitor to generate serialization functions for shapes in protocol document bodies.
+ *
+ * Visitor methods for aggregate types are final and will generate functions that dispatch
+ * their body generation to the matching abstract method. The {@link DocumentMemberSerVisitor}
+ * is provided to reduce the effort of this implementation by providing the default strategies
+ * for serializing content from aggregate type members.
+ *
+ * Visitor methods for all other types will default to not generating serialization functions.
+ * This may be overwritten by downstream implementations if the protocol requires more
+ * complex serialization strategies for those types.
+ *
+ * This class reduces the effort necessary to build protocol implementations, specifically when
+ * implementing {@link HttpBindingProtocolGenerator#generateDocumentShapeSerializers(GenerationContext, Set)}.
+ *
+ * Implementations of this class independent of protocol documents are also possible.
+ *
+ * The standard implementation is as follows; no assumptions are made about the protocol
+ * being generated for.
+ *
+ * <ul>
+ *   <li>Service, Operation, Resource: no function generated. <b>Not overridable.</b></li>
+ *   <li>Document, List, Map, Set, Structure, Union: generates a serialization function.
+ *     <b>Not overridable.</b></li>
+ *   <li>All other types: no function generated. <b>May be overridden.</b></li>
+ * </ul>
+ */
+public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void> {
+    private final GenerationContext context;
+
+    public DocumentShapeSerVisitor(GenerationContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    @Override
+    protected Void getDefault(Shape shape) {
+        return null;
+    }
+
+    /**
+     * Writes the code needed to serialize a collection in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the CollectionShape {@code shape} parameter that is
+     * serializable by {@code serializeInputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * list ParameterList {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code input: Array&lt;Parameter&gt;}: the type generated for the CollectionShape shape parameter.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code any} return type; the function body
+     * should return a value serializable by {@code serializeInputDocument}.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * return (input || []).map(entry =>
+     *   serializeAws_restJson1_1Parameter(entry, context)
+     * );
+     * }</pre>
+     *
+     * <p>{@code Set} types will be generated appropriately for signatures when given.
+     *
+     * @param context The generation context.
+     * @param shape The collection shape being generated.
+     */
+    protected abstract void serializeCollection(GenerationContext context, CollectionShape shape);
+
+    /**
+     * Writes the code needed to serialize a document in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the DocumentShape {@code shape} parameter that is
+     * serializable by {@code serializeInputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * document FooDocument
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code input: FooDocument}: the type generated for the DocumentShape shape parameter.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code any} return type; the function body
+     * should return a value serializable by {@code serializeInputDocument}.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * return JSON.stringify(input);
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The document shape being generated.
+     */
+    protected abstract void serializeDocument(GenerationContext context, DocumentShape shape);
+
+    /**
+     * Writes the code needed to serialize a map in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the MapShape {@code shape} parameter that is
+     * serializable by {@code serializeInputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * map FieldMap {
+     *     key: String,
+     *     value: Field
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code input: { [key: string]: Field }}: the type generated for the MapShape shape parameter.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code any} return type; the function body
+     * should return a value serializable by {@code serializeInputDocument}.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * let mapParams: any = {};
+     * Object.keys(input).forEach(key => {
+     *   mapParams[key] = serializeAws_restJson1_1Field(input[key], context);
+     * });
+     * return mapParams;
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The map shape being generated.
+     */
+    protected abstract void serializeMap(GenerationContext context, MapShape shape);
+
+    /**
+     * Writes the code needed to serialize a structure in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the StructureShape {@code shape} parameter that is
+     * serializable by {@code serializeInputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * structure Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code input: Field}: the type generated for the StructureShape shape parameter.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code any} return type; the function body
+     * should return a value serializable by {@code serializeInputDocument}.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * let bodyParams: any = {}
+     * if (input.fooValue !== undefined) {
+     *   bodyParams['fooValue'] = serializeAws_restJson1_1Foo(input.fooValue, context);
+     * }
+     * if (input.barValue !== undefined) {
+     *   bodyParams['barValue'] = input.barValue;
+     * }
+     * return bodyParams;
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The structure shape being generated.
+     */
+    protected abstract void serializeStructure(GenerationContext context, StructureShape shape);
+
+    /**
+     * Writes the code needed to serialize a union in the document of a request.
+     *
+     * <p>Implementations of this method are expected to generate a function body that
+     * returns a value representing the UnionShape {@code shape} parameter that is
+     * serializable by {@code serializeInputDocument}.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * union Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The function signature for this body will have two parameters available in scope:
+     * <ul>
+     *   <li>{@code input: Field}: the type generated for the UnionShape shape parameter.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>The function signature specifies an {@code any} return type; the function body
+     * should return a value serializable by {@code serializeInputDocument}.
+     *
+     * <p>This function would generate the following:
+     *
+     * <pre>{@code
+     * return Field.visit(input, {
+     *   fooValue: value => serializeAws_restJson1_1Foo(value, context),
+     *   barValue: value => value,
+     *   _: value => value
+     * });
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param shape The union shape being generated.
+     */
+    protected abstract void serializeUnion(GenerationContext context, UnionShape shape);
+
+    /**
+     * Generates a function for serializing the input shape, dispatching the body generation
+     * to the supplied function.
+     *
+     * @param shape The shape to generate a serializer for.
+     * @param functionBody An implementation that will generate a function body to
+     *                     serialize the shape.
+     */
+    private void generateSerFunction(
+            Shape shape,
+            BiConsumer<GenerationContext, Shape> functionBody
+    ) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        TypeScriptWriter writer = context.getWriter();
+
+        Symbol symbol = symbolProvider.toSymbol(shape);
+        // Use the shape name for the function name.
+        String methodName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
+
+        writer.addImport(symbol, symbol.getName());
+        writer.openBlock("const $L = (\n"
+                       + "  input: $L,\n"
+                       + "  context: SerdeContext\n"
+                       + "): any => {", "}", methodName, symbol.getName(), () -> functionBody.accept(context, shape));
+        writer.write("");
+    }
+
+    @Override
+    public final Void operationShape(OperationShape shape) {
+        throw new CodegenException("Operation shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void resourceShape(ResourceShape shape) {
+        throw new CodegenException("Resource shapes cannot be bound to documents.");
+    }
+
+    @Override
+    public final Void serviceShape(ServiceShape shape) {
+        throw new CodegenException("Service shapes cannot be bound to documents.");
+    }
+
+    /**
+     * Dispatches to create the body of document shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * document FooDocument
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1FooDocument = (
+     *   input: FooDocument,
+     *   context: SerdeContext
+     * ): any => {
+     *   return JSON.stringify(input);
+     * }
+     * }</pre>
+     *
+     * @param shape The document shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void documentShape(DocumentShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeDocument(c, s.asDocumentShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of list shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * list ParameterList {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1ParametersList = (
+     *   input: Array<Parameter>,
+     *   context: SerdeContext
+     * ): any => {
+     *   return (input || []).map(entry =>
+     *     serializeAws_restJson1_1Parameter(entry, context)
+     *   );
+     * }
+     * }</pre>
+     *
+     * @param shape The list shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void listShape(ListShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeCollection(c, s.asListShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of map shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * map FieldMap {
+     *     key: String,
+     *     value: Field
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1FieldMap = (
+     *   input: { [key: string]: Field },
+     *   context: SerdeContext
+     * ): any => {
+     *   let mapParams: any = {};
+     *   Object.keys(input).forEach(key => {
+     *     mapParams[key] = serializeAws_restJson1_1Field(input[key], context);
+     *   });
+     *   return mapParams;
+     * }
+     * }</pre>
+     *
+     * @param shape The map shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void mapShape(MapShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeMap(c, s.asMapShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of set shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * set ParameterSet {
+     *     member: Parameter
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1ParametersSet = (
+     *   input: Set<Parameter>,
+     *   context: SerdeContext
+     * ): any => {
+     *   return (input || []).map(entry =>
+     *     serializeAws_restJson1_1Parameter(entry, context)
+     *   );
+     * }
+     * }</pre>
+     *
+     * @param shape The set shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void setShape(SetShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeCollection(c, s.asSetShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of structure shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * structure Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1Field = (
+     *   input: Field,
+     *   context: SerdeContext
+     * ): any => {
+     *   let bodyParams: any = {}
+     *   if (input.fooValue !== undefined) {
+     *     bodyParams['fooValue'] = serializeAws_restJson1_1Foo(input.fooValue, context);
+     *   }
+     *   if (input.barValue !== undefined) {
+     *     bodyParams['barValue'] = input.barValue;
+     *   }
+     *   return bodyParams;
+     * }
+     * }</pre>
+     *
+     * @param shape The structure shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void structureShape(StructureShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeStructure(c, s.asStructureShape().get()));
+        return null;
+    }
+
+    /**
+     * Dispatches to create the body of union shape serialization functions.
+     * The function signature will be generated.
+     *
+     * <p>For example, given the following Smithy model:
+     *
+     * <pre>{@code
+     * union Field {
+     *     fooValue: Foo,
+     *     barValue: String,
+     * }
+     * }</pre>
+     *
+     * <p>The following code is generated for a serializer:
+     *
+     * <pre>{@code
+     * const serializeAws_restJson1_1Field = (
+     *   input: Field,
+     *   context: SerdeContext
+     * ): any => {
+     *   return Field.visit(input, {
+     *     fooValue: value => serializeAws_restJson1_1Foo(value, context),
+     *     barValue: value => value,
+     *     _: value => value
+     *   });
+     * }
+     * }</pre>
+     *
+     * @param shape The union shape to generate serialization for.
+     * @return Null.
+     */
+    @Override
+    public final Void unionShape(UnionShape shape) {
+        generateSerFunction(shape, (c, s) -> serializeUnion(c, s.asUnionShape().get()));
+        return null;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -182,6 +182,7 @@ public interface ProtocolGenerator {
         private SymbolProvider symbolProvider;
         private TypeScriptWriter writer;
         private List<TypeScriptIntegration> integrations;
+        private String protocolName;
 
         public TypeScriptSettings getSettings() {
             return settings;
@@ -229,6 +230,14 @@ public interface ProtocolGenerator {
 
         public void setIntegrations(List<TypeScriptIntegration> integrations) {
             this.integrations = integrations;
+        }
+
+        public String getProtocolName() {
+            return protocolName;
+        }
+
+        public void setProtocolName(String protocolName) {
+            this.protocolName = protocolName;
         }
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -1,0 +1,144 @@
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Collection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.ListUtils;
+
+public class DocumentMemberDeserVisitorTest {
+    private static final String DATA_SOURCE = "dataSource";
+    private static final String PROTOCOL = "TestProtocol";
+    private static final Format FORMAT = Format.EPOCH_SECONDS;
+    private static GenerationContext mockContext;
+
+    static {
+        mockContext = new GenerationContext();
+        mockContext.setProtocolName(PROTOCOL);
+        mockContext.setSymbolProvider(new MockProvider());
+    }
+
+    @ParameterizedTest
+    @MethodSource("validMemberTargetTypes")
+    public void providesExpectedDefaults(Shape shape, String expected) {
+        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT);
+        assertThat(expected, equalTo(shape.accept(visitor)));
+    }
+
+    public static Collection<Object[]> validMemberTargetTypes() {
+        String id = "com.smithy.example#Foo";
+        String targetId = id + "Target";
+        MemberShape member = MemberShape.builder().id(id + "$member").target(targetId).build();
+        MemberShape key = MemberShape.builder().id(id + "$key").target(targetId).build();
+        MemberShape value = MemberShape.builder().id(id + "$value").target(targetId).build();
+        String delegate = "deserialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+                + "(" + DATA_SOURCE + ", context)";
+
+        return ListUtils.of(new Object[][]{
+                {BooleanShape.builder().id(id).build(), DATA_SOURCE},
+                {BigIntegerShape.builder().id(id).build(), "BigInt(" + DATA_SOURCE + ")"},
+                {ByteShape.builder().id(id).build(), DATA_SOURCE},
+                {DoubleShape.builder().id(id).build(), DATA_SOURCE},
+                {FloatShape.builder().id(id).build(), DATA_SOURCE},
+                {IntegerShape.builder().id(id).build(), DATA_SOURCE},
+                {LongShape.builder().id(id).build(), DATA_SOURCE},
+                {ShortShape.builder().id(id).build(), DATA_SOURCE},
+                {StringShape.builder().id(id).build(), DATA_SOURCE},
+                {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")"},
+                {DocumentShape.builder().id(id).build(), delegate},
+                {ListShape.builder().id(id).member(member).build(), delegate},
+                {SetShape.builder().id(id).member(member).build(), delegate},
+                {MapShape.builder().id(id).key(key).value(value).build(), delegate},
+                {StructureShape.builder().id(id).build(), delegate},
+                {UnionShape.builder().id(id).addMember(member).build(), delegate},
+        });
+    }
+
+    @Test
+    public void throwsOnInvalidDocumentMembers() {
+        String id = "com.smithy.example#Foo";
+        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT);
+
+        Assertions.assertThrows(CodegenException.class, () -> {
+            ServiceShape.builder().version("1").id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            OperationShape.builder().id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            ResourceShape.builder().addIdentifier("id", id + "Id").id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            MemberShape.builder().target(id + "Target").id(id + "$member").build().accept(visitor);
+        });
+    }
+
+    @Test
+    public void givesCorrectTimestampDeserialization() {
+        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
+        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT);
+
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.DATE_TIME)));
+        assertThat("new Date(" + DATA_SOURCE + " % 1 != 0 ? Math.round("
+                           + DATA_SOURCE + " * 1000) : " + DATA_SOURCE + ")",
+                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.EPOCH_SECONDS)));
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.HTTP_DATE)));
+    }
+
+    private static final class MockProvider implements SymbolProvider {
+        private final String id = "com.smithy.example#Foo";
+        private Symbol mock = Symbol.builder()
+                .name("Foo")
+                .namespace("com.smithy.example", "/")
+                .build();
+        private Symbol collectionMock = Symbol.builder()
+                .name("Array<Foo>")
+                .namespace("com.smithy.example", "/")
+                .build();
+
+        @Override
+        public Symbol toSymbol(Shape shape) {
+        if (shape instanceof CollectionShape) {
+            MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
+            return collectionMock.toBuilder().putProperty("shape",
+                    ListShape.builder().id(id).member(member).build()).build();
+        }
+        return mock.toBuilder().putProperty("shape",
+                StructureShape.builder().id(id).build()).build();
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -1,0 +1,145 @@
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Collection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.DocumentShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShortShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.ListUtils;
+
+public class DocumentMemberSerVisitorTest {
+    private static final String DATA_SOURCE = "dataSource";
+    private static final String PROTOCOL = "TestProtocol";
+    private static final Format FORMAT = Format.EPOCH_SECONDS;
+    private static GenerationContext mockContext;
+
+    static {
+        mockContext = new GenerationContext();
+        mockContext.setProtocolName(PROTOCOL);
+        mockContext.setSymbolProvider(new MockProvider());
+    }
+
+    @ParameterizedTest
+    @MethodSource("validMemberTargetTypes")
+    public void providesExpectedDefaults(Shape shape, String expected) {
+        DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT);
+        assertThat(expected, equalTo(shape.accept(visitor)));
+    }
+
+    public static Collection<Object[]> validMemberTargetTypes() {
+        String id = "com.smithy.example#Foo";
+        String targetId = id + "Target";
+        MemberShape member = MemberShape.builder().id(id + "$member").target(targetId).build();
+        MemberShape key = MemberShape.builder().id(id + "$key").target(targetId).build();
+        MemberShape value = MemberShape.builder().id(id + "$value").target(targetId).build();
+        String delegate = "serialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+                + "(" + DATA_SOURCE + ", context)";
+
+        return ListUtils.of(new Object[][]{
+                {BooleanShape.builder().id(id).build(), DATA_SOURCE},
+                {BigDecimalShape.builder().id(id).build(), DATA_SOURCE + ".toString()"},
+                {BigIntegerShape.builder().id(id).build(), DATA_SOURCE + ".toString()"},
+                {ByteShape.builder().id(id).build(), DATA_SOURCE},
+                {DoubleShape.builder().id(id).build(), DATA_SOURCE},
+                {FloatShape.builder().id(id).build(), DATA_SOURCE},
+                {IntegerShape.builder().id(id).build(), DATA_SOURCE},
+                {LongShape.builder().id(id).build(), DATA_SOURCE},
+                {ShortShape.builder().id(id).build(), DATA_SOURCE},
+                {StringShape.builder().id(id).build(), DATA_SOURCE},
+                {BlobShape.builder().id(id).build(), "context.base64Encoder(" + DATA_SOURCE + ")"},
+                {DocumentShape.builder().id(id).build(), delegate},
+                {ListShape.builder().id(id).member(member).build(), delegate},
+                {SetShape.builder().id(id).member(member).build(), delegate},
+                {MapShape.builder().id(id).key(key).value(value).build(), delegate},
+                {StructureShape.builder().id(id).build(), delegate},
+                {UnionShape.builder().id(id).addMember(member).build(), delegate},
+        });
+    }
+
+    @Test
+    public void throwsOnInvalidDocumentMembers() {
+        String id = "com.smithy.example#Foo";
+        DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT);
+
+        Assertions.assertThrows(CodegenException.class, () -> {
+            ServiceShape.builder().version("1").id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            OperationShape.builder().id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            ResourceShape.builder().addIdentifier("id", id + "Id").id(id).build().accept(visitor);
+        });
+        Assertions.assertThrows(CodegenException.class, () -> {
+            MemberShape.builder().target(id + "Target").id(id + "$member").build().accept(visitor);
+        });
+    }
+
+    @Test
+    public void givesCorrectTimestampSerialization() {
+        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
+        DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT);
+
+        assertThat(DATA_SOURCE + ".toISOString()",
+                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.DATE_TIME)));
+        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
+                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.EPOCH_SECONDS)));
+        assertThat(DATA_SOURCE + ".toUTCString()",
+                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.HTTP_DATE)));
+    }
+
+    private static final class MockProvider implements SymbolProvider {
+        private final String id = "com.smithy.example#Foo";
+        private Symbol mock = Symbol.builder()
+                .name("Foo")
+                .namespace("com.smithy.example", "/")
+                .build();
+        private Symbol collectionMock = Symbol.builder()
+                .name("Array<Foo>")
+                .namespace("com.smithy.example", "/")
+                .build();
+
+        @Override
+        public Symbol toSymbol(Shape shape) {
+        if (shape instanceof CollectionShape) {
+            MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
+            return collectionMock.toBuilder().putProperty("shape",
+                    ListShape.builder().id(id).member(member).build()).build();
+        }
+        return mock.toBuilder().putProperty("shape",
+                StructureShape.builder().id(id).build()).build();
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGeneratorTest.java
@@ -4,11 +4,81 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.StringShape;
 
 public class ProtocolGeneratorTest {
     @Test
     public void sanitizesNames() {
         assertThat(ProtocolGenerator.getSanitizedName("aws.rest-json.1.1"), equalTo("Aws_restJson_1_1"));
+    }
+
+    @Test
+    public void buildsSerFunctionName() {
+        StringShape shape = StringShape.builder().id("com.smithy.example#Foo").build();
+        Symbol symbol = Symbol.builder()
+                .name("Foo")
+                .namespace("com.smithy.example", ".")
+                .putProperty("shape", shape)
+                .build();
+
+        assertThat(ProtocolGenerator.getSerFunctionName(symbol, "aws.rest-json.1.1"),
+                equalTo("serializeAws_restJson_1_1Foo"));
+    }
+
+    @Test
+    public void buildsSerFunctionNameForCollection() {
+        MemberShape member = MemberShape.builder()
+                .id("com.smithy.example#FooList$member")
+                .target("com.smithy.example#Foo")
+                .build();
+        ListShape list = ListShape.builder()
+                .id("com.smithy.example#FooList")
+                .member(member)
+                .build();
+        Symbol symbol = Symbol.builder()
+                .name("Array<Foo>")
+                .namespace("com.smithy.example", ".")
+                .putProperty("shape", list)
+                .build();
+
+        assertThat(ProtocolGenerator.getSerFunctionName(symbol, "aws.rest-json.1.1"),
+                equalTo("serializeAws_restJson_1_1FooList"));
+    }
+
+    @Test
+    public void buildsDeserFunctionName() {
+        StringShape shape = StringShape.builder().id("com.smithy.example#Foo").build();
+        Symbol symbol = Symbol.builder()
+                .name("Foo")
+                .namespace("com.smithy.example", ".")
+                .putProperty("shape", shape)
+                .build();
+
+        assertThat(ProtocolGenerator.getDeserFunctionName(symbol, "aws.rest-json.1.1"),
+                equalTo("deserializeAws_restJson_1_1Foo"));
+    }
+
+    @Test
+    public void buildsDeserFunctionNameForCollection() {
+        MemberShape member = MemberShape.builder()
+                .id("com.smithy.example#FooList$member")
+                .target("com.smithy.example#Foo")
+                .build();
+        ListShape list = ListShape.builder()
+                .id("com.smithy.example#FooList")
+                .member(member)
+                .build();
+        Symbol symbol = Symbol.builder()
+                .name("Array<Foo>")
+                .namespace("com.smithy.example", ".")
+                .putProperty("shape", list)
+                .build();
+
+        assertThat(ProtocolGenerator.getDeserFunctionName(symbol, "aws.rest-json.1.1"),
+                equalTo("deserializeAws_restJson_1_1FooList"));
     }
 
     @Test


### PR DESCRIPTION
This commit is a significant refactor of the previous iteration of
generating HTTP protocols. Most importantly, the process of building
out support for a protocol is more composible. It has been broken
down into 2 components.

1. The HttpBindingProtocolGenerator implementation, responsible for
handling or dispatching document serde and generating components for
that.
2. The DocumentShapeSerdeVisitor implementations, responsible for
generating serde functions specific to shapes contained within the
document body of a protocol. Implmenentations for serialization
and deserialization are provided.

HttpBindingProtocolGenerator implementations are responsible for
tracking which shapes need serde generated by the implementations
of DocumentShapeSerdeVisitors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
