### PR TITLE
Support a single protocol in the generator

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -32,7 +32,6 @@ final class RuntimeConfigGenerator {
     private final Model model;
     private final ServiceShape service;
     private final SymbolProvider symbolProvider;
-    private final String protocolName;
     private final TypeScriptDelegator delegator;
     private final List<TypeScriptIntegration> integrations;
 
@@ -40,7 +39,6 @@ final class RuntimeConfigGenerator {
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,
-            String protocolName,
             TypeScriptDelegator delegator,
             List<TypeScriptIntegration> integrations
     ) {
@@ -48,7 +46,6 @@ final class RuntimeConfigGenerator {
         this.model = model;
         this.service = settings.getService(model);
         this.symbolProvider = symbolProvider;
-        this.protocolName = protocolName;
         this.delegator = delegator;
         this.integrations = integrations;
     }
@@ -58,10 +55,6 @@ final class RuntimeConfigGenerator {
         String contents = template
                 .replace("${clientModuleName}", symbolProvider.toSymbol(service).getNamespace())
                 .replace("${apiVersion}", service.getVersion())
-                // Set the protocol to "undefined" if no default protocol can be resolved.
-                // This should only be the case when testing out code generators. The runtime
-                // code is expected to throw an exception when this value is encountered.
-                .replace("${protocol}", protocolName == null ? "undefined" : protocolName)
                 .replace("$", "$$") // sanitize template place holders.
                 .replace("$${customizations}", "${L@customizations}");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnresolvableProtocolException.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnresolvableProtocolException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.CodegenException;
+
+public class UnresolvableProtocolException extends CodegenException {
+    public UnresolvableProtocolException(String message) {
+        super(message);
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
@@ -1,5 +1,4 @@
 export const ClientSharedValues = {
-  protocol: "${protocol}",
   apiVersion: "${apiVersion}",
 ${customizations}
 };

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -42,7 +42,7 @@ public class RuntimeConfigGeneratorTest {
         TypeScriptDelegator delegator = new TypeScriptDelegator(
                 settings, model, manifest, symbolProvider, integrations);
         RuntimeConfigGenerator generator = new RuntimeConfigGenerator(
-                settings, model, symbolProvider, "undefined", delegator, integrations);
+                settings, model, symbolProvider, delegator, integrations);
         generator.generate(LanguageTarget.NODE);
         generator.generate(LanguageTarget.BROWSER);
         generator.generate(LanguageTarget.SHARED);
@@ -54,7 +54,6 @@ public class RuntimeConfigGeneratorTest {
 
         // Does the runtimeConfig.shared.ts file expand the template properties properly?
         String runtimeConfigSharedContents = manifest.getFileString("runtimeConfig.shared.ts").get();
-        assertThat(runtimeConfigSharedContents, containsString("protocol: \"undefined\","));
         assertThat(runtimeConfigSharedContents, containsString("apiVersion: \"1.0.0\","));
         assertThat(runtimeConfigSharedContents, containsString("syn: 'ack',"));
 


### PR DESCRIPTION
This commit updates the generator to support a single protocol and
removes the protocol name from the runtime code. We can add support for
multiple protocols in the future if needed (for example, if a service
actually splits their operations across protocols), but for now, it's
safer to expose only a single protocol in both the generator and the
generated code. The location and format of the generated protocol code
all remains the same, however, the generator no longer supports multiple
protocols in the "protocols" option, there's no longer a code generated
"protocol" property available at runtime, and the method that used to
dispatch to different protocols now just supports calling a single
protocol.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
