### PR TITLE
loosen TS compiler config for noUnusedLocals

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -11,7 +11,6 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
-    "noUnusedLocals": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },


### PR DESCRIPTION
In some circumstances(e.g. endpoints.ts), it's very hard to infer which variable won't be used in the codegen, so we loose the ts config requirement to make the build pass. 

Later on, we shoud introduce TS linter(like prettier) to remove ununsed variables in the codegen script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
