### PR TITLE
Remove duplicate shapes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -146,7 +146,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         Set<Shape> serviceShapes = new TreeSet<>(new Walker(nonTraits).walkShapes(service));
         Map<String, Shape> shapeMap = new TreeMap<>();
 
-        // Check for colliding shapes generating models and prune non-unique shapes
+        // Check for colliding shapes and prune non-unique shapes
         for (Shape shape : serviceShapes) {
             String shapeReference = shape.getType().toString() + shape.getId().asRelativeReference();
 
@@ -309,11 +309,6 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private boolean shapesMatch(Shape shape, Shape otherShape) {
         // Check names match.
         if (!shape.getId().getName().equals(otherShape.getId().getName())) {
-            return false;
-        }
-
-        // Check types match.
-        if (!shape.getType().equals(otherShape.getType())) {
             return false;
         }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -145,7 +145,6 @@ public class CodegenVisitorTest {
                         "}"));
     }
 
-
     @Test
     public void invokesOnWriterCustomizations() {
         // TODO

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 
 public class CodegenVisitorTest {
     @Test
@@ -97,6 +99,52 @@ public class CodegenVisitorTest {
         Assertions.assertTrue(manifest.hasFile("ExampleClient.ts"));
         assertThat(manifest.getFileString("ExampleClient.ts").get(), containsString("export class ExampleClient"));
     }
+
+    @Test void throwsOnShapesThatCannotBeCondensed() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service-with-shape-conflict.smithy"))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .model(model)
+                .fileManifest(manifest)
+                .pluginClassLoader(getClass().getClassLoader())
+                .settings(Node.objectNodeBuilder()
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+
+        Assertions.assertThrows(CodegenException.class, () -> new TypeScriptCodegenPlugin().execute(context));
+    }
+
+    @Test void successfullyCondensesShapesThatMatch() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service-with-condensible-shapes.smithy"))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .model(model)
+                .fileManifest(manifest)
+                .pluginClassLoader(getClass().getClassLoader())
+                .settings(Node.objectNodeBuilder()
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+
+        new TypeScriptCodegenPlugin().execute(context);
+
+        Assertions.assertTrue(manifest.hasFile("models/index.ts"));
+        assertThat(manifest.getFileString("models/index.ts").get(),
+                containsString("export interface Bar {\n" +
+                        "  __type?: \"Bar\";\n" +
+                        "  baz: string | undefined;\n" +
+                        "}"));
+    }
+
 
     @Test
     public void invokesOnWriterCustomizations() {

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes.smithy
@@ -1,0 +1,32 @@
+namespace smithy.example
+
+@protocols([{name: "aws.rest-json-1.1"}])
+service Example {
+    version: "1.0.0",
+    operations: [GetFoo]
+}
+
+operation GetFoo(GetFooInput)
+
+structure GetFooInput {
+    @required
+    foo: Bar,
+
+    @required
+    baz: another.example#Bar
+}
+
+namespace smithy.example
+
+structure Bar {
+    @required
+    baz: String
+}
+
+namespace another.example
+
+structure Bar {
+    @required
+    baz: String
+}
+

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict.smithy
@@ -1,0 +1,32 @@
+namespace smithy.example
+
+@protocols([{name: "aws.rest-json-1.1"}])
+service Example {
+    version: "1.0.0",
+    operations: [GetFoo]
+}
+
+operation GetFoo(GetFooInput)
+
+structure GetFooInput {
+    @required
+    foo: Bar,
+
+    @required
+    baz: another.example#Bar
+}
+
+namespace smithy.example
+
+structure Bar {
+    @required
+    baz: String
+}
+
+namespace another.example
+
+structure Bar {
+    @required
+    qux: String
+}
+


### PR DESCRIPTION
When generating TypeScript shapes, attempt to first condense any matching shapes to eliminate duplicate generated shapes. Throws a CodegenException if shapes exist that cannot be condensed.

Fixes: #80

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
