### PR TITLE
Updates for HTTP serde correctness and safety

### DIFF
--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -175,9 +175,9 @@ structure GetCityImageInput {
 }
 
 structure GetCityImageOutput {
+    @streaming
     @httpPayload
     image: CityImageData,
 }
 
-@streaming
 blob CityImageData

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -36,7 +36,6 @@ import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -64,7 +63,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private final ServiceShape service;
     private final FileManifest fileManifest;
     private final SymbolProvider symbolProvider;
-    private final ShapeIndex nonTraits;
+    private final Model nonTraits;
     private final TypeScriptDelegator writers;
     private final List<TypeScriptIntegration> integrations = new ArrayList<>();
     private final List<RuntimeClientPlugin> runtimePlugins = new ArrayList<>();
@@ -73,7 +72,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     CodegenVisitor(PluginContext context) {
         settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
-        nonTraits = context.getNonTraitShapes();
+        nonTraits = context.getModelWithoutTraitShapes();
         model = context.getModel();
         service = settings.getService(model);
         fileManifest = context.getFileManifest();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -91,7 +91,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
         // Get each structure that's used as output or errors.
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
-        model.getShapeIndex().shapes(OperationShape.class).forEach(operationShape -> {
+        model.shapes(OperationShape.class).forEach(operationShape -> {
             operationIndex.getOutput(operationShape).ifPresent(outputShapes::add);
             outputShapes.addAll(operationIndex.getErrors(operationShape));
         });
@@ -297,7 +297,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol memberShape(MemberShape shape) {
-        Shape targetShape = model.getShapeIndex().getShape(shape.getTarget())
+        Shape targetShape = model.getShape(shape.getTarget())
                 .orElseThrow(() -> new CodegenException("Shape not found: " + shape.getTarget()));
         Symbol targetSymbol = targetShape.accept(this);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -84,7 +84,7 @@ public final class TypeScriptSettings {
 
     // TODO: this seems reusable across generators.
     private static ShapeId inferService(Model model) {
-        List<ShapeId> services = model.getShapeIndex()
+        List<ShapeId> services = model
                 .shapes(ServiceShape.class)
                 .map(Shape::getId)
                 .sorted()
@@ -205,7 +205,7 @@ public final class TypeScriptSettings {
      * @throws CodegenException if the service is invalid or not found.
      */
     public ServiceShape getService(Model model) {
-        return model.getShapeIndex()
+        return model
                 .getShape(getService())
                 .orElseThrow(() -> new CodegenException("Service shape not found: " + getService()))
                 .asServiceShape()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -210,7 +210,7 @@ public final class TypeScriptWriter extends CodeWriter {
      * @return Returns true if docs were written.
      */
     boolean writeMemberDocs(Model model, MemberShape member) {
-        return member.getMemberTrait(model.getShapeIndex(), DocumentationTrait.class)
+        return member.getMemberTrait(model, DocumentationTrait.class)
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
                     writeDocs(docs);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -48,7 +48,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * more complex deserialization strategies for those types.
  *
  * This class reduces the effort necessary to build protocol implementations, specifically when
- * implementing {@link HttpBindingProtocolGenerator#generateDocumentShapeDeserializers(GenerationContext, Set)}.
+ * implementing {@link HttpBindingProtocolGenerator#generateDocumentBodyShapeDeserializers(GenerationContext, Set)}.
  *
  * Implementations of this class independent of protocol documents are also possible.
  *

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -305,7 +305,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
         writer.addImport(symbol, symbol.getName());
         writer.openBlock("const $L = (\n"
                        + "  output: any,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): $T => {", "}", methodName, symbol, () -> functionBody.accept(context, shape));
         writer.write("");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -300,7 +300,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
         writer.addImport(symbol, symbol.getName());
         writer.openBlock("const $L = (\n"
                        + "  input: $T,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): any => {", "}", methodName, symbol, () -> functionBody.accept(context, shape));
         writer.write("");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -48,7 +48,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * complex serialization strategies for those types.
  *
  * This class reduces the effort necessary to build protocol implementations, specifically when
- * implementing {@link HttpBindingProtocolGenerator#generateDocumentShapeSerializers(GenerationContext, Set)}.
+ * implementing {@link HttpBindingProtocolGenerator#generateDocumentBodyShapeSerializers(GenerationContext, Set)}.
  *
  * Implementations of this class independent of protocol documents are also possible.
  *

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -36,6 +36,7 @@ import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.DoubleShape;
 import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -169,7 +170,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
         // e.g., serializeAws_restJson1_1ExecuteStatement
         String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName());
@@ -178,7 +179,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("export async function $L(\n"
                        + "  input: $T,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
             List<HttpBinding> labelBindings = writeRequestLabels(context, operation, bindingIndex, trait);
             List<HttpBinding> queryBindings = writeRequestQueryString(context, operation, bindingIndex);
@@ -303,11 +304,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             for (HttpBinding binding : bindingIndex.getRequestBindings(operation, Location.PREFIX_HEADERS)) {
                 String memberName = symbolProvider.toMemberName(binding.getMember());
                 writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
-                    Shape target = index.getShape(binding.getMember().getTarget()).get();
+                    MapShape prefixMap = index.getShape(binding.getMember().getTarget()).get().asMapShape().get();
+                    Shape target = index.getShape(prefixMap.getValue().getTarget()).get();
                     // Iterate through each entry in the member.
-                    writer.openBlock("Object.keys(input.$L).forEach(suffix -> {", "});", memberName, () -> {
+                    writer.openBlock("Object.keys(input.$L).forEach(suffix => {", "});", memberName, () -> {
+                        // Use a ! since we already validated the input member is defined above.
                         String headerValue = getInputValue(context, binding.getLocation(),
-                                "input." + memberName + "[suffix]", binding.getMember(), target);
+                                "input." + memberName + "![suffix]", binding.getMember(), target);
                         // Append the suffix to the defined prefix and serialize the value in to that key.
                         writer.write("headers[$S + suffix] = $L;", binding.getLocationName(), headerValue);
                     });
@@ -529,7 +532,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the response type is imported.
         writer.addUseImports(responseType);
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         // e.g., deserializeAws_restJson1_1ExecuteStatement
         String methodName = ProtocolGenerator.getDeserFunctionName(symbol, getName());
         String errorMethodName = methodName + "Error";
@@ -539,7 +542,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Handle the general response.
         writer.openBlock("export async function $L(\n"
                        + "  output: $T,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): Promise<$T> {", "}", methodName, responseType, outputType, () -> {
             // Redirect error deserialization to the dispatcher
             writer.openBlock("if (output.statusCode !== $L) {", "}", trait.getCode(), () -> {
@@ -588,7 +591,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("const $L = (\n"
                        + "  output: any,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): $T => {", "};", errorDeserMethodName, errorSymbol, () -> {
             writer.write("const data: any = output.body;");
 
@@ -638,23 +641,24 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 bindingIndex.getResponseBindings(operationOrError, Location.PREFIX_HEADERS);
         if (!prefixHeaderBindings.isEmpty()) {
             // Run through the headers one time, matching any prefix groups.
-            writer.openBlock("Object.keys(output.headers).forEach(header -> {", "});", () -> {
+            writer.openBlock("Object.keys(output.headers).forEach(header => {", "});", () -> {
                 for (HttpBinding binding : prefixHeaderBindings) {
                     // Generate a single block for each group of prefix headers.
-                    writer.openBlock("if (header.startsWith($L)) {", binding.getLocationName(), "}", () -> {
+                    writer.openBlock("if (header.startsWith($S)) {", "}", binding.getLocationName(), () -> {
                         String memberName = symbolProvider.toMemberName(binding.getMember());
-                        Shape target = context.getModel().getShapeIndex()
-                                .getShape(binding.getMember().getTarget()).get();
+                        MapShape prefixMap = index.getShape(binding.getMember().getTarget()).get().asMapShape().get();
+                        Shape target = index.getShape(prefixMap.getValue().getTarget()).get();
                         String headerValue = getOutputValue(context, binding.getLocation(),
                                 "output.headers[header]", binding.getMember(), target);
 
                         // Prepare a grab bag for these headers if necessary
                         writer.openBlock("if (contents.$L === undefined) {", "}", memberName, () -> {
-                            writer.write("contents.$L: any = {};", memberName);
+                            writer.write("contents.$L = {};", memberName);
                         });
 
                         // Extract the non-prefix portion as the key.
-                        writer.write("contents.$L[header.substring(header.length)] = $L;", memberName, headerValue);
+                        writer.write("contents.$L[header.substring($L)] = $L;",
+                                memberName, binding.getLocationName().length(), headerValue);
                     });
                 }
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -93,7 +93,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @param context The generation context.
      * @param shapes The shapes to generate serialization for.
      */
-    protected abstract void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes);
+    protected abstract void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes);
 
     /**
      * Generates deserialization functions for shapes in the passed set. These functions
@@ -104,13 +104,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @param context The generation context.
      * @param shapes The shapes to generate deserialization for.
      */
-    protected abstract void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes);
+    protected abstract void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes);
 
     @Override
     public void generateSharedComponents(GenerationContext context) {
         deserializingErrorShapes.forEach(error -> generateErrorDeserializer(context, error));
-        generateDocumentShapeSerializers(context, serializingDocumentShapes);
-        generateDocumentShapeDeserializers(context, deserializingDocumentShapes);
+        generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
+        generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -135,14 +135,17 @@ final class HttpProtocolGeneratorUtils {
 
         writer.openBlock("async function $L(\n"
                        + "  output: $T,\n"
-                       + "  context: SerdeContext,\n"
+                       + "  context: __SerdeContext,\n"
                        + "): Promise<$T> {", "}", errorMethodName, responseType, outputType, () -> {
             writer.write("const data: any = await parseBody(output.body, context);");
-            // Create a holding object since we have already parsed the body, but retain the rest of the output.
-            writer.openBlock("const parsedOutput: any = {", "};", () -> {
-                writer.write("...output,");
-                writer.write("body: data,");
-            });
+            // We only consume the parsedOutput if we're dispatching, so only generate if we will.
+            if (!operation.getErrors().isEmpty()) {
+                // Create a holding object since we have already parsed the body, but retain the rest of the output.
+                writer.openBlock("const parsedOutput: any = {", "};", () -> {
+                    writer.write("...output,");
+                    writer.write("body: data,");
+                });
+            }
             writer.write("let response: any;");
             writer.write("let errorCode: String;");
             errorCodeGenerator.accept(context);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -152,8 +152,7 @@ final class HttpProtocolGeneratorUtils {
             writer.openBlock("switch (errorCode) {", "}", () -> {
                 // Generate the case statement for each error, invoking the specific deserializer.
                 new TreeSet<>(operation.getErrors()).forEach(errorId -> {
-                    StructureShape error = context.getModel().getShapeIndex().getShape(errorId)
-                            .get().asStructureShape().get();
+                    StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
                     // Track errors bound to the operation so their deserializers may be generated.
                     errorShapes.add(error);
                     Symbol errorSymbol = symbolProvider.toSymbol(error);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -110,7 +110,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
         // e.g., serializeAws_restJson1_1ExecuteStatement
         String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName());
@@ -118,9 +118,9 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
 
         writer.openBlock("export async function $L(\n"
-                                 + "  input: $T,\n"
-                                 + "  context: SerdeContext\n"
-                                 + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
+                       + "  input: $T,\n"
+                       + "  context: __SerdeContext\n"
+                       + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
             writeRequestHeaders(context, operation);
             boolean hasRequestBody = writeRequestBody(context, operation);
 
@@ -220,7 +220,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // Ensure that the response type is imported.
         writer.addUseImports(responseType);
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         // e.g., deserializeAws_restJson1_1ExecuteStatement
         String methodName = ProtocolGenerator.getDeserFunctionName(symbol, getName());
         String errorMethodName = methodName + "Error";
@@ -230,7 +230,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Handle the general response.
         writer.openBlock("export async function $L(\n"
                        + "  output: $T,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): Promise<$T> {", "}", methodName, responseType, outputType, () -> {
             // Redirect error deserialization to the dispatcher
             writer.openBlock("if (output.statusCode >= 400) {", "}", () -> {
@@ -272,7 +272,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         writer.openBlock("const $L = (\n"
                        + "  output: any,\n"
-                       + "  context: SerdeContext\n"
+                       + "  context: __SerdeContext\n"
                        + "): $T => {", "};", errorDeserMethodName, errorSymbol, () -> {
             // First deserialize the body properly.
             writer.write("const deserialized: any = $L(output.body, context);",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -59,7 +59,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * @param context The generation context.
      * @param shapes The shapes to generate serialization for.
      */
-    protected abstract void generateDocumentShapeSerializers(GenerationContext context, Set<Shape> shapes);
+    protected abstract void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes);
 
     /**
      * Generates deserialization functions for shapes in the passed set. These functions
@@ -70,13 +70,13 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * @param context The generation context.
      * @param shapes The shapes to generate deserialization for.
      */
-    protected abstract void generateDocumentShapeDeserializers(GenerationContext context, Set<Shape> shapes);
+    protected abstract void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes);
 
     @Override
     public void generateSharedComponents(GenerationContext context) {
         deserializingErrorShapes.forEach(error -> generateErrorDeserializer(context, error));
-        generateDocumentShapeSerializers(context, serializingDocumentShapes);
-        generateDocumentShapeDeserializers(context, deserializingDocumentShapes);
+        generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
+        generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -151,8 +151,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     private boolean writeRequestBody(GenerationContext context, OperationShape operation) {
         if (operation.getInput().isPresent()) {
             // If there's an input present, we know it's a structure.
-            StructureShape inputShape = context.getModel().getShapeIndex().getShape(operation.getInput().get())
-                    .get().asStructureShape().get();
+            StructureShape inputShape = context.getModel().expectShape(operation.getInput().get())
+                    .asStructureShape().get();
 
             // Track input shapes so their serializers may be generated.
             serializingDocumentShapes.add(inputShape);
@@ -295,8 +295,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     private void readResponseBody(GenerationContext context, OperationShape operation) {
         operation.getOutput().ifPresent(outputId -> {
             // If there's an output present, we know it's a structure.
-            StructureShape outputShape = context.getModel().getShapeIndex().getShape(outputId)
-                    .get().asStructureShape().get();
+            StructureShape outputShape = context.getModel().expectShape(outputId).asStructureShape().get();
 
             // Track output shapes so their deserializers may be generated.
             deserializingDocumentShapes.add(outputShape);

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words.txt
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words.txt
@@ -92,6 +92,7 @@ Blob
 Boolean
 ConstructorParameters
 Date
+Error
 Exclude
 Extract
 Infinity

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -109,8 +109,8 @@ public class SymbolProviderTest {
                 .assemble()
                 .unwrap();
 
-        Shape input = model.getShapeIndex().getShape(ShapeId.from("smithy.example#GetFooInput")).get();
-        Shape output = model.getShapeIndex().getShape(ShapeId.from("smithy.example#GetFooOutput")).get();
+        Shape input = model.expectShape(ShapeId.from("smithy.example#GetFooInput"));
+        Shape output = model.expectShape(ShapeId.from("smithy.example#GetFooOutput"));
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol inputSymbol = provider.toSymbol(input);
         Symbol outputSymbol = provider.toSymbol(output);
@@ -136,7 +136,7 @@ public class SymbolProviderTest {
                 .assemble()
                 .unwrap();
 
-        Shape command = model.getShapeIndex().getShape(ShapeId.from("smithy.example#GetFoo")).get();
+        Shape command = model.expectShape(ShapeId.from("smithy.example#GetFoo"));
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol commandSymbol = provider.toSymbol(command);
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegatorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegatorTest.java
@@ -21,7 +21,7 @@ public class TypeScriptDelegatorTest {
     @Test
     public void vendsWritersForShapes() {
         Model model = createModel();
-        Shape fooShape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#Foo")).get();
+        Shape fooShape = model.expectShape(ShapeId.from("smithy.example#Foo"));
         SymbolProvider provider = createProvider();
         MockManifest manifest = new MockManifest();
         TypeScriptSettings settings = new TypeScriptSettings();
@@ -49,7 +49,7 @@ public class TypeScriptDelegatorTest {
     @Test
     public void appendsToOpenedWriterWithNewline() {
         Model model = createModel();
-        Shape fooShape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#Foo")).get();
+        Shape fooShape = model.expectShape(ShapeId.from("smithy.example#Foo"));
         SymbolProvider provider = createProvider();
         MockManifest manifest = new MockManifest();
         TypeScriptSettings settings = new TypeScriptSettings();
@@ -66,7 +66,7 @@ public class TypeScriptDelegatorTest {
     @Test
     public void emitsBeforeWritingAndWhenCreated() {
         Model model = createModel();
-        Shape fooShape = model.getShapeIndex().getShape(ShapeId.from("smithy.example#Foo")).get();
+        Shape fooShape = model.expectShape(ShapeId.from("smithy.example#Foo"));
         SymbolProvider provider = createProvider();
         MockManifest manifest = new MockManifest();
         List<Pair<TypeScriptWriter, Shape>> before = new ArrayList<>();


### PR DESCRIPTION
This commit includes updates to Http ProtocolGenerator components for
correctness and safety.

1. It fixes generation issues for the @httpPrefixHeaders trait in
the HttpBindingProtocolGenerator.
2. It updates SerdeContext to use an import alias for safety.
3. It only generates a local parsedOutput if it will be consumed.
4. It adds the Error type to the list of Typescript reserved words.

-----

Use Model instead of deprecated ShapeIndex. This commit will require using the latest version of Smithy published locally.

-----

Use better name for document body shape serde gen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
