### PR TITLE
fix non modular client generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -253,7 +253,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         String nonModularName = serviceSymbol.getName().replace("Client", "");
         String filename = serviceSymbol.getDefinitionFile().replace("Client", "");
         writers.useFileWriter(filename, writer -> new NonModularServiceGenerator(
-                settings, model, symbolProvider, nonModularName, writer).run());
+                settings, model, symbolProvider, nonModularName, writer, applicationProtocol).run());
 
         // Generate each operation for the service.
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -85,6 +85,8 @@ final class CommandGenerator implements Runnable {
 
         // Add required imports.
         writer.addImport(configType, configType, serviceSymbol.getNamespace());
+        writer.addImport("ServiceInputTypes", "ServiceInputTypes", serviceSymbol.getNamespace());
+        writer.addImport("ServiceOutputTypes", "ServiceOutputTypes", serviceSymbol.getNamespace());
         writer.addImport("Command", "$Command", "@aws-sdk/smithy-client");
         writer.addImport("FinalizeHandlerArguments", "FinalizeHandlerArguments", "@aws-sdk/types");
         writer.addImport("Handler", "Handler", "@aws-sdk/types");
@@ -133,7 +135,7 @@ final class CommandGenerator implements Runnable {
 
         writer.write("resolveMiddleware(")
                 .indent()
-                .write("clientStack: MiddlewareStack<$T, $T>,", inputType, outputType)
+                .write("clientStack: MiddlewareStack<$L, $L>,", "ServiceInputTypes", "ServiceOutputTypes")
                 .write("configuration: $L,", configType)
                 .write("options?: $T", applicationProtocol.getOptionsType())
                 .dedent();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -47,6 +47,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
@@ -539,7 +540,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             });
 
             // Start deserializing the response.
-            writer.write("const data: any = await parseBody(output.body, context)");
             writer.openBlock("const contents: $T = {", "};", outputType, () -> {
                 writer.write("$$metadata: deserializeMetadata(output),");
 
@@ -582,7 +582,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "  output: any,\n"
                        + "  context: SerdeContext\n"
                        + "): $T => {", "};", errorDeserMethodName, errorSymbol, () -> {
-            writer.write("const data: any = output.body;");
 
             writer.openBlock("const contents: $T = {", "};", errorSymbol, () -> {
                 writer.write("__type: $S,", error.getId().getName());
@@ -662,6 +661,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         List<HttpBinding> documentBindings = bindingIndex.getResponseBindings(operationOrError, Location.DOCUMENT);
         documentBindings.sort(Comparator.comparing(HttpBinding::getMemberName));
         List<HttpBinding> payloadBindings = bindingIndex.getResponseBindings(operationOrError, Location.PAYLOAD);
+
+        if (operationOrError.isOperationShape() && !payloadBindings.get(0).getMember().hasTrait(StreamingTrait.class)) {
+            writer.write("const data: any = await parseBody(output.body, context)");
+        } else {
+            // Don't collect stream for errors and streaming payload
+            writer.write("const data: any = output.body;");
+        }
 
         if (!documentBindings.isEmpty()) {
             deserializeOutputDocument(context, operationOrError, documentBindings);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -19,16 +19,19 @@ import static software.amazon.smithy.model.knowledge.HttpBinding.Location;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.logging.Logger;
+
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
@@ -662,11 +665,20 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         documentBindings.sort(Comparator.comparing(HttpBinding::getMemberName));
         List<HttpBinding> payloadBindings = bindingIndex.getResponseBindings(operationOrError, Location.PAYLOAD);
 
-        if (operationOrError.isOperationShape() && !payloadBindings.get(0).getMember().hasTrait(StreamingTrait.class)) {
-            writer.write("const data: any = await parseBody(output.body, context)");
-        } else {
-            // Don't collect stream for errors and streaming payload
+        // Prepare response body for deserializing.
+        OperationIndex operationIndex = context.getModel().getKnowledge(OperationIndex.class);
+        StructureShape operationOutputOrError = operationOrError.asStructureShape()
+                .orElseGet(() -> operationIndex.getOutput(operationOrError).orElse(null));
+        boolean hasStreamingComponent = Optional.ofNullable(operationOutputOrError)
+                .map(structure -> structure.getAllMembers().values().stream()
+                        .anyMatch(memberShape -> memberShape.hasTrait(StreamingTrait.class)))
+                .orElse(false);
+        if (hasStreamingComponent) {
+            // For operations with streaming output or errors with streaming body we keep the body intact.
             writer.write("const data: any = output.body;");
+        } else {
+            // Otherwise, we collect the response body to structured object with parseBody().
+            writer.write("const data: any = await parseBody(output.body, context);");
         }
 
         if (!documentBindings.isEmpty()) {


### PR DESCRIPTION
These changes are included:

1. populate parseBody() for non streaming command reponse and errors:
When preparing reponse body for command deserializers or error
deserializers, we don't always collect response body binaries
in structured JS object. If the command ouput or error has a
streaming trait, we need to keep the response body intact and
return users the raw response stream.

2. Update non-modular client generator to reflect the [newest client interface](https://github.com/aws/aws-sdk-js-v3/blob/2066ae107aec7b5cf967536ff37a816216e4d264/packages/smithy-client/src/client.ts#L31-L61)

3. Fix typing issues in commands


This PR generates a buildable full-blood RDS-data client: https://github.com/aws/aws-sdk-js-v3/pull/496

/cc @kstich 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
