### PR TITLE
Bump smithy-codegen-core dep to 0.9.7

### DIFF
--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -33,7 +33,11 @@ string CityId
 
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}")
-operation GetCity(GetCityInput) -> GetCityOutput errors [NoSuchResource]
+operation GetCity {
+    input: GetCityInput,
+    output: GetCityOutput,
+    errors: [NoSuchResource]
+}
 
 /// The input used to get a city.
 structure GetCityInput {
@@ -81,7 +85,10 @@ structure NoSuchResource {
 @readonly
 @paginated(items: "items")
 @http(method: "GET", uri: "/cities")
-operation ListCities(ListCitiesInput) -> ListCitiesOutput
+operation ListCities {
+    input: ListCitiesInput,
+    output: ListCitiesOutput
+}
 
 structure ListCitiesInput {
     @httpQuery("nextToken")
@@ -118,7 +125,9 @@ structure CitySummary {
 
 @readonly
 @http(method: "GET", uri: "/current-time")
-operation GetCurrentTime() -> GetCurrentTimeOutput
+operation GetCurrentTime {
+    output: GetCurrentTimeOutput
+}
 
 structure GetCurrentTimeOutput {
     @required
@@ -127,7 +136,10 @@ structure GetCurrentTimeOutput {
 
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}/forecast")
-operation GetForecast(GetForecastInput) -> GetForecastOutput
+operation GetForecast {
+    input: GetForecastInput,
+    output: GetForecastOutput
+}
 
 // "cityId" provides the only identifier for the resource since
 // a Forecast doesn't have its own.
@@ -167,7 +179,11 @@ map StringMap {
 
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}/image")
-operation GetCityImage(GetCityImageInput) -> GetCityImageOutput errors [NoSuchResource]
+operation GetCityImage {
+    input: GetCityImageInput,
+    output: GetCityImageOutput,
+    errors: [NoSuchResource]
+}
 
 structure GetCityImageInput {
     @required @httpLabel

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -18,5 +18,5 @@ extra["displayName"] = "Smithy :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.typescript.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:0.9.6")
+    api("software.amazon.smithy:smithy-codegen-core:0.9.7")
 }


### PR DESCRIPTION
Updates smithy-codegen-core dependency to 0.9.7 and uses new operation syntax to remove `Deprecated IDL syntax detected for operation definition` warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
