### PR TITLE
Add HTTP RPC protocol support

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -185,20 +185,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     public String timestampShape(TimestampShape shape) {
         HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
         Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
-        return getTimestampSerializedWithFormat(shape, format);
-    }
-
-    public String getTimestampSerializedWithFormat(TimestampShape shape, Format format) {
-        switch (format) {
-            case DATE_TIME:
-                return dataSource + ".toISOString()";
-            case EPOCH_SECONDS:
-                return "Math.round(" + dataSource + ".getTime() / 1000)";
-            case HTTP_DATE:
-                return dataSource + ".toUTCString()";
-            default:
-                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
-        }
+        return HttpProtocolGeneratorUtils.getTimestampInputParam(dataSource, shape, format);
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+
+/**
+ * Utility methods for generating HTTP protocols.
+ */
+final class HttpProtocolGeneratorUtils {
+
+    private HttpProtocolGeneratorUtils() {}
+
+    /**
+     * Given a format and a source of data, generate an input value provider for the
+     * timestamp.
+     *
+     * @param dataSource The in-code location of the data to provide an input of
+     *                   ({@code input.foo}, {@code entry}, etc.)
+     * @param shape The shape that represents the value being provided.
+     * @param format The timestamp format to provide.
+     * @return Returns a value or expression of the input timestamp.
+     */
+    static String getTimestampInputParam(String dataSource, Shape shape, Format format) {
+        switch (format) {
+            case DATE_TIME:
+                return dataSource + ".toISOString()";
+            case EPOCH_SECONDS:
+                return "Math.round(" + dataSource + ".getTime() / 1000)";
+            case HTTP_DATE:
+                return dataSource + ".toUTCString()";
+            default:
+                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
+        }
+    }
+
+    /**
+     * Given a format and a source of data, generate an output value provider for the
+     * timestamp.
+     *
+     * @param dataSource The in-code location of the data to provide an output of
+     *                   ({@code output.foo}, {@code entry}, etc.)
+     * @param shape The shape that represents the value being received.
+     * @param format The timestamp format to provide.
+     * @return Returns a value or expression of the output timestamp.
+     */
+    static String getTimestampOutputParam(String dataSource, Shape shape, Format format) {
+        String modifiedSource;
+        switch (format) {
+            case DATE_TIME:
+            case HTTP_DATE:
+                modifiedSource = dataSource;
+                break;
+            case EPOCH_SECONDS:
+                // Account for seconds being sent over the wire in some cases where milliseconds are required.
+                modifiedSource = dataSource + " % 1 != 0 ? Math.round(" + dataSource + " * 1000) : " + dataSource;
+                break;
+            default:
+                throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
+        }
+
+        return "new Date(" + modifiedSource + ")";
+    }
+
+    /**
+     * Writes a response metadata deserializer function for HTTP protocols. This
+     * will load things like the status code, headers, and more.
+     *
+     * @param context The generation context.
+     * @param responseType The response type for the HTTP protocol.
+     */
+    static void generateMetadataDeserializer(GenerationContext context, SymbolReference responseType) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.addImport("ResponseMetadata", "__ResponseMetadata", "@aws-sdk/types");
+        writer.openBlock("const deserializeMetadata = (output: $T): __ResponseMetadata => ({", "});", responseType,
+                () -> {
+                    writer.write("httpStatusCode: output.statusCode,");
+                    writer.write("httpHeaders: output.headers,");
+                    writer.write("requestId: output.headers[\"x-amzn-requestid\"]");
+                });
+        writer.write("");
+    }
+
+    /**
+     * Writes a function used to dispatch to the proper error deserializer
+     * for each error that the operation can return. The generated function
+     * assumes a deserialization function is generated for the structures
+     * returned.
+     *
+     * @param context The generation context.
+     * @param operation The operation to generate for.
+     * @param responseType The response type for the HTTP protocol.
+     * @param errorCodeGenerator A consumer
+     * @return A set of all error shapes for the operation that were dispatched to.
+     */
+    static Set<Shape> generateErrorDispatcher(
+            GenerationContext context,
+            OperationShape operation,
+            SymbolReference responseType,
+            Consumer<GenerationContext> errorCodeGenerator
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        Set<Shape> errorShapes = new TreeSet<>();
+
+        Symbol symbol = symbolProvider.toSymbol(operation);
+        Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
+        String errorMethodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()) + "Error";
+
+        writer.openBlock("async function $L(\n"
+                       + "  output: $T,\n"
+                       + "  context: SerdeContext,\n"
+                       + "): Promise<$T> {", "}", errorMethodName, responseType, outputType, () -> {
+            writer.write("let data: any = await parseBody(output.body, context);");
+            writer.write("let response: any;");
+            writer.write("let errorCode: String;");
+            errorCodeGenerator.accept(context);
+            writer.openBlock("switch (errorCode) {", "}", () -> {
+                // Generate the case statement for each error, invoking the specific deserializer.
+                new TreeSet<>(operation.getErrors()).forEach(errorId -> {
+                    Shape error = context.getModel().getShapeIndex().getShape(errorId).get();
+                    // Track errors bound to the operation so their deserializers may be generated.
+                    errorShapes.add(error);
+                    Symbol errorSymbol = symbolProvider.toSymbol(error);
+                    String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
+                            context.getProtocolName());
+                    writer.openBlock("case $S:\ncase $S:", "  break;", errorId.getName(), errorId.toString(), () -> {
+                        // Dispatch to the error deserialization function.
+                        writer.write("response = $L(data, context);", errorDeserMethodName);
+                    });
+                });
+
+                // Build a generic error the best we can for ones we don't know about.
+                writer.write("default:").indent()
+                        .write("errorCode = errorCode || \"UnknownError\";")
+                        .openBlock("response = {", "};", () -> {
+                            writer.write("__type: `$L#$${errorCode}`,", operation.getId().getNamespace());
+                            writer.write("$$name: errorCode,");
+                            writer.write("$$fault: \"client\",");
+                        }).dedent();
+            });
+            writer.write("return Promise.reject(response);");
+        });
+        writer.write("");
+
+        return errorShapes;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Abstract implementation useful for all HTTP protocols without bindings.
+ */
+public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
+
+    private final Set<Shape> documentSerializingShapes = new TreeSet<>();
+    private final Set<Shape> documentDeserializingShapes = new TreeSet<>();
+
+    @Override
+    public ApplicationProtocol getApplicationProtocol() {
+        return ApplicationProtocol.createDefaultHttpApplicationProtocol();
+    }
+
+    /**
+     * Gets the content-type for a request body.
+     *
+     * @return Returns the default content-type.
+     */
+    protected abstract String getDocumentContentType();
+
+    /**
+     * Generates serialization functions for shapes in the passed set. These functions
+     * should return a value that can then be serialized by the implementation of
+     * {@code serializeDocument}. The {@link DocumentShapeSerVisitor} and {@link DocumentMemberSerVisitor}
+     * are provided to reduce the effort of this implementation.
+     *
+     * TODO.
+     *
+     * @param context The generation context.
+     * @param shapes The shapes to generate serialization for.
+     */
+    protected abstract void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes);
+
+    /**
+     * Generates deserialization functions for shapes in the passed set. These functions
+     * should return a value that can then be deserialized by the implementation of
+     * {@code deserializeDocument}. The {@link DocumentShapeDeserVisitor} and
+     * {@link DocumentMemberDeserVisitor} are provided to reduce the effort of this implementation.
+     *
+     * TODO.
+     *
+     * @param context The generation context.
+     * @param shapes The shapes to generate deserialization for.
+     */
+    protected abstract void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes);
+
+    @Override
+    public void generateSharedComponents(GenerationContext context) {
+        generateDocumentShapeSerializers(context, documentSerializingShapes);
+        generateDocumentShapeDeserializers(context, documentDeserializingShapes);
+        HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
+    }
+
+    @Override
+    public void generateRequestSerializers(GenerationContext context) {
+        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            generateOperationSerializer(context, operation);
+        }
+    }
+
+    @Override
+    public void generateResponseDeserializers(GenerationContext context) {
+        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            generateOperationDeserializer(context, operation);
+        }
+    }
+
+    private void generateOperationSerializer(GenerationContext context, OperationShape operation) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        Symbol symbol = symbolProvider.toSymbol(operation);
+        SymbolReference requestType = getApplicationProtocol().getRequestType();
+        TypeScriptWriter writer = context.getWriter();
+
+        // Ensure that the request type is imported.
+        writer.addUseImports(requestType);
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
+        // e.g., serializeAws_restJson1_1ExecuteStatement
+        String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName());
+        // TODO Do we need to handle optional input everywhere?
+        // Add the normalized input type.
+        Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
+
+        writer.openBlock("export function $L(\n"
+                                 + "  input: $T,\n"
+                                 + "  context: SerdeContext\n"
+                                 + "): $T {", "}", methodName, inputType, requestType, () -> {
+            writeRequestHeaders(context);
+            boolean hasRequestBody = writeRequestBody(context, operation);
+
+            writer.openBlock("return new $T({", "});", requestType, () -> {
+                writer.write("...context.endpoint,");
+                writer.write("protocol: \"https\",");
+                writer.write("method: \"POST\",");
+                writer.write("path: \"/$L\",", StringUtils.capitalize(operation.getId().getName()));
+                writer.write("headers: headers,");
+                if (hasRequestBody) {
+                    writer.write("body: body,");
+                }
+            });
+        });
+
+        writer.write("");
+    }
+
+    private void writeRequestHeaders(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // The Content-Type header is always present.
+        writer.write("let headers: any = {};");
+        writer.write("headers['Content-Type'] = $S;", getDocumentContentType());
+    }
+
+    private boolean writeRequestBody(GenerationContext context, OperationShape operation) {
+        if (operation.getInput().isPresent()) {
+            // If there's an input present, we know it's a structure.
+            StructureShape inputShape = context.getModel().getShapeIndex().getShape(operation.getInput().get())
+                    .get().asStructureShape().get();
+
+            // Track input shapes so their serializers may be generated.
+            documentSerializingShapes.add(inputShape);
+
+            // Write the default `body` property.
+            context.getWriter().write("let body: any = undefined;");
+            serializeInputDocument(context, operation, inputShape);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Writes the code needed to serialize the input document of a request.
+     *
+     * <p>Implementations of this method are expected to set a value to the
+     * {@code body} variable that will be serialized as the request body.
+     * This variable will already be defined in scope.
+     *
+     * <p>For example:
+     *
+     * <pre>{@code
+     * let wrappedBody: any = {
+     *   OperationRequest: serializeAws_json1_1OperationRequest(input, context),
+     * };
+     * body = JSON.stringify(wrappedBody);
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param operation The operation being generated.
+     * @param inputStructure The structure containing the operation input.
+     */
+    protected abstract void serializeInputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape inputStructure
+    );
+
+    private void generateOperationDeserializer(GenerationContext context, OperationShape operation) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        Symbol symbol = symbolProvider.toSymbol(operation);
+        SymbolReference responseType = getApplicationProtocol().getResponseType();
+        TypeScriptWriter writer = context.getWriter();
+
+        // Ensure that the response type is imported.
+        writer.addUseImports(responseType);
+        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        // e.g., deserializeAws_restJson1_1ExecuteStatement
+        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, getName());
+        String errorMethodName = methodName + "Error";
+        // TODO Do we need to handle optional outputs everywhere?
+        // Add the normalized output type.
+        Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
+
+        // Handle the general response.
+        writer.openBlock("export async function $L(\n"
+                       + "  output: $T,\n"
+                       + "  context: SerdeContext\n"
+                       + "): Promise<$T> {", "}", methodName, responseType, outputType, () -> {
+            // Redirect error deserialization to the dispatcher
+            writer.openBlock("if (output.statusCode >= 400) {", "}", () -> {
+                writer.write("return $L(output, context);", errorMethodName);
+            });
+
+            // Start deserializing the response.
+            writer.write("let data: any = await parseBody(output.body, context)");
+            writer.write("let contents: any = {};");
+            readResponseBody(context, operation);
+
+            // Build the response with typing and metadata.
+            writer.openBlock("let response: $T = {", "};", outputType, () -> {
+                writer.write("$$metadata: deserializeMetadata(output),");
+                operation.getOutput().ifPresent(outputId -> {
+                    writer.write("__type: $S,", outputId.getName());
+                    writer.write("...contents,");
+                });
+            });
+            writer.write("return Promise.resolve(response);");
+        });
+        writer.write("");
+
+        // Write out the error deserialization dispatcher.
+        documentDeserializingShapes.addAll(HttpProtocolGeneratorUtils.generateErrorDispatcher(
+                context, operation, responseType, this::writeErrorCodeParser));
+    }
+
+    private void readResponseBody(GenerationContext context, OperationShape operation) {
+        operation.getOutput().ifPresent(outputId -> {
+            // If there's an output present, we know it's a structure.
+            StructureShape outputShape = context.getModel().getShapeIndex().getShape(outputId)
+                    .get().asStructureShape().get();
+
+            // Track output shapes so their deserializers may be generated.
+            documentDeserializingShapes.add(outputShape);
+
+            deserializeOutputDocument(context, operation, outputShape);
+        });
+    }
+
+    /**
+     * Writes the code that loads an {@code errorCode} String with the content used
+     * to dispatch errors to specific serializers.
+     *
+     * <p>Three variables will be in scope:
+     *   <ul>
+     *       <li>{@code output}: a value of the HttpResponse type.</li>
+     *       <li>{@code data}: the contents of the response body.</li>
+     *       <li>{@code context}: the SerdeContext.</li>
+     *   </ul>
+     *
+     * <p>For example:
+     *
+     * <pre>{@code
+     * errorCode = output.headers["x-amzn-errortype"].split(':')[0];
+     * }</pre>
+     *
+     * @param context The generation context.
+     */
+    protected abstract void writeErrorCodeParser(GenerationContext context);
+
+    /**
+     * Writes the code needed to deserialize the output document of a response.
+     *
+     * <p>Implementations of this method are expected to set members in the
+     * {@code contents} variable that represents the type generated for the
+     * response. This variable will already be defined in scope.
+     *
+     * <p>The contents of the response body will be available in a {@code data} variable.
+     *
+     * <p>For example:
+     *
+     * <pre>{@code
+     * contents = deserializeAws_json1_1OperationResponse(data.OperationResponse, context);
+     * }</pre>
+     *
+     * @param context The generation context.
+     * @param operation The operation being generated.
+     * @param outputStructure The structure containing the operation output.
+     */
+    protected abstract void deserializeOutputDocument(
+            GenerationContext context,
+            OperationShape operation,
+            StructureShape outputStructure
+    );
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.ListUtils;
@@ -101,20 +102,6 @@ public class DocumentMemberDeserVisitorTest {
         Assertions.assertThrows(CodegenException.class, () -> {
             MemberShape.builder().target(id + "Target").id(id + "$member").build().accept(visitor);
         });
-    }
-
-    @Test
-    public void givesCorrectTimestampDeserialization() {
-        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
-        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT);
-
-        assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.DATE_TIME)));
-        assertThat("new Date(" + DATA_SOURCE + " % 1 != 0 ? Math.round("
-                           + DATA_SOURCE + " * 1000) : " + DATA_SOURCE + ")",
-                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.EPOCH_SECONDS)));
-        assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(visitor.getTimestampDeserializedWithFormat(shape, Format.HTTP_DATE)));
     }
 
     private static final class MockProvider implements SymbolProvider {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -107,19 +107,6 @@ public class DocumentMemberSerVisitorTest {
         });
     }
 
-    @Test
-    public void givesCorrectTimestampSerialization() {
-        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
-        DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT);
-
-        assertThat(DATA_SOURCE + ".toISOString()",
-                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.DATE_TIME)));
-        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
-                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.EPOCH_SECONDS)));
-        assertThat(DATA_SOURCE + ".toUTCString()",
-                equalTo(visitor.getTimestampSerializedWithFormat(shape, Format.HTTP_DATE)));
-    }
-
     private static final class MockProvider implements SymbolProvider {
         private final String id = "com.smithy.example#Foo";
         private Symbol mock = Symbol.builder()

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -1,0 +1,37 @@
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+
+public class HttpProtocolGeneratorUtilsTest {
+    private static final String DATA_SOURCE = "dataSource";
+
+    @Test
+    public void givesCorrectTimestampSerialization() {
+        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
+
+        assertThat(DATA_SOURCE + ".toISOString()",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.DATE_TIME)));
+        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
+        assertThat(DATA_SOURCE + ".toUTCString()",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.HTTP_DATE)));
+    }
+
+    @Test
+    public void givesCorrectTimestampDeserialization() {
+        TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
+
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.DATE_TIME)));
+        assertThat("new Date(" + DATA_SOURCE + " % 1 != 0 ? Math.round("
+                           + DATA_SOURCE + " * 1000) : " + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.HTTP_DATE)));
+    }
+}


### PR DESCRIPTION
This commit adds support for HTTP RPC protocols through the
`HttpRpcProtocolGenerator` abstract class. Its surface area
is similar to the `HttpBindingProtocolGenerator` but instead
generates POST-based RPC api calls.

Shared code between the two `ProtocolGenerator` implementations
has been moved to a utils class for reuse; implementations and
tests have been updated accordingly.

In the process of building this feature, several bugs and some
documentation issues were resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
