### PR TITLE
feat: make command's serializer asynchronous

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -193,7 +193,11 @@ final class CommandGenerator implements Runnable {
                     .write("protocol: string,")
                     .write("context: SerdeContext")
                 .dedent()
-                .openBlock("): $T {", "}", applicationProtocol.getRequestType(), () -> writeSerdeDispatcher(true));
+                .openBlock(
+                        "): Promise<$T> {", "}",
+                        applicationProtocol.getRequestType(),
+                        () -> writeSerdeDispatcher(true)
+                );
 
         writer.write("")
                 .write("private deserialize(")

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -168,10 +168,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
 
-        writer.openBlock("export function $L(\n"
+        writer.openBlock("export async function $L(\n"
                        + "  input: $T,\n"
                        + "  context: SerdeContext\n"
-                       + "): $T {", "}", methodName, inputType, requestType, () -> {
+                       + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
             List<HttpBinding> labelBindings = writeRequestLabels(context, operation, bindingIndex, trait);
             List<HttpBinding> queryBindings = writeRequestQueryString(context, operation, bindingIndex);
             writeHeaders(context, operation, bindingIndex);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -119,10 +119,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
 
-        writer.openBlock("export function $L(\n"
+        writer.openBlock("export async function $L(\n"
                                  + "  input: $T,\n"
                                  + "  context: SerdeContext\n"
-                                 + "): $T {", "}", methodName, inputType, requestType, () -> {
+                                 + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
             writeRequestHeaders(context);
             boolean hasRequestBody = writeRequestBody(context, operation);
 


### PR DESCRIPTION
*Description of changes:*

command's deserializer is already async, this change makes serializer
async to avoid antipattern 

refer: https://github.com/aws/aws-sdk-js-v3/pull/474
/cc @kstich @srchase 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
