### PR TITLE
make best effort to infer unmodeled error message and name

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -221,8 +221,9 @@ final class HttpProtocolGeneratorUtils {
                             // Body is not parsed above, so parse it here
                             writer.write("const parsedBody = await parseBody(output.body, context);");
                         }
-                        writer.write("errorCode = errorCode || \"UnknownError\";")
-                        .openBlock("response = {", "} as any;", () -> {
+
+                        writer.write("errorCode = errorCode || \"UnknownError\";");
+                        writer.openBlock("response = {", "} as any;", () -> {
                             writer.write("...parsedBody,");
                             writer.write("name: `$${errorCode}`,");
                             writer.write("message: parsedBody.message || parsedBody.Message || errorCode,");
@@ -231,7 +232,7 @@ final class HttpProtocolGeneratorUtils {
                             writer.write("$$metadata: deserializeMetadata(output)");
                         }).dedent();
             });
-            writer.write("return Promise.reject(Object.assign(new Error(response.message), response));");
+            writer.write("return Promise.reject(Object.assign(new Error(), response));");
         });
         writer.write("");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -214,10 +214,12 @@ final class HttpProtocolGeneratorUtils {
 
                 // Build a generic error the best we can for ones we don't know about.
                 writer.write("default:").indent()
-                        .openBlock("response = {", "};", () -> {
+                        .write("errorCode = errorCode || \"UnknownError\";")
+                        .openBlock("response = {", "} as any;", () -> {
                             writer.write("__type: `$L#$${errorCode}`,", operation.getId().getNamespace());
                             writer.write("$$fault: \"client\",");
                             writer.write("$$metadata: deserializeMetadata(output),");
+                            writer.write("message: await collectBodyString(output.body, context)");
                         }).dedent();
             });
             writer.write("return Promise.reject(Object.assign(new Error(response.__type), response));");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -213,16 +213,25 @@ final class HttpProtocolGeneratorUtils {
                 });
 
                 // Build a generic error the best we can for ones we don't know about.
-                writer.write("default:").indent()
-                        .write("errorCode = errorCode || \"UnknownError\";")
+                writer.write("default:").indent();
+                        if (shouldParseErrorBody) {
+                            // Body is already parsed above
+                            writer.write("const parsedBody = parsedOutput.body;");
+                        } else {
+                            // Body is not parsed above, so parse it here
+                            writer.write("const parsedBody = await parseBody(output.body, context);");
+                        }
+                        writer.write("errorCode = errorCode || \"UnknownError\";")
                         .openBlock("response = {", "} as any;", () -> {
+                            writer.write("...parsedBody,");
+                            writer.write("name: `$${errorCode}`,");
+                            writer.write("message: parsedBody.message || parsedBody.Message || errorCode,");
                             writer.write("__type: `$L#$${errorCode}`,", operation.getId().getNamespace());
                             writer.write("$$fault: \"client\",");
-                            writer.write("$$metadata: deserializeMetadata(output),");
-                            writer.write("message: await collectBodyString(output.body, context)");
+                            writer.write("$$metadata: deserializeMetadata(output)");
                         }).dedent();
             });
-            writer.write("return Promise.reject(Object.assign(new Error(response.__type), response));");
+            writer.write("return Promise.reject(Object.assign(new Error(response.message), response));");
         });
         writer.write("");
 


### PR DESCRIPTION
This change makes SDK parses more information when unmodeled exception comes in:
1. Always parse unknow error response body to structured data and mixin to JS Error
2. Always set `name` and `message` onto the JS Error

Parsing error response body is required because body stream will never be consumed 
otherwise. The stream will be around in memory for a whilre before they are flushed 
eventually, which would use a lot of resources.

fix: #86 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
