### PR TITLE
fix response payload and incorrectly parsing error response

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -48,7 +48,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
@@ -721,6 +720,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 .orElse(false);
 
         if (!documentBindings.isEmpty()) {
+            // If response has document binding, the body can be parsed to JavaScript object.
             writer.write("const data: any = await parseBody(output.body, context);");
             deserializeOutputDocument(context, operationOrError, documentBindings);
             return documentBindings;
@@ -735,12 +735,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             } else if (target instanceof BlobShape) {
                 // If payload is blob, only need to collect stream to binary data(Uint8Array).
                 writer.write("const data: any = await collectBody(output.body, context);");
-            } else if (target instanceof CollectionShape || target instanceof StructureShape) {
-                // If body is Collection or Structure, they we need to parse the string into JavaScript object.
+            } else if (target instanceof StructureShape || target instanceof UnionShape) {
+                // If body is Structure or Union, they we need to parse the string into JavaScript object.
                 writer.write("const data: any = await parseBody(output.body, context);");
             } else {
-                // If payload is other scalar types(not Collection or Structure), because payload will be values in
-                // string instead of valid JSON or XML. So we need to collect body and encode binary to string.
+                // If payload is string, we need to collect body and encode binary to string.
                 writer.write("const data: any = await collectBodyString(output.body, context);");
             }
             writer.write("contents.$L = $L;", binding.getMemberName(), getOutputValue(context,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -656,8 +656,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         if (isErrorCodeInBody) {
             // Body is already parsed in error dispatcher, simply assign body to data.
             writer.write("const data: any = output.body;");
-            List<HttpBinding> responseBindings = bindingIndex.getResponseBindings(error).values()
-                    .stream().collect(Collectors.toList());
+            List<HttpBinding> responseBindings = bindingIndex.getResponseBindings(error, Location.DOCUMENT);
             responseBindings.sort(Comparator.comparing(HttpBinding::getMemberName));
             return responseBindings;
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -926,9 +926,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      *
      * <p>Two variables will be in scope:
      *   <ul>
-     *       <li>{@code errorOutput} or {@code parsedOutput}: a value of the HttpResponse type.
+     *       <li>{@code output} or {@code parsedOutput}: a value of the HttpResponse type.
      *          <ul>
-     *              <li>{@code errorOutput} is a raw HttpResponse, available when {@code isErrorCodeInBody} is set to
+     *              <li>{@code output} is a raw HttpResponse, available when {@code isErrorCodeInBody} is set to
      *              {@code false}</li>
      *              <li>{@code parsedOutput} is a HttpResponse type with body parsed to JavaScript object, available
      *              when {@code isErrorCodeInBody} is set to {@code true}</li>

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -120,6 +120,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
         generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
+        HttpProtocolGeneratorUtils.generateCollectBody(context);
+        HttpProtocolGeneratorUtils.generateCollectBodyString(context);
     }
 
     /**
@@ -690,27 +692,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         List<HttpBinding> documentBindings = bindingIndex.getResponseBindings(operationOrError, Location.DOCUMENT);
         documentBindings.sort(Comparator.comparing(HttpBinding::getMemberName));
         List<HttpBinding> payloadBindings = bindingIndex.getResponseBindings(operationOrError, Location.PAYLOAD);
-
-        if (!documentBindings.isEmpty()) {
-            readReponseBodyData(context, operationOrError);
-            deserializeOutputDocument(context, operationOrError, documentBindings);
-            return documentBindings;
-        }
-        if (!payloadBindings.isEmpty()) {
-            readReponseBodyData(context, operationOrError);
-            // There can only be one payload binding.
-            HttpBinding binding = payloadBindings.get(0);
-            Shape target = context.getModel().expectShape(binding.getMember().getTarget());
-            writer.write("contents.$L = $L;", binding.getMemberName(), getOutputValue(context,
-                    Location.PAYLOAD, "data", binding.getMember(), target));
-            return payloadBindings;
-        }
-        return ListUtils.of();
-    }
-
-    private void readReponseBodyData(GenerationContext context, Shape operationOrError) {
-        TypeScriptWriter writer = context.getWriter();
-        // Prepare response body for deserializing.
         OperationIndex operationIndex = context.getModel().getKnowledge(OperationIndex.class);
         StructureShape operationOutputOrError = operationOrError.asStructureShape()
                 .orElseGet(() -> operationIndex.getOutput(operationOrError).orElse(null));
@@ -718,13 +699,35 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 .map(structure -> structure.getAllMembers().values().stream()
                         .anyMatch(memberShape -> memberShape.hasTrait(StreamingTrait.class)))
                 .orElse(false);
-        if (hasStreamingComponent || operationOrError.getType().equals(ShapeType.STRUCTURE)) {
-            // For operations with streaming output or errors with streaming body we keep the body intact.
-            writer.write("const data: any = output.body;");
-        } else {
-            // Otherwise, we collect the response body to structured object with parseBody().
+
+        if (!documentBindings.isEmpty()) {
             writer.write("const data: any = await parseBody(output.body, context);");
+            deserializeOutputDocument(context, operationOrError, documentBindings);
+            return documentBindings;
         }
+        if (!payloadBindings.isEmpty()) {
+            // There can only be one payload binding.
+            HttpBinding binding = payloadBindings.get(0);
+            Shape target = context.getModel().expectShape(binding.getMember().getTarget());
+            if (hasStreamingComponent) {
+                // If payload is streaming, return raw low-level stream directly.
+                writer.write("const data: any = output.body;");
+            } else if (target instanceof BlobShape) {
+                // If payload is blob, only need to collect stream to binary data(Uint8Array).
+                writer.write("const data: any = await collectBody(output.body, context);");
+            } else if (target instanceof CollectionShape || target instanceof StructureShape) {
+                // If body is Collection or Structure, they we need to parse the string into JavaScript object.
+                writer.write("const data: any = await parseBody(output.body, context);");
+            } else {
+                // If payload is other scalar types(not Collection or Structure), because payload will be values in
+                // string instead of valid JSON or XML. So we need to collect body and encode binary to string.
+                writer.write("const data: any = await collectBodyString(output.body, context);");
+            }
+            writer.write("contents.$L = $L;", binding.getMemberName(), getOutputValue(context,
+                    Location.PAYLOAD, "data", binding.getMember(), target));
+            return payloadBindings;
+        }
+        return ListUtils.of();
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -156,7 +156,7 @@ final class HttpProtocolGeneratorUtils {
      * @param operation The operation to generate for.
      * @param responseType The response type for the HTTP protocol.
      * @param errorCodeGenerator A consumer
-     * @param shouldParseErrorBody Flag indicating whether need to parse response body
+     * @param shouldParseErrorBody Flag indicating whether need to parse response body in this dispatcher function
      * @return A set of all error structure shapes for the operation that were dispatched to.
      */
     static Set<StructureShape> generateErrorDispatcher(
@@ -180,8 +180,9 @@ final class HttpProtocolGeneratorUtils {
                        + "): Promise<$T> {", "}", errorMethodName, responseType, outputType, () -> {
             // Prepare error response for parsing error code. If error code needs to be parsed from response body
             // then we collect body and parse it to JS object, otherwise leave the response body as is.
+            String outputReference = shouldParseErrorBody ? "parsedOutput" : "errorOutput";
             writer.openBlock(
-                    "const $L: any = {", "};", shouldParseErrorBody ? "parsedOutput" : "errorOutput",
+                    "const $L: any = {", "};", outputReference,
                     () -> {
                         writer.write("...output,");
                         writer.write("body: $L,",
@@ -208,7 +209,7 @@ final class HttpProtocolGeneratorUtils {
                     writer.openBlock("case $S:\ncase $S:", "  break;", errorId.getName(), errorId.toString(), () -> {
                         // Dispatch to the error deserialization function.
                         writer.write("response = await $L($L, context);",
-                                errorDeserMethodName, shouldParseErrorBody ? "parsedOutput" : "errorOutput");
+                                errorDeserMethodName, outputReference);
                     });
                 });
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -108,6 +108,30 @@ final class HttpProtocolGeneratorUtils {
         writer.write("");
     }
 
+    static void generateCollectBody(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const collectBody = (streamBody: any, context: __SerdeContext): Promise<Uint8Array> => {",
+                "};", () -> {
+            writer.write("return context.streamCollector(streamBody) || new Uint8Array();");
+        });
+
+        writer.write("");
+    }
+
+    static void generateCollectBodyString(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => {",
+                "};", () -> {
+            writer.write("return collectBody(streamBody, context).then(body => context.utf8Encoder(body));");
+        });
+
+        writer.write("");
+    }
+
     /**
      * Writes a function used to dispatch to the proper error deserializer
      * for each error that the operation can return. The generated function

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -181,8 +181,7 @@ final class HttpProtocolGeneratorUtils {
             // Prepare error response for parsing error code. If error code needs to be parsed from response body
             // then we collect body and parse it to JS object, otherwise leave the response body as is.
             if (shouldParseErrorBody) {
-                writer.openBlock(
-                        "const parsedOutput: any = {", "};",
+                writer.openBlock("const parsedOutput: any = {", "};",
                         () -> {
                             writer.write("...output,");
                             writer.write("body: await parseBody(output.body, context)");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -254,7 +254,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
-                context, operation, responseType, this::writeErrorCodeParser);
+                context, operation, responseType, this::writeErrorCodeParser, this.isErrorCodeInBody());
         deserializingErrorShapes.addAll(errorShapes);
     }
 
@@ -311,10 +311,13 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * Writes the code that loads an {@code errorCode} String with the content used
      * to dispatch errors to specific serializers.
      *
-     * <p>Three variables will be in scope:
+     * <p>Two variables will be in scope:
      *   <ul>
-     *       <li>{@code output}: a value of the HttpResponse type.</li>
-     *       <li>{@code data}: the contents of the response body.</li>
+     *       <li>{@code errorOutput} or {@code parsedOutput}: a value of the HttpResponse type.
+     *          {@code errorOutput} is a raw HttpResponse whereas {@code parsedOutput} is a HttpResponse type with
+     *          body parsed to JavaScript object.
+     *          The actual value available is determined by {@link #isErrorCodeInBody}
+     *       </li>
      *       <li>{@code context}: the SerdeContext.</li>
      *   </ul>
      *
@@ -327,6 +330,17 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * @param context The generation context.
      */
     protected abstract void writeErrorCodeParser(GenerationContext context);
+
+    /**
+     * Indicates whether body is collected and parsed in error dispatcher.
+     *
+     * <p>If returns true, {@link #writeErrorCodeParser} will have {@code parsedOutput} in scope
+     *
+     * <P>If returns false, {@link #writeErrorCodeParser} will have {@code errorOutput} in scope
+     *
+     * @return returns whether the error code exists in response body
+     */
+    protected abstract boolean isErrorCodeInBody();
 
     /**
      * Writes the code needed to deserialize the output document of a response.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -291,7 +291,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                 writer.write("const body = $L.body", outputReference);
             } else {
                 // If error node not in body, error body is not parsed in dispatcher.
-                writer.write("const body = parsedBody($L.body, context);", outputReference);
+                writer.write("const body = parseBody($L.body, context);", outputReference);
             }
             writer.write("const deserialized: any = $L(body, context);",
                     ProtocolGenerator.getDeserFunctionName(errorSymbol, context.getProtocolName()));
@@ -333,9 +333,9 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      *
      * <p>Two variables will be in scope:
      *   <ul>
-     *       <li>{@code errorOutput} or {@code parsedOutput}: a value of the HttpResponse type.
+     *       <li>{@code output} or {@code parsedOutput}: a value of the HttpResponse type.
      *          <ul>
-     *              <li>{@code errorOutput} is a raw HttpResponse, available when {@code isErrorCodeInBody} is set to
+     *              <li>{@code output} is a raw HttpResponse, available when {@code isErrorCodeInBody} is set to
      *              {@code false}</li>
      *              <li>{@code parsedOutput} is a HttpResponse type with body parsed to JavaScript object, available
      *              when {@code isErrorCodeInBody} is set to {@code true}</li>

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -43,8 +43,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * Creates a Http RPC protocol generator.
      *
      * @param isErrorCodeInBody A boolean that indicates if the error code for the implementing protocol is located in
-     *                          the error response body, meaning this generator will parse the body before attempting
-     *                          to load an error code.
+     *   the error response body, meaning this generator will parse the body before attempting to load an error code.
      */
     public HttpRpcProtocolGenerator(boolean isErrorCodeInBody) {
         this.isErrorCodeInBody = isErrorCodeInBody;
@@ -288,6 +287,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                        + "): Promise<$T> => {", "};", errorDeserMethodName, outputReference, errorSymbol, () -> {
             // First deserialize the body properly.
             if (isErrorCodeInBody) {
+                // Body is already parsed in error dispatcher, simply assign body to data.
                 writer.write("const body = $L.body", outputReference);
             } else {
                 // If error node not in body, error body is not parsed in dispatcher.


### PR DESCRIPTION
reopen #63 

Two fixes:
1. Currently when response body is a payload member, the SDK either
keeps reponse intact if it has a `streaming` trait, or parse the body
to JS object.<br/>
Actually when response payload is not streaming, it is
**NOT** always parsable(not a valid JSON or XML string). Specificly,
when payload is String, we shouldn't
parse it with XML or JSON parser; We should also treat `Blob` shape
differently as we should encode the binaries into string; Only when
shape is `Union` or `Structure` can we assume payload is parsable
by JSON or XML parser.

2.  For some protocols, error type flag exists in error response body,
then we need to collect response stream to JS object and parse the
error type; For other protocols, error type flag doesn't exist in
error response body, then we don't need to collect the response
stream in error dispatcher. Instead, we can treat the error like
normal response. So that error shape supports the same traits as
normal responses like streaming, payload etc.<br/>
This is done by adding a new class member in Protocol generator--
`isErrorCodeInBody`. When it is true, it means error type flag
exists in error response body, then body is parsed in errors
dispatcher, and each error deser only need to deal with parsed
response body in JS object format;

Example:
```TypeScript
//Exception dispatcher
async function exceptionDispatcher(
  output: __HttpResponse,
  context: __SerdeContext,
): Promise<CommandOutput> {
    const parsedOutput: any = { // parse output in dispatcher
    ...output,
    body: await parseBody(output.body, context),
  };
  let response: __SmithyException & __MetadataBearer;
  let errorCode: String;
  const errorTypeParts: String = parsedOutput.body["__type"].split('#');
  errorCode = (errorTypeParts[1] === undefined) ? errorTypeParts[0] : errorTypeParts[1];
  switch (errorCode) {
     case "com.amazon.aws.sdk.foo#FooException":
        response = await deserializeFooExceptionResponse(parsedOutput, context);
        break;
  //other cases
  }
}

const deserializeFooExceptionResponse = async (
  output: any,
  context: __SerdeContext
): Promise<FooException> => {
  //Don't parse response again in error deser
  const deserialized: any = deserializeFooException(output.body, context);
  const contents: FooException = {
    __type: "FooException",
    $fault: "client",
    $metadata: deserializeMetadata(output),
    ...deserialized,
  };
  return contents;
};
```

When it is false, it means
error type can be inferred without touching response body, then
error deser can access the error response intact.

```TypeScript
async function exceptionDispatcher (
  output: __HttpResponse,
  context: __SerdeContext,
): Promise<CommandOutput> {
  const errorOutput: any = { // No need to parse response here
    ...output,
    body: output.body,
  };
  let response: __SmithyException & __MetadataBearer;
  let errorCode: String;
  errorCode = output.headers["x-amzn-errortype"].split(':')[0];
  switch (errorCode) {
     case "FooException":
      response = await deserializeFooExceptionResponse(errorOutput, context);
      break;
    //other cases
  }
}

const deserializeFooExceptionResponse = async (
  output: any,
  context: __SerdeContext
): Promise<FooException> => {
  const contents: FooException = {
    __type: "FooException",
    $fault: "client",
    $metadata: deserializeMetadata(output),
    Code: undefined,
    Message: undefined,
  };
  const data: any = await parseBody(output.body, context); //parse response here.
  //parse the error members
  return contents;
};

```

/cc @kstich 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
