### PR TITLE
Add support for extra params on serde functions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
+import java.util.Set;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
@@ -45,6 +46,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Visitor to generate member values for aggregate types deserialized from documents.
@@ -59,16 +61,17 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *   <li>Timestamp: converted to JS Date.</li>
  *   <li>Service, Operation, Resource, Member: not deserializable from documents. <b>Not overridable.</b></li>
  *   <li>Document, List, Map, Set, Structure, Union: delegated to a deserialization function.
- *     <b>Not overridable.</b></li>
+ *     <b>Not overridable.</b> These delegations respect the {@code additionalParams} property.</li>
  *   <li>All other types: unmodified.</li>
  * </ul>
  *
  * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
  */
 public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
-    private final Format defaultTimestampFormat;
     private final GenerationContext context;
     private final String dataSource;
+    private final Format defaultTimestampFormat;
+    private final Set<String> additionalParams;
 
     /**
      * Constructor.
@@ -84,9 +87,39 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
             String dataSource,
             Format defaultTimestampFormat
     ) {
+        this(context, dataSource, defaultTimestampFormat, SetUtils.of());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param context The generation context.
+     * @param dataSource The in-code location of the data to provide an output of
+     *                   ({@code output.foo}, {@code entry}, etc.)
+     * @param defaultTimestampFormat The default timestamp format used in absence
+     *                               of a TimestampFormat trait.
+     * @param additionalParams A set of variable names to be passed as additional
+     *                         parameters to any delegate deserializers.
+     */
+    public DocumentMemberDeserVisitor(
+            GenerationContext context,
+            String dataSource,
+            Format defaultTimestampFormat,
+            Set<String> additionalParams
+    ) {
         this.context = context;
         this.dataSource = dataSource;
         this.defaultTimestampFormat = defaultTimestampFormat;
+        this.additionalParams = additionalParams;
+    }
+
+    /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
     }
 
     /**
@@ -95,8 +128,27 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
      *
      * @return The data source.
      */
-    protected String getDataSource() {
+    protected final String getDataSource() {
         return dataSource;
+    }
+
+    /**
+     * Gets the default timestamp format used in absence of a TimestampFormat trait.
+     *
+     * @return The default timestamp format.
+     */
+    protected final Format getDefaultTimestampFormat() {
+        return defaultTimestampFormat;
+    }
+
+    /**
+     * Gets a set of variable names to be passed as additional parameters
+     * to any delegate deserializers.
+     *
+     * @return The additional parameters.
+     */
+    protected final Set<String> getAdditionalParams() {
+        return additionalParams;
     }
 
     @Override
@@ -224,7 +276,18 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     private String getDelegateDeserializer(Shape shape) {
         // Use the shape for the function name.
         Symbol symbol = context.getSymbolProvider().toSymbol(shape);
-        return ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
-                + "(" + dataSource + ", context)";
+        StringBuilder delegateInvoke = new StringBuilder(
+                ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()));
+        delegateInvoke.append("(")
+                .append(dataSource)
+                .append(", context");
+
+        // Write any additional parameters to the invocation.
+        for (String additionalParam : additionalParams) {
+            delegateInvoke.append(", ")
+                    .append(additionalParam);
+        }
+        delegateInvoke.append(")");
+        return delegateInvoke.toString();
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -34,6 +35,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Visitor to generate serialization functions for shapes in protocol document bodies.
@@ -58,15 +60,33 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * <ul>
  *   <li>Service, Operation, Resource: no function generated. <b>Not overridable.</b></li>
  *   <li>Document, List, Map, Set, Structure, Union: generates a serialization function.
- *     <b>Not overridable.</b></li>
+ *     <b>Not overridable.</b> These function signatures respect the {@code additionalParams} property.</li>
  *   <li>All other types: no function generated. <b>May be overridden.</b></li>
  * </ul>
  */
 public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void> {
     private final GenerationContext context;
+    private final Map<String, String> additionalParams;
 
+    /**
+     * Constructor.
+     *
+     * @param context The generation context.
+     */
     public DocumentShapeSerVisitor(GenerationContext context) {
+        this(context, MapUtils.of());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param context The generation context.
+     * @param additionalParams The parameter name to type map of additional parameters
+     *                         for any delegate serializer function signatures.
+     */
+    public DocumentShapeSerVisitor(GenerationContext context, Map<String, String> additionalParams) {
         this.context = context;
+        this.additionalParams = additionalParams;
     }
 
     /**
@@ -76,6 +96,16 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      */
     protected final GenerationContext getContext() {
         return context;
+    }
+
+    /**
+     * Gets the parameter name to type map of additional parameters for
+     * any delegate serializer function signatures.
+     *
+     * @return The additional parameters.
+     */
+    protected final Map<String, String> getAdditionalParams() {
+        return additionalParams;
     }
 
     @Override
@@ -103,6 +133,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *   <li>{@code input: Array&lt;Parameter&gt;}: the type generated for the CollectionShape shape parameter.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
+     *
+     * <p>Any entries in the {@code additionalParams} of this visitor will be available in scope as well.
      *
      * <p>The function signature specifies an {@code any} return type; the function body
      * should return a value serializable by {@code serializeInputDocument}.
@@ -141,6 +173,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
      *
+     * <p>Any entries in the {@code additionalParams} of this visitor will be available in scope as well.
+     *
      * <p>The function signature specifies an {@code any} return type; the function body
      * should return a value serializable by {@code serializeInputDocument}.
      *
@@ -176,6 +210,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *   <li>{@code input: { [key: string]: Field }}: the type generated for the MapShape shape parameter.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
+     *
+     * <p>Any entries in the {@code additionalParams} of this visitor will be available in scope as well.
      *
      * <p>The function signature specifies an {@code any} return type; the function body
      * should return a value serializable by {@code serializeInputDocument}.
@@ -216,6 +252,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *   <li>{@code input: Field}: the type generated for the StructureShape shape parameter.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
+     *
+     * <p>Any entries in the {@code additionalParams} of this visitor will be available in scope as well.
      *
      * <p>The function signature specifies an {@code any} return type; the function body
      * should return a value serializable by {@code serializeInputDocument}.
@@ -260,6 +298,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
      *
+     * <p>Any entries in the {@code additionalParams} of this visitor will be available in scope as well.
+     *
      * <p>The function signature specifies an {@code any} return type; the function body
      * should return a value serializable by {@code serializeInputDocument}.
      *
@@ -280,7 +320,8 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
 
     /**
      * Generates a function for serializing the input shape, dispatching the body generation
-     * to the supplied function.
+     * to the supplied function. These function signatures respect the {@code additionalParams}
+     * property.
      *
      * @param shape The shape to generate a serializer for.
      * @param functionBody An implementation that will generate a function body to
@@ -296,12 +337,24 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
         Symbol symbol = symbolProvider.toSymbol(shape);
         // Use the shape name for the function name.
         String methodName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
+        StringBuilder functionSignature =  new StringBuilder(
+                "const $L = (\n"
+              + "  input: $T,\n"
+              + "  context: __SerdeContext,\n");
+
+        // Write any additional parameters to the function signature.
+        for (Map.Entry<String, String> additionalParam : additionalParams.entrySet()) {
+            functionSignature.append("  ")
+                    .append(additionalParam.getKey())
+                    .append(": ")
+                    .append(additionalParam.getValue())
+                    .append(",\n");
+        }
+        functionSignature.append("): any => {");
 
         writer.addImport(symbol, symbol.getName());
-        writer.openBlock("const $L = (\n"
-                       + "  input: $T,\n"
-                       + "  context: __SerdeContext\n"
-                       + "): any => {", "}", methodName, symbol, () -> functionBody.accept(context, shape));
+        writer.openBlock(functionSignature.toString(), "}", methodName, symbol,
+                () -> functionBody.accept(context, shape));
         writer.write("");
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,9 +33,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.ListUtils;
@@ -102,6 +102,20 @@ public class DocumentMemberDeserVisitorTest {
         Assertions.assertThrows(CodegenException.class, () -> {
             MemberShape.builder().target(id + "Target").id(id + "$member").build().accept(visitor);
         });
+    }
+
+    @Test
+    public void generatesAdditionalParameters() {
+        String id = "com.smithy.example#Foo";
+        Set<String> additionalParams = new LinkedHashSet<>();
+        additionalParams.add("foo");
+        additionalParams.add("bar");
+        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT,
+                additionalParams);
+
+        String expected = "deserialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+                + "(" + DATA_SOURCE + ", context, foo, bar)";
+        assertThat(expected, equalTo(StructureShape.builder().id(id).build().accept(visitor)));
     }
 
     private static final class MockProvider implements SymbolProvider {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,7 +35,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
@@ -105,6 +106,20 @@ public class DocumentMemberSerVisitorTest {
         Assertions.assertThrows(CodegenException.class, () -> {
             MemberShape.builder().target(id + "Target").id(id + "$member").build().accept(visitor);
         });
+    }
+
+    @Test
+    public void generatesAdditionalParameters() {
+        String id = "com.smithy.example#Foo";
+        Set<String> additionalParams = new LinkedHashSet<>();
+        additionalParams.add("foo");
+        additionalParams.add("bar");
+        DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT,
+                additionalParams);
+
+        String expected = "serialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+                + "(" + DATA_SOURCE + ", context, foo, bar)";
+        assertThat(expected, equalTo(StructureShape.builder().id(id).build().accept(visitor)));
     }
 
     private static final class MockProvider implements SymbolProvider {


### PR DESCRIPTION
This commit adds support for supplying and consuming additional parameters
for delegate serialization and deserialization functions. This will be
necessary for protocol implementations that need extra, protocol
specific context when performing serde.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
