### PR TITLE
chore: update @aws-crypto/sha256-browser

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -40,7 +40,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", "^1.0.0-alpha.1", true),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", "^1.0.0-alpha.1", true),
 
-    AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^0.1.0-preview.1", true),
+    AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^0.1.0-preview.4", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^1.0.0-alpha.1", true),
 
     AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^1.0.0-alpha.1", true),


### PR DESCRIPTION
*Issue #, if available:*
Refs https://github.com/aws/aws-sdk-js-v3/pull/740

*Description of changes:*
update @aws-crypto/sha256-browser in codegen dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
