### PR TITLE
escape multi-line comment close tag

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -189,7 +189,8 @@ public final class TypeScriptWriter extends CodeWriter {
      */
     public TypeScriptWriter writeDocs(String docs) {
         // Docs can have valid $ characters that shouldn't run through formatters.
-        writeDocs(() -> write(docs.replace("$", "$$")));
+        // Escapes multi-line comment closings.
+        writeDocs(() -> write(docs.replace("$", "$$").replace("*/", "*\\/")));
         return this;
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -37,6 +37,17 @@ public class TypeScriptWriterTest {
     }
 
     @Test
+    public void escapesMultiLineCloseInDocStrings() {
+        String docs = "This is */ valid documentation.";
+
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
+        writer.writeDocs(docs);
+        String result = writer.toString();
+
+        assertThat(result, equalTo("/**\n * This is *\\/ valid documentation.\n */\n"));
+    }
+
+    @Test
     public void addsFormatterForSymbols() {
         // TODO
     }


### PR DESCRIPTION
Fixes doc strings containing ```*/``` causing mult-line comments to be closed prematurely.

Fixes https://github.com/awslabs/smithy-typescript/issues/74

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
