### PR TITLE
chore: add publishToMavenLocal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ to Maven local:
 
 - `git clone https://github.com/awslabs/smithy.git`
 - `cd smithy`
-- `./gradlew publishToMavenLocal`
+- `./gradlew clean build publishToMavenLocal`
 - `cd ..`
 - `git clone https://github.com/awslabs/smithy-typescript.git`
 - `cd smithy-typescript`
 - `./gradlew build`
+
+If you're consuming smithy-typescript locally in other project, run the following command instead:
+- `./gradlew clean build publishToMavenLocal`
 
 You can find the build artifacts of the test package at:
 `build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ to Maven local:
 
 - `git clone https://github.com/awslabs/smithy.git`
 - `cd smithy`
-- `./gradlew clean build publishToMavenLocal`
+- `./gradlew publishToMavenLocal`
 - `cd ..`
 - `git clone https://github.com/awslabs/smithy-typescript.git`
 - `cd smithy-typescript`

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ to Maven local:
 - `cd smithy-typescript`
 - `./gradlew build`
 
-If you're consuming smithy-typescript locally in other project, run the following command instead:
-- `./gradlew clean build publishToMavenLocal`
+If you're consuming `smithy` or `smithy-typescript` and have already published
+locally, run the following command to publish the newest contents in your local
+repository:
+ - `./gradlew clean publishToMavenLocal`
 
 You can find the build artifacts of the test package at:
 `build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen`


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/613

*Description of changes:*
add publishToMavenLocal command if using smithy-typescript in different package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
