### PR TITLE
Clean up runtime config and make it more generic

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/LanguageTarget.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/LanguageTarget.java
@@ -19,16 +19,38 @@ package software.amazon.smithy.typescript.codegen;
  * Represents a possible language target that can be generated.
  */
 public enum LanguageTarget {
-    NODE,
-    BROWSER;
-
-    String getTemplateFileName() {
-        if (this == NODE) {
+    /**
+     * Node-specific language target.
+     */
+    NODE {
+        @Override
+        String getTemplateFileName() {
             return "runtimeConfig.ts.template";
-        } else {
+        }
+    },
+
+    /**
+     * Browser-specific language target.
+     */
+    BROWSER {
+        @Override
+        String getTemplateFileName() {
             return "runtimeConfig.browser.ts.template";
         }
-    }
+    },
+
+    /**
+     * A language target that shares configuration that is shared across all
+     * runtimes.
+     */
+    SHARED {
+        @Override
+        String getTemplateFileName() {
+            return "runtimeConfig.shared.ts.template";
+        }
+    };
+
+    abstract String getTemplateFileName();
 
     String getTargetFilename() {
         return getTemplateFileName().replace(".template", "");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -57,6 +57,7 @@ final class RuntimeConfigGenerator {
         String template = TypeScriptUtils.loadResourceAsString(target.getTemplateFileName());
         String contents = template
                 .replace("${clientModuleName}", symbolProvider.toSymbol(service).getNamespace())
+                .replace("${apiVersion}", service.getVersion())
                 // Set the protocol to "undefined" if no default protocol can be resolved.
                 // This should only be the case when testing out code generators. The runtime
                 // code is expected to throw an exception when this value is encountered.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -165,7 +165,7 @@ public interface TypeScriptIntegration {
      * Adds additional client config interface fields.
      *
      * <p>Implementations of this method are expected to add fields to the
-     * client dependency interface of a generated client. This interface
+     * "ClientDefaults" interface of a generated client. This interface
      * contains fields that are either statically generated from
      * a model or are dependent on the runtime that a client is running in.
      * Implementations are expected to write interface field names and
@@ -211,12 +211,12 @@ public interface TypeScriptIntegration {
     }
 
     /**
-     * Adds additional runtime-specific client config values.
+     * Adds additional runtime-specific or shared client config values.
      *
      * <p>Implementations of this method are expected to add values to
-     * a runtime-specific configuration object that is used to provide
-     * values for a client dependency interface. This method is invoked
-     * for every supported {@link LanguageTarget}. Implementations are
+     * a runtime-specific or shared configuration object that is used to
+     * provide values for a "ClientDefaults" interface. This method is
+     * invoked for every supported {@link LanguageTarget}. Implementations are
      * expected to branch on the provided {@code LanguageTarget} and add
      * the appropriate default values and imports, each followed by a
      * (,). Any number of key-value pairs can be added, and any {@link Symbol}
@@ -226,7 +226,7 @@ public interface TypeScriptIntegration {
      * generated {@code package.json} file.
      *
      * <p>For example, the following code adds two values for both the
-     * node and browser targets:
+     * node and browser targets and ignores the SHARED target:
      *
      * <pre>
      * {@code
@@ -252,8 +252,37 @@ public interface TypeScriptIntegration {
      *             case BROWSER:
      *                 writer.write("bar: someBrowserValue,");
      *                 break;
+     *             case SHARED:
+     *                 break;
      *             default:
      *                 LOGGER.warn("Unknown target: " + target);
+     *         }
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p>The following code adds a value to the runtimeConfig.shared.ts file
+     * so that it used on all platforms. It pulls a trait value from the
+     * service being generated and adds it to the client configuration. Note
+     * that a corresponding entry needs to be added to
+     * {@link #addConfigInterfaceFields} to make TypeScript aware of the
+     * property.
+     *
+     * <pre>
+     * {@code
+     * public final class MyIntegration2 implements TypeScriptIntegration {
+     *     public void addRuntimeConfigValues(
+     *             TypeScriptSettings settings,
+     *             Model model,
+     *             SymbolProvider symbolProvider,
+     *             TypeScriptWriter writer,
+     *             LanguageTarget target
+     *     ) {
+     *         if (target == LanguageTarget.SHARED) {
+     *             String someTraitValue = settings.getModel(model).getTrait(SomeTrait.class)
+     *                          .map(SomeTrait::getValue)
+     *                          .orElse("");
+     *             writer.write("someTraitValue: $S,", someTraitValue);
      *         }
      *     }
      * }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -7,10 +7,11 @@ import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { name, version } from "./package.json";
-import { ClientRuntimeDependencies } from "${clientModuleName}";
+import { ClientDefaults } from "${clientModuleName}";
+import { ClientSharedValues } from "./runtimeConfig.shared";
 
-export const ClientRuntimeConfiguration: Required<ClientRuntimeDependencies> = {
-  protocol: "${protocol}",
+export const ClientDefaultValues: Required<ClientDefaults> = {
+  ...ClientSharedValues,
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   urlParser: parseUrl,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
@@ -1,0 +1,5 @@
+export const ClientSharedValues = {
+  protocol: "${protocol}",
+  apiVersion: "${apiVersion}",
+${customizations}
+};

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -7,10 +7,11 @@ import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { name, version } from "./package.json";
-import { ClientRuntimeDependencies } from "${clientModuleName}";
+import { ClientDefaults } from "${clientModuleName}";
+import { ClientSharedValues } from "./runtimeConfig.shared";
 
-export const ClientRuntimeConfiguration: Required<ClientRuntimeDependencies> = {
-  protocol: "${protocol}",
+export const ClientDefaultValues: Required<ClientDefaults> = {
+  ...ClientSharedValues,
   requestHandler: new NodeHttpHandler(),
   sha256: Hash.bind(null, "sha256"),
   urlParser: parseUrl,

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -45,23 +45,29 @@ public class RuntimeConfigGeneratorTest {
                 settings, model, symbolProvider, "undefined", delegator, integrations);
         generator.generate(LanguageTarget.NODE);
         generator.generate(LanguageTarget.BROWSER);
+        generator.generate(LanguageTarget.SHARED);
         delegator.flushWriters();
 
         Assertions.assertTrue(manifest.hasFile("runtimeConfig.ts"));
         Assertions.assertTrue(manifest.hasFile("runtimeConfig.browser.ts"));
+        Assertions.assertTrue(manifest.hasFile("runtimeConfig.shared.ts"));
+
+        // Does the runtimeConfig.shared.ts file expand the template properties properly?
+        String runtimeConfigSharedContents = manifest.getFileString("runtimeConfig.shared.ts").get();
+        assertThat(runtimeConfigSharedContents, containsString("protocol: \"undefined\","));
+        assertThat(runtimeConfigSharedContents, containsString("apiVersion: \"1.0.0\","));
+        assertThat(runtimeConfigSharedContents, containsString("syn: 'ack',"));
 
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigContents,
-                   containsString("import { ClientRuntimeDependencies } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigContents, containsString("protocol: \"undefined\","));
+                   containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack',"));
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigBrowserContents,
-                   containsString("import { ClientRuntimeDependencies } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigBrowserContents, containsString("protocol: \"undefined\","));
+                   containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack',"));
     }
 }


### PR DESCRIPTION
This commit updates runtime configuration to now have a SHARED
LanguageTarget. This language target allows for code generated
configuration values to be provided by the code generator (for example,
setting things like the protocol name and apiVersion). This change
renames the interfaces and exported consts used in clients so that they
are more general purpose than just runtime configuration.

Related to https://github.com/aws/aws-sdk-js-v3/pull/490/files

*Issue #, if available:*

*Description of changes:*

Generates the following for runtimeConfig.shared.ts:

```typescript
export const ClientSharedValues = {
  protocol: "undefined",
  apiVersion: "2006-03-01",

};
```

Generates the following for runtimeConfig.ts:

```typescript
import { Hash } from "@aws-sdk/hash-node";
import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
import { parseUrl } from "@aws-sdk/url-parser-node";
import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
import { streamCollector } from "@aws-sdk/stream-collector-node";
import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
import { name, version } from "./package.json";
import { ClientDefaults } from "./WeatherClient";
import { ClientSharedValues } from "./runtimeConfig.shared";

export const ClientDefaultValues: Required<ClientDefaults> = {
  ...ClientSharedValues,
  requestHandler: new NodeHttpHandler(),
  sha256: Hash.bind(null, "sha256"),
  urlParser: parseUrl,
  bodyLengthChecker: calculateBodyLength,
  streamCollector,
  base64Decoder: fromBase64,
  base64Encoder: toBase64,
  utf8Decoder: fromUtf8,
  utf8Encoder: toUtf8,
  defaultUserAgent: defaultUserAgent(name, version),

};
```

Generates the following for runtimeConfig.browser.ts:

```typescript
import { Sha256 } from "@aws-crypto/sha256-browser";
import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
import { parseUrl } from "@aws-sdk/url-parser-browser";
import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
import { streamCollector } from "@aws-sdk/stream-collector-browser";
import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
import { name, version } from "./package.json";
import { ClientDefaults } from "./WeatherClient";
import { ClientSharedValues } from "./runtimeConfig.shared";

export const ClientDefaultValues: Required<ClientDefaults> = {
  ...ClientSharedValues,
  requestHandler: new FetchHttpHandler(),
  sha256: Sha256,
  urlParser: parseUrl,
  bodyLengthChecker: calculateBodyLength,
  streamCollector,
  base64Decoder: fromBase64,
  base64Encoder: toBase64,
  utf8Decoder: fromUtf8,
  utf8Encoder: toUtf8,
  defaultUserAgent: defaultUserAgent(name, version),

};
```
The interface for clients now is named `ClientDefaults`, and starts like this:

```typescript
export interface ClientDefaults
  extends Partial<SmithyResolvedConfiguration<__HttpOptions>> {
  // ...
}
```

The client then goes on to mix in the generated runtime specific values into the constructor here:

```typescript
  constructor(configuration: WeatherClientConfig) {
    let _config_0 = {
      ...__ClientDefaultValues,
      ...configuration
    };
    super(_config_0);
    this.config = _config_0;
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.