### PR TITLE
Add accessors on document member visitors

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -66,9 +66,9 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
  */
 public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
-    private final Format defaultTimestampFormat;
     private final GenerationContext context;
     private final String dataSource;
+    private final Format defaultTimestampFormat;
 
     /**
      * Constructor.
@@ -90,13 +90,31 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     }
 
     /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    /**
      * Gets the in-code location of the data to provide an output of
      * ({@code output.foo}, {@code entry}, etc.).
      *
      * @return The data source.
      */
-    protected String getDataSource() {
+    protected final String getDataSource() {
         return dataSource;
+    }
+
+    /**
+     * Gets the default timestamp format used in absence of a TimestampFormat trait.
+     *
+     * @return The default timestamp format.
+     */
+    protected final Format getDefaultTimestampFormat() {
+        return defaultTimestampFormat;
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -65,9 +65,9 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
  */
 public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
-    private final Format defaultTimestampFormat;
     private final GenerationContext context;
     private final String dataSource;
+    private final Format defaultTimestampFormat;
 
     /**
      * Constructor.
@@ -89,13 +89,31 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     }
 
     /**
+     * Gets the generation context.
+     *
+     * @return The generation context.
+     */
+    protected final GenerationContext getContext() {
+        return context;
+    }
+
+    /**
      * Gets the in-code location of the data to provide an input of
      * ({@code input.foo}, {@code entry}, etc.).
      *
      * @return The data source.
      */
-    protected String getDataSource() {
+    protected final String getDataSource() {
         return dataSource;
+    }
+
+    /**
+     * Gets the default timestamp format used in absence of a TimestampFormat trait.
+     *
+     * @return The default timestamp format.
+     */
+    protected final Format getDefaultTimestampFormat() {
+        return defaultTimestampFormat;
     }
 
     @Override


### PR DESCRIPTION
These accessors are necessary to allow extending implementations to
not need to store their own copies of this information in order to
perform their own work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
