### PR TITLE
add error name to error deser

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -625,6 +625,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "): Promise<$T> => {", "};",
                 errorDeserMethodName, isErrorCodeInBody ? "parsedOutput" : "output", errorSymbol, () -> {
             writer.openBlock("const contents: $T = {", "};", errorSymbol, () -> {
+                writer.write("name: $S,", error.getId().getName());
                 writer.write("__type: $S,", error.getId().getName());
                 writer.write("$$fault: $S,", error.getTrait(ErrorTrait.class).get().getValue());
                 writer.write("$$metadata: deserializeMetadata(output),");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -298,6 +298,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
             // Then load it into the object with additional error and response properties.
             writer.openBlock("const contents: $T = {", "};", errorSymbol, () -> {
+                writer.write("name: $S,", error.getId().getName());
                 writer.write("__type: $S,", error.getId().getName());
                 writer.write("$$fault: $S,", error.getTrait(ErrorTrait.class).get().getValue());
                 writer.write("$$metadata: deserializeMetadata($L),", outputReference);


### PR DESCRIPTION
Now SDK throws error like:
```
{Error: 1 validation error detected: Value null at 'certificateArn' failed to satisfy constraint: Member must not be null 
...
```

After the change, the thrown error looks like:

```
{ValidationException: 1 validation error detected: Value null at 'certificateArn' failed to satisfy constraint: Member must not be null 
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
