### PR TITLE
Generate unique error response deserializers

### DIFF
--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -17,7 +17,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesEmptyMessageMemberOfException() {
         testErrorStructureCodegen("error-test-empty.smithy",
-                                  "export interface Err extends _smithy.SmithyException {\n"
+                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
                                   + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "}");
@@ -26,7 +26,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesOptionalMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-message.smithy",
-                                  "export interface Err extends _smithy.SmithyException {\n"
+                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
                                   + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message?: string;\n"
@@ -36,7 +36,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesRequiredMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-message.smithy",
-                                  "export interface Err extends _smithy.SmithyException {\n"
+                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
                                   + "  __type: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message: string | undefined;\n"


### PR DESCRIPTION
#### Generate unique error response deserializers

This commit updates the abstact `ProtocolGenerator` implementations
to generate unique error response deserializers. This supports error
shapes that have HTTP bindings in the `HttpBindingProtocolGenerator`
as well as adding `$metadata` contents to errors.

This commit also includes minor updates to move from `let` to `const`.

-----

#### Fix Error structure interface extensions

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
