### PR TITLE
fix memberShape using reserved words

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -299,7 +299,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     public Symbol memberShape(MemberShape shape) {
         Shape targetShape = model.getShape(shape.getTarget())
                 .orElseThrow(() -> new CodegenException("Shape not found: " + shape.getTarget()));
-        Symbol targetSymbol = targetShape.accept(this);
+        Symbol targetSymbol = toSymbol(targetShape);
 
         if (targetSymbol.getProperties().containsKey(EnumTrait.class.getName())) {
             return createMemberSymbolWithEnumTarget(targetSymbol);


### PR DESCRIPTION
Use toSymbol to escape reserved words on memberShape.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
