### PR TITLE
add md5 config

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -191,6 +191,10 @@ final class ServiceGenerator implements Runnable {
                              + "that computes the SHA-256 HMAC or checksum of a string or binary buffer.");
             writer.write("sha256?: __HashConstructor;\n");
 
+            writer.writeDocs("A constructor for a class implementing the @aws-sdk/types.Hash interface \n"
+                             + "that computes md5 checksums");
+            writer.write("md5?: __HashConstructor;\n");
+
             writer.addImport("UrlParser", "__UrlParser", "@aws-sdk/types");
             writer.writeDocs("The function that will be used to convert strings into HTTP endpoints.");
             writer.write("urlParser?: __UrlParser;\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -43,7 +43,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^0.1.0-preview.1", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^0.1.0-preview.5", true),
 
-    AWS_SDK_MD5_BROWSER("dependencies", "@aws-sdk/md-js", "^0.1.0-preview.8", true),
+    AWS_SDK_MD5_BROWSER("dependencies", "@aws-sdk/md5-js", "^0.1.0-preview.8", true),
 
     AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^0.1.0-preview.6", true),
     AWS_SDK_STREAM_COLLECTOR_BROWSER("dependencies", "@aws-sdk/stream-collector-browser", "^0.1.0-preview.5", true),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -43,6 +43,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^0.1.0-preview.1", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^0.1.0-preview.5", true),
 
+    AWS_SDK_MD5_BROWSER("dependencies", "@aws-sdk/md-js", "^0.1.0-preview.8", true),
+
     AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^0.1.0-preview.6", true),
     AWS_SDK_STREAM_COLLECTOR_BROWSER("dependencies", "@aws-sdk/stream-collector-browser", "^0.1.0-preview.5", true),
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -1,4 +1,5 @@
 import { Sha256 } from "@aws-crypto/sha256-browser";
+import { Md5 } from "@aws-sdk/md5-js"
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
@@ -13,6 +14,7 @@ export const ClientRuntimeConfiguration: Required<ClientRuntimeDependencies> = {
   protocol: "${protocol}",
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
+  md5: Md5,
   urlParser: parseUrl,
   bodyLengthChecker: calculateBodyLength,
   streamCollector,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -13,6 +13,7 @@ export const ClientRuntimeConfiguration: Required<ClientRuntimeDependencies> = {
   protocol: "${protocol}",
   requestHandler: new NodeHttpHandler(),
   sha256: Hash.bind(null, "sha256"),
+  md5: Hash.bind(null, "md5"),
   urlParser: parseUrl,
   bodyLengthChecker: calculateBodyLength,
   streamCollector,


### PR DESCRIPTION
Adds md5 hashing constructor to runtime configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
