### PR TITLE
ensure consistent ordering

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -255,11 +255,11 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         // Generate each operation for the service.
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        containedOperations.forEach(operation -> {
+        for (OperationShape operation : containedOperations) {
             writers.useShapeWriter(operation, commandWriter -> new CommandGenerator(
                     settings, model, operation, symbolProvider, commandWriter,
                     runtimePlugins, protocolGenerator, applicationProtocol).run());
-        });
+        }
 
         if (protocolGenerator != null) {
             LOGGER.info("Generating serde for protocol " + protocolGenerator.getName() + " on " + shape.getId());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -254,11 +254,12 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         // Generate each operation for the service.
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+        Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+        containedOperations.forEach(operation -> {
             writers.useShapeWriter(operation, commandWriter -> new CommandGenerator(
                     settings, model, operation, symbolProvider, commandWriter,
                     runtimePlugins, protocolGenerator, applicationProtocol).run());
-        }
+        });
 
         if (protocolGenerator != null) {
             LOGGER.info("Generating serde for protocol " + protocolGenerator.getName() + " on " + shape.getId());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -52,9 +52,9 @@ final class IndexGenerator {
         // write export statements for each command in /commands directory
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        containedOperations.forEach(operation -> {
+        for (OperationShape operation : containedOperations) {
             writer.write("export * from \"./commands/" + symbolProvider.toSymbol(operation).getName() + "\";");
-        });
+        }
         fileManifest.writeFile("index.ts", writer.toString());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -49,9 +51,10 @@ final class IndexGenerator {
 
         // write export statements for each command in /commands directory
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
-        for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+        Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+        containedOperations.forEach(operation -> {
             writer.write("export * from \"./commands/" + symbolProvider.toSymbol(operation).getName() + "\";");
-        }
+        });
         fileManifest.writeFile("index.ts", writer.toString());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
@@ -70,7 +70,7 @@ final class NonModularServiceGenerator implements Runnable {
         writer.writeShapeDocs(service);
         writer.openBlock("export class $L extends $T {", "}", nonModularName, serviceSymbol, () -> {
             Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-            containedOperations.forEach(operation -> {
+            for (OperationShape operation : containedOperations) {
                 Symbol operationSymbol = symbolProvider.toSymbol(operation);
                 Symbol input = operationSymbol.expectProperty("inputType", Symbol.class);
                 Symbol output = operationSymbol.expectProperty("outputType", Symbol.class);
@@ -117,7 +117,7 @@ final class NonModularServiceGenerator implements Runnable {
                                  + "}", operationSymbol);
                 });
                 writer.write("");
-            });
+            }
         });
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -67,7 +69,8 @@ final class NonModularServiceGenerator implements Runnable {
         // Generate the client and extend from the modular client.
         writer.writeShapeDocs(service);
         writer.openBlock("export class $L extends $T {", "}", nonModularName, serviceSymbol, () -> {
-            for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+            Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+            containedOperations.forEach(operation -> {
                 Symbol operationSymbol = symbolProvider.toSymbol(operation);
                 Symbol input = operationSymbol.expectProperty("inputType", Symbol.class);
                 Symbol output = operationSymbol.expectProperty("outputType", Symbol.class);
@@ -114,7 +117,7 @@ final class NonModularServiceGenerator implements Runnable {
                                  + "}", operationSymbol);
                 });
                 writer.write("");
-            }
+            });
         });
     }
 }


### PR DESCRIPTION
Use TreeSet to wrap getContainedOperations results, ensuring consistent order.

Fixes https://github.com/awslabs/smithy-typescript/issues/75

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
