### PR TITLE
Add ability to infer a service shape ID

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -73,7 +73,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private final ApplicationProtocol applicationProtocol;
 
     CodegenVisitor(PluginContext context) {
-        settings = TypeScriptSettings.from(context.getSettings());
+        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
         nonTraits = context.getNonTraitShapes();
         model = context.getModel();
         service = settings.getService(model);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -33,7 +33,7 @@ public class RuntimeConfigGeneratorTest {
             }
         });
 
-        TypeScriptSettings settings = TypeScriptSettings.from(Node.objectNodeBuilder()
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("service", Node.from("smithy.example#Example"))
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServiceGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServiceGeneratorTest.java
@@ -21,7 +21,7 @@ public class ServiceGeneratorTest {
     @Test
     public void addsCustomIntegrationDependencyFields() {
         Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
-        TypeScriptSettings settings = TypeScriptSettings.from(Node.objectNodeBuilder()
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("service", Node.from("smithy.example#Example"))
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptSettingsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptSettingsTest.java
@@ -1,8 +1,29 @@
 package software.amazon.smithy.typescript.codegen;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
 
 public class TypeScriptSettingsTest {
+
+    @Test
+    public void resolvesDefaultService() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+
+        assertThat(settings.getService(), equalTo(ShapeId.from("smithy.example#Example")));
+    }
+
     @Test
     public void resolvesSupportProtocols() {
         // TODO


### PR DESCRIPTION
Inferring which service is being generated makes it easier to codegen as
part of an automated process where you might not know the service ID of
the service to generate in advance, but you know that the model has only
one service.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
