### PR TITLE
support eventstream traits

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -47,10 +47,13 @@ public final class CodegenUtils {
      * @return The TypeScript type for the serializer context
      */
     public static String getOperationSerializerContextType(
-            TypeScriptWriter writer, Model model, OperationShape operation) {
-        // add default SerdeContext
+            TypeScriptWriter writer,
+            Model model,
+            OperationShape operation
+    ) {
+        // Get default SerdeContext.
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
-        //check if event stream trait exists
+        // If event stream trait exists, add corresponding serde context type to the intersection type.
         EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
         if (eventStreamIndex.getInputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
@@ -67,10 +70,13 @@ public final class CodegenUtils {
      * @return The TypeScript type for the deserializer context
      */
     public static String getOperationDeserializerContextType(
-            TypeScriptWriter writer, Model model, OperationShape operation) {
-        // add default SerdeContext
+            TypeScriptWriter writer,
+            Model model,
+            OperationShape operation
+    ) {
+        // Get default SerdeContext.
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
-        //check if event stream trait exists
+        // If event stream trait exists, add corresponding serde context type to the intersection type.
         EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
         if (eventStreamIndex.getOutputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
@@ -81,7 +87,7 @@ public final class CodegenUtils {
 
     private static List<String> getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
         List<String> contextInterfaceList = new ArrayList<>();
-        // add default SerdeContext
+        // Get default SerdeContext.
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         contextInterfaceList.add("__SerdeContext");
         return contextInterfaceList;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -43,8 +43,7 @@ public final class CodegenUtils {
     public static String getOperationSerializerContextType(
             TypeScriptWriter writer, Model model, OperationShape operation) {
         // add default SerdeContext
-        List<String> contextInterfaceList = new ArrayList<>();
-        contextInterfaceList.add(getDefaultOperationSerdeContextTypes(writer));
+        List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
         if (EventStreamGenerator.operationHasEventStreamInput(model, operation)
         ) {
@@ -57,8 +56,7 @@ public final class CodegenUtils {
     public static String getOperationDeserializerContextType(
             TypeScriptWriter writer, Model model, OperationShape operation) {
         // add default SerdeContext
-        List<String> contextInterfaceList = new ArrayList<>();
-        contextInterfaceList.add(getDefaultOperationSerdeContextTypes(writer));
+        List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
         if (EventStreamGenerator.operationHasEventStreamOutput(model, operation)
         ) {
@@ -68,9 +66,11 @@ public final class CodegenUtils {
         return String.join(" & ", contextInterfaceList);
     }
 
-    private static String getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
+    private static List<String> getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
+        List<String> contextInterfaceList = new ArrayList<>();
         // add default SerdeContext
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
-        return "__SerdeContext";
+        contextInterfaceList.add("__SerdeContext");
+        return contextInterfaceList;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.typescript.codegen.integration.EventStreamGenerator;
+import software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency;
 
 /**
  * Utility methods needed across Java packages.
@@ -45,7 +45,7 @@ public final class CodegenUtils {
         // add default SerdeContext
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
-        if (EventStreamGenerator.operationHasEventStreamInput(model, operation)
+        if (AddEventStreamDependency.operationHasEventStreamInput(model, operation)
         ) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");
@@ -58,7 +58,7 @@ public final class CodegenUtils {
         // add default SerdeContext
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
-        if (EventStreamGenerator.operationHasEventStreamOutput(model, operation)
+        if (AddEventStreamDependency.operationHasEventStreamOutput(model, operation)
         ) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
-import software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency;
 
 /**
  * Utility methods needed across Java packages.
@@ -39,27 +39,40 @@ public final class CodegenUtils {
         return mediaType.equals("application/json") || mediaType.endsWith("+json");
     }
 
-
+    /**
+     * Get context type for command serializer functions.
+     * @param writer The code writer.
+     * @param model The model for the service containing the given command.
+     * @param operation The operation shape for given command.
+     * @return The TypeScript type for the serializer context
+     */
     public static String getOperationSerializerContextType(
             TypeScriptWriter writer, Model model, OperationShape operation) {
         // add default SerdeContext
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
-        if (AddEventStreamDependency.operationHasEventStreamInput(model, operation)
-        ) {
+        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        if (eventStreamIndex.getInputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");
         }
         return String.join(" & ", contextInterfaceList);
     }
 
+    /**
+     * Get context type for command deserializer function.
+     * @param writer The code writer.
+     * @param model The model for the service containing the given command.
+     * @param operation The operation shape for given command.
+     * @return The TypeScript type for the deserializer context
+     */
     public static String getOperationDeserializerContextType(
             TypeScriptWriter writer, Model model, OperationShape operation) {
         // add default SerdeContext
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         //check if event stream trait exists
-        if (AddEventStreamDependency.operationHasEventStreamOutput(model, operation)
-        ) {
+        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        if (eventStreamIndex.getOutputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -15,6 +15,13 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.typescript.codegen.integration.EventStreamGenerator;
+
 /**
  * Utility methods needed across Java packages.
  */
@@ -30,5 +37,40 @@ public final class CodegenUtils {
      */
     public static boolean isJsonMediaType(String mediaType) {
         return mediaType.equals("application/json") || mediaType.endsWith("+json");
+    }
+
+
+    public static String getOperationSerializerContextType(
+            TypeScriptWriter writer, Model model, OperationShape operation) {
+        // add default SerdeContext
+        List<String> contextInterfaceList = new ArrayList<>();
+        contextInterfaceList.add(getDefaultOperationSerdeContextTypes(writer));
+        //check if event stream trait exists
+        if (EventStreamGenerator.operationHasEventStreamInput(model, operation)
+        ) {
+            writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
+            contextInterfaceList.add("__EventStreamSerdeContext");
+        }
+        return String.join(" & ", contextInterfaceList);
+    }
+
+    public static String getOperationDeserializerContextType(
+            TypeScriptWriter writer, Model model, OperationShape operation) {
+        // add default SerdeContext
+        List<String> contextInterfaceList = new ArrayList<>();
+        contextInterfaceList.add(getDefaultOperationSerdeContextTypes(writer));
+        //check if event stream trait exists
+        if (EventStreamGenerator.operationHasEventStreamOutput(model, operation)
+        ) {
+            writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
+            contextInterfaceList.add("__EventStreamSerdeContext");
+        }
+        return String.join(" & ", contextInterfaceList);
+    }
+
+    private static String getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
+        // add default SerdeContext
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        return "__SerdeContext";
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -93,7 +93,6 @@ final class CommandGenerator implements Runnable {
         writer.addImport("Handler", "Handler", "@aws-sdk/types");
         writer.addImport("HandlerExecutionContext", "HandlerExecutionContext", "@aws-sdk/types");
         writer.addImport("MiddlewareStack", "MiddlewareStack", "@aws-sdk/types");
-        writer.addImport("SerdeContext", "SerdeContext", "@aws-sdk/types");
 
         addInputAndOutputTypes();
 
@@ -204,7 +203,7 @@ final class CommandGenerator implements Runnable {
                 .write("private serialize(")
                 .indent()
                     .write("input: $T,", inputType)
-                    .write("context: SerdeContext")
+                    .write("context: $L", CodegenUtils.getOperationSerializerContextType(writer, model, operation))
                 .dedent()
                 .openBlock(
                         "): Promise<$T> {", "}",
@@ -216,7 +215,7 @@ final class CommandGenerator implements Runnable {
                 .write("private deserialize(")
                 .indent()
                     .write("output: $T,", applicationProtocol.getResponseType())
-                    .write("context: SerdeContext")
+                    .write("context: $L", CodegenUtils.getOperationDeserializerContextType(writer, model, operation))
                 .dedent()
                 .openBlock("): Promise<$T> {", "}", outputType, () -> writeSerdeDispatcher(false))
                 .write("");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -57,8 +57,8 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
-import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.EventStreamTrait;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.StringUtils;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -58,6 +58,7 @@ import software.amazon.smithy.model.shapes.ToShapeId;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.EventStreamTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -321,6 +322,10 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             return createMemberSymbolWithEnumTarget(targetSymbol);
         }
 
+        if (shape.hasTrait(EventStreamTrait.class)) {
+            return createMemberSymbolWithEventStream(targetSymbol);
+        }
+
         return targetSymbol;
     }
 
@@ -328,6 +333,14 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         return targetSymbol.toBuilder()
                 .namespace(null, "/")
                 .name(targetSymbol.getName() + " | string")
+                .addReference(targetSymbol)
+                .build();
+    }
+
+    private Symbol createMemberSymbolWithEventStream(Symbol targetSymbol) {
+        return targetSymbol.toBuilder()
+                .namespace(null, "/")
+                .name(String.format("AsyncIterable<%s>", targetSymbol.getName()))
                 .addReference(targetSymbol)
                 .build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -69,7 +69,12 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^5.2.2", false),
-    TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false);
+    TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false),
+
+    // Conditionally added if a event stream shape is found anywhere in the model
+    AWS_SDK_UTIL_EVENT_STREAM_NODE("dependencies", "@aws-sdk/util-eventstream-node", "^0.1.0-preview.1", false),
+    // Conditionally added if a event stream shape found in model's input
+    MIDDLEWARE_EVENT_STREAM("dependencies", "@aws-sdk/middleware-event-stream", "^0.1.0-preview.1", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.typescript.codegen;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
@@ -72,9 +73,9 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false),
 
     // Conditionally added if a event stream shape is found anywhere in the model
-    AWS_SDK_UTIL_EVENT_STREAM_NODE("dependencies", "@aws-sdk/util-eventstream-node", "^0.1.0-preview.1", false),
-    // Conditionally added if a event stream shape found in model's input
-    MIDDLEWARE_EVENT_STREAM("dependencies", "@aws-sdk/middleware-event-stream", "^0.1.0-preview.1", false);
+    AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
+            "^1.0.0-alpha.0", false),
+    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-alpha.0", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -68,14 +68,15 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "^1.0.0-alpha.1", false),
     AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", "^1.0.0-alpha.1", false),
 
-    // Conditionally added if a big decimal shape is found in a model.
-    BIG_JS("dependencies", "big.js", "^5.2.2", false),
-    TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false),
-
     // Conditionally added if a event stream shape is found anywhere in the model
     AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
             "^1.0.0-alpha.0", false),
-    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-alpha.0", false);
+    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-alpha.0", false),
+    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "^1.0.0-alpha.0", false),
+
+    // Conditionally added if a big decimal shape is found in a model.
+    BIG_JS("dependencies", "big.js", "^5.2.2", false),
+    TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -56,6 +56,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
         if (!hasEventStream(model, settings.getService(model))) {
             return;
         }
+
         writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER);
         writer.addImport("EventStreamSerdeProvider", "__EventStreamSerdeProvider",
                 TypeScriptDependency.AWS_SDK_TYPES.packageName);
@@ -88,6 +89,14 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                         TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
                 writer.write("eventStreamSerdeProvider");
                 break;
+            case REACT_NATIVE:
+                // TODO: add ReactNative eventstream support
+                writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
+                writer.addImport("invalidFunction", "invalidFunction",
+                        TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                writer.write("eventStreamSerdeProvider: invalidFunction(\"event stream is not supported in "
+                                + "ReactNative\") as any,");
+                break;
             default:
                 // do nothing
         }
@@ -102,7 +111,8 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
         EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
         for (OperationShape operation : operations) {
             if (eventStreamIndex.getInputInfo(operation).isPresent()
-                    || eventStreamIndex.getOutputInfo(operation).isPresent()) {
+                    || eventStreamIndex.getOutputInfo(operation).isPresent()
+            ) {
                 return true;
             }
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -34,18 +34,15 @@ import software.amazon.smithy.utils.ListUtils;
 /**
  * Adds event streams if needed.
  */
-public class EventStreamGenerator implements TypeScriptIntegration {
+public class AddEventStreamDependency implements TypeScriptIntegration {
 
     @Override
     public List<RuntimeClientPlugin> getClientPlugins() {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
-                        .withConventions(
-                                TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER.dependency,
-                                "EventStreamSerde",
-                                RuntimeClientPlugin.Convention.HAS_CONFIG
-                        )
-                        .servicePredicate(EventStreamGenerator::hasEventStream)
+                        .withConventions(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER.dependency,
+                                "EventStreamSerde", RuntimeClientPlugin.Convention.HAS_CONFIG)
+                        .servicePredicate(AddEventStreamDependency::hasEventStream)
                         .build()
         );
     }
@@ -60,13 +57,11 @@ public class EventStreamGenerator implements TypeScriptIntegration {
         if (!hasEventStream(model, settings.getService(model))) {
             return;
         }
-        writer.addImport(
-                "EventStreamSerdeProvider",
-                "EventStreamSerdeProvider",
-                TypeScriptDependency.AWS_SDK_TYPES.packageName
-        );
+        writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER);
+        writer.addImport("EventStreamSerdeProvider", "__EventStreamSerdeProvider",
+                TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.writeDocs("The function that provides necessary utilities for generating and signing event stream");
-        writer.write("eventStreamSerdeProvider?: EventStreamSerdeProvider;");
+        writer.write("eventStreamSerdeProvider?: __EventStreamSerdeProvider;\n");
     }
 
     @Override
@@ -84,20 +79,14 @@ public class EventStreamGenerator implements TypeScriptIntegration {
         switch (target) {
             case NODE:
                 writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
-                writer.addImport(
-                        "eventStreamSerdeProvider",
-                        "eventStreamSerdeProvider",
-                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName
-                );
+                writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
                 writer.write("eventStreamSerdeProvider");
                 break;
             case BROWSER:
                 writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
-                writer.addImport(
-                        "eventStreamSerdeProvider",
-                        "eventStreamSerdeProvider",
-                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName
-                );
+                writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
                 writer.write("eventStreamSerdeProvider");
                 break;
             default:
@@ -105,7 +94,7 @@ public class EventStreamGenerator implements TypeScriptIntegration {
         }
     }
 
-    public static final boolean hasEventStream(
+    private static boolean hasEventStream(
             Model model,
             ServiceShape service
     ) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -42,7 +42,7 @@ public class EventStreamGenerator implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(
                                 TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER.dependency,
-                                "EventStream",
+                                "EventStreamSerde",
                                 RuntimeClientPlugin.Convention.HAS_CONFIG
                         )
                         .servicePredicate(EventStreamGenerator::hasEventStream)
@@ -92,14 +92,13 @@ public class EventStreamGenerator implements TypeScriptIntegration {
                 writer.write("eventStreamSerdeProvider");
                 break;
             case BROWSER:
+                writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                 writer.addImport(
-                        "invalidFunction",
-                        "invalidFunction",
-                        TypeScriptDependency.INVALID_DEPENDENCY.packageName
+                        "eventStreamSerdeProvider",
+                        "eventStreamSerdeProvider",
+                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName
                 );
-                writer.openBlock("eventStreamSerdeProvider: invalidFunction(", ")", () -> {
-                    writer.write("\"event stream serde for browser is not available\"");
-                });
+                writer.write("eventStreamSerdeProvider");
                 break;
             default:
                 // do nothing
@@ -155,6 +154,9 @@ public class EventStreamGenerator implements TypeScriptIntegration {
 
     /**
      * The value of event header 'type' property of given shape.
+     *
+     * @param shape shape bond to event header
+     * @return string literal for the event message header type
      */
     public static String getEventHeaderType(Shape shape) {
         switch (shape.getType()) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -111,7 +111,12 @@ public class EventStreamGenerator implements TypeScriptIntegration {
                                 RuntimeClientPlugin.Convention.HAS_CONFIG
                         )
                         .servicePredicate(EventStreamGenerator::hasEventStream)
-                        .build()
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .withConventions(
+                                TypeScriptDependency.MIDDLEWARE_EVENT_STREAM.dependency,
+                                "EventStream"
+                        ).operationPredicate((m, s, o) -> operationHasEventStreamInput(m, o)).build()
         );
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Adds event streams if needed.
+ */
+public class EventStreamGenerator implements TypeScriptIntegration {
+
+    static BiFunction<Model, OperationShape, Boolean> operationHasEventStreamOutput =
+            (model, operationShape) -> {
+                EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+                return eventStreamIndex.getOutputInfo(operationShape).isPresent();
+            };
+
+    static BiFunction<Model, OperationShape, Boolean> operationHasEventStreamInput =
+            (model, operationShape) -> {
+                EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+                return eventStreamIndex.getInputInfo(operationShape).isPresent();
+            };
+
+    static BiFunction<Model, OperationShape, Boolean> operationHasEventStream =
+            (model, operationShape) ->
+                    operationHasEventStreamInput.apply(model, operationShape)
+                            || operationHasEventStreamOutput.apply(model, operationShape);
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+                RuntimeClientPlugin.builder()
+                        .withConventions(TypeScriptDependency.MIDDLEWARE_EVENT_STREAM.dependency, "EventStream")
+                        .operationPredicate((m, s, o) -> hasEventStream(m, s, operationHasEventStreamInput))
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .withConventions(
+                                TypeScriptDependency.MIDDLEWARE_EVENT_STREAM.dependency,
+                                "EventStream",
+                                HAS_CONFIG
+                        )
+                        .servicePredicate((m, s) -> hasEventStream(m, s, operationHasEventStream))
+                        .build()
+        );
+    }
+
+    @Override
+    public void addConfigInterfaceFields(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer
+    ) {
+        if (!hasEventStream(model, settings.getService(model), operationHasEventStream)) {
+            return;
+        }
+        writer.addImport(
+                "EventStreamSerdeProvider",
+                "EventStreamSerdeProvider",
+                TypeScriptDependency.AWS_SDK_TYPES.packageName
+        );
+        writer.writeDocs("The function that provides necessary utilities for generating and signing event stream");
+        writer.write("eventStreamSerdeProvider?: EventStreamSerdeProvider;");
+    }
+
+    @Override
+    public void addRuntimeConfigValues(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer,
+            LanguageTarget target
+    ) {
+        if (!hasEventStream(model, settings.getService(model), operationHasEventStream)) {
+            return;
+        }
+
+        switch (target) {
+            case NODE:
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_EVENT_STREAM_NODE);
+                writer.addImport(
+                        "eventStreamSerdeProvider",
+                        "eventStreamSerdeProvider",
+                        TypeScriptDependency.AWS_SDK_UTIL_EVENT_STREAM_NODE.packageName
+                );
+                writer.write("eventStreamSerdeProvider");
+                break;
+            case BROWSER:
+                writer.addImport(
+                        "invalidFunction",
+                        "invalidFunction",
+                        TypeScriptDependency.INVALID_DEPENDENCY.packageName
+                );
+                writer.openBlock("eventStreamSerdeProvider: invalidFunction(", ")", () -> {
+                    writer.write("\"event stream serde for browser is not available\"");
+                });
+                break;
+            default:
+                // do nothing
+        }
+    }
+
+    private static boolean hasEventStream(
+            Model model,
+            ServiceShape service,
+            BiFunction<Model, OperationShape, Boolean> predicate
+    ) {
+        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
+        for (OperationShape operation : operations) {
+            if (predicate.apply(model, operation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.pattern.Pattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -356,97 +355,5 @@ final class HttpProtocolGeneratorUtils {
                 writer.write("throw new Error(\"ValidationError: prefixed hostname must be hostname compatible.\");");
             });
         });
-    }
-
-    /**
-     * Writes a function used to dispatch event to corresponding event deserializers.
-     * This function assumes a event-specific deserialization function is generated
-     * for each returned structures.
-     *
-     * @param context The generation context.
-     * @param events The union of of events bond to an event stream
-     * @return A list of all event structure shapes for the event stream that were dispatched to.
-     */
-    static Set<StructureShape> generateDeserializingEventUnion(
-            GenerationContext context,
-            UnionShape events
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-        SymbolProvider symbolProvider = context.getSymbolProvider();
-        Symbol symbol = symbolProvider.toSymbol(events);
-        String protocolName = context.getProtocolName();
-        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, protocolName) + "_event";
-        Model model = context.getModel();
-        Set<StructureShape> targets = new TreeSet<>();
-        writer.openBlock("const $L = async (\n"
-                + "  output: any,\n"
-                + "  context: __SerdeContext\n"
-                + "): Promise<$T> => {", "}", methodName, symbol, () -> {
-            events.getAllMembers().forEach((name, member) -> {
-                Shape target = model.expectShape(member.getTarget());
-                targets.add(target.asStructureShape().orElseThrow(
-                        () -> new CodegenException("Expect event to be structure shape, got " + target.getType())));
-                // In shape deser, Unions are indexed by local name. But event name in event stream has different
-                // meaning than actual unions index, which may have local name. Here assume event union is indexed by
-                // member name
-                writer.openBlock("if (output['$L'] !== undefined) {", "}", name, () -> {
-                    writer.openBlock("return {", "};", () -> {
-                        // Dispatch to special event deserialize function
-                        Symbol eventSymbol = symbolProvider.toSymbol(target);
-                        String eventDeserMethodName =
-                                ProtocolGenerator.getDeserFunctionName(eventSymbol, protocolName) + "_event";
-                        String statement = eventDeserMethodName + "(output['" + name + "'], context)";
-                        writer.write("$L: await $L", name, statement);
-                    });
-                });
-            });
-            writer.write("return {$$unknown: output}");
-        });
-        return targets;
-    }
-
-    /**
-     * Writes a function used to dispatch event to corresponding event serializer.
-     * This function assumes a event-specific serializer function is generated
-     * for each returned structures.
-     *
-     * @param context The generation context.
-     * @param events The union of of events bond to an event stream
-     * @return A list of all event structure shapes for the event stream that were dispatched to.
-     */
-    static Set<StructureShape> generateSerializingEventUnion(
-            GenerationContext context,
-            UnionShape events
-    ) {
-        TypeScriptWriter writer = context.getWriter();
-        SymbolProvider symbolProvider = context.getSymbolProvider();
-        Symbol symbol = symbolProvider.toSymbol(events);
-        String protocolName = context.getProtocolName();
-        String methodName = ProtocolGenerator.getSerFunctionName(symbol, protocolName) + "_event";
-        Model model = context.getModel();
-        Set<StructureShape> targets = new TreeSet<>();
-        writer.addImport("Message", "__Message", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.openBlock("const $L = (\n"
-                + "  input: any,\n"
-                + "  context: __SerdeContext\n"
-                + "): __Message => {", "}", methodName, () -> {
-            // Visit over the union type, then get the right serialization for the member.
-            writer.openBlock("return $T.visit(input, {", "});", symbol, () -> {
-                events.getAllMembers().forEach((memberName, memberShape) -> {
-                    Shape target = model.expectShape(memberShape.getTarget());
-                    targets.add(target.asStructureShape().orElseThrow(
-                            () -> new CodegenException("Expect event to be structure shape, got " + target.getType())));
-                    // Dispatch to special event deserialize function
-                    Symbol eventSymbol = symbolProvider.toSymbol(target);
-                    String eventSerMethodName =
-                            ProtocolGenerator.getSerFunctionName(eventSymbol, protocolName) + "_event";
-                    writer.write("$L: value => $L(value, context),", memberName, eventSerMethodName);
-                });
-
-                // Handle the unknown property.
-                writer.write("_: value => value as any");
-            });
-        });
-        return targets;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -34,9 +34,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
-import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.UnionShape;
-import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
@@ -193,11 +190,11 @@ final class HttpProtocolGeneratorUtils {
         writer.write("// Collect low-level response body stream to Uint8Array.");
         writer.openBlock("const collectBody = (streamBody: any, context: __SerdeContext): Promise<Uint8Array> => {",
                 "};", () -> {
-                    writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
-                        writer.write("return Promise.resolve(streamBody);");
-                    });
-                    writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
-                });
+            writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
+                writer.write("return Promise.resolve(streamBody);");
+            });
+            writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
+        });
 
         writer.write("");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -59,8 +59,8 @@ final class HttpProtocolGeneratorUtils {
      *
      * @param dataSource The in-code location of the data to provide an input of
      *                   ({@code input.foo}, {@code entry}, etc.)
-     * @param shape The shape that represents the value being provided.
-     * @param format The timestamp format to provide.
+     * @param shape      The shape that represents the value being provided.
+     * @param format     The timestamp format to provide.
      * @return Returns a value or expression of the input timestamp.
      */
     static String getTimestampInputParam(String dataSource, Shape shape, Format format) {
@@ -82,8 +82,8 @@ final class HttpProtocolGeneratorUtils {
      *
      * @param dataSource The in-code location of the data to provide an output of
      *                   ({@code output.foo}, {@code entry}, etc.)
-     * @param shape The shape that represents the value being received.
-     * @param format The timestamp format to provide.
+     * @param shape      The shape that represents the value being received.
+     * @param format     The timestamp format to provide.
      * @return Returns a value or expression of the output timestamp.
      */
     static String getTimestampOutputParam(String dataSource, Shape shape, Format format) {
@@ -165,7 +165,7 @@ final class HttpProtocolGeneratorUtils {
      * Writes a response metadata deserializer function for HTTP protocols. This
      * will load things like the status code, headers, and more.
      *
-     * @param context The generation context.
+     * @param context      The generation context.
      * @param responseType The response type for the HTTP protocol.
      */
     static void generateMetadataDeserializer(GenerationContext context, SymbolReference responseType) {
@@ -194,11 +194,11 @@ final class HttpProtocolGeneratorUtils {
         writer.write("// Collect low-level response body stream to Uint8Array.");
         writer.openBlock("const collectBody = (streamBody: any, context: __SerdeContext): Promise<Uint8Array> => {",
                 "};", () -> {
-            writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
-                writer.write("return Promise.resolve(streamBody);");
-            });
-            writer.write("return context.streamCollector(streamBody) || new Uint8Array();");
-        });
+                    writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
+                        writer.write("return Promise.resolve(streamBody);");
+                    });
+                    writer.write("return context.streamCollector(streamBody) || new Uint8Array();");
+                });
 
         writer.write("");
     }
@@ -228,10 +228,10 @@ final class HttpProtocolGeneratorUtils {
      * assumes a deserialization function is generated for the structures
      * returned.
      *
-     * @param context The generation context.
-     * @param operation The operation to generate for.
-     * @param responseType The response type for the HTTP protocol.
-     * @param errorCodeGenerator A consumer
+     * @param context              The generation context.
+     * @param operation            The operation to generate for.
+     * @param responseType         The response type for the HTTP protocol.
+     * @param errorCodeGenerator   A consumer
      * @param shouldParseErrorBody Flag indicating whether need to parse response body in this dispatcher function
      * @param bodyErrorLocationModifier A function that returns the location of an error in a body given a data source.
      * @return A set of all error structure shapes for the operation that were dispatched to.
@@ -330,7 +330,7 @@ final class HttpProtocolGeneratorUtils {
      * Writes resolved hostname, prepending existing hostname with hostPrefix and replacing each hostLabel with
      * the corresponding top-level input member value.
      *
-     * @param context The generation context.
+     * @param context   The generation context.
      * @param operation The operation to generate for.
      */
     static void writeHostPrefix(GenerationContext context, OperationShape operation) {
@@ -358,6 +358,15 @@ final class HttpProtocolGeneratorUtils {
         });
     }
 
+    /**
+     * Writes a function used to dispatch event to corresponding event deserializers.
+     * This function assumes a event-specific deserialization function is generated
+     * for each returned structures.
+     *
+     * @param context The generation context.
+     * @param events  The union of of events bond to an event stream
+     * @return A list of all event structure shapes for the event stream that were dispatched to.
+     */
     static Set<StructureShape> generateDeserializingEventUnion(
             GenerationContext context,
             UnionShape events
@@ -396,6 +405,15 @@ final class HttpProtocolGeneratorUtils {
         return targets;
     }
 
+    /**
+     * Writes a function used to dispatch event to corresponding event serializer.
+     * This function assumes a event-specific serializer function is generated
+     * for each returned structures.
+     *
+     * @param context The generation context.
+     * @param events  The union of of events bond to an event stream
+     * @return A list of all event structure shapes for the event stream that were dispatched to.
+     */
     static Set<StructureShape> generateSerializingEvnetUnion(
             GenerationContext context,
             UnionShape events

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -59,8 +59,8 @@ final class HttpProtocolGeneratorUtils {
      *
      * @param dataSource The in-code location of the data to provide an input of
      *                   ({@code input.foo}, {@code entry}, etc.)
-     * @param shape      The shape that represents the value being provided.
-     * @param format     The timestamp format to provide.
+     * @param shape The shape that represents the value being provided.
+     * @param format The timestamp format to provide.
      * @return Returns a value or expression of the input timestamp.
      */
     static String getTimestampInputParam(String dataSource, Shape shape, Format format) {
@@ -82,8 +82,8 @@ final class HttpProtocolGeneratorUtils {
      *
      * @param dataSource The in-code location of the data to provide an output of
      *                   ({@code output.foo}, {@code entry}, etc.)
-     * @param shape      The shape that represents the value being received.
-     * @param format     The timestamp format to provide.
+     * @param shape The shape that represents the value being received.
+     * @param format The timestamp format to provide.
      * @return Returns a value or expression of the output timestamp.
      */
     static String getTimestampOutputParam(String dataSource, Shape shape, Format format) {
@@ -165,7 +165,7 @@ final class HttpProtocolGeneratorUtils {
      * Writes a response metadata deserializer function for HTTP protocols. This
      * will load things like the status code, headers, and more.
      *
-     * @param context      The generation context.
+     * @param context The generation context.
      * @param responseType The response type for the HTTP protocol.
      */
     static void generateMetadataDeserializer(GenerationContext context, SymbolReference responseType) {
@@ -197,7 +197,7 @@ final class HttpProtocolGeneratorUtils {
                     writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
                         writer.write("return Promise.resolve(streamBody);");
                     });
-                    writer.write("return context.streamCollector(streamBody) || new Uint8Array();");
+                    writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
                 });
 
         writer.write("");
@@ -228,10 +228,10 @@ final class HttpProtocolGeneratorUtils {
      * assumes a deserialization function is generated for the structures
      * returned.
      *
-     * @param context              The generation context.
-     * @param operation            The operation to generate for.
-     * @param responseType         The response type for the HTTP protocol.
-     * @param errorCodeGenerator   A consumer
+     * @param context The generation context.
+     * @param operation The operation to generate for.
+     * @param responseType The response type for the HTTP protocol.
+     * @param errorCodeGenerator A consumer
      * @param shouldParseErrorBody Flag indicating whether need to parse response body in this dispatcher function
      * @param bodyErrorLocationModifier A function that returns the location of an error in a body given a data source.
      * @return A set of all error structure shapes for the operation that were dispatched to.
@@ -330,7 +330,7 @@ final class HttpProtocolGeneratorUtils {
      * Writes resolved hostname, prepending existing hostname with hostPrefix and replacing each hostLabel with
      * the corresponding top-level input member value.
      *
-     * @param context   The generation context.
+     * @param context The generation context.
      * @param operation The operation to generate for.
      */
     static void writeHostPrefix(GenerationContext context, OperationShape operation) {
@@ -364,7 +364,7 @@ final class HttpProtocolGeneratorUtils {
      * for each returned structures.
      *
      * @param context The generation context.
-     * @param events  The union of of events bond to an event stream
+     * @param events The union of of events bond to an event stream
      * @return A list of all event structure shapes for the event stream that were dispatched to.
      */
     static Set<StructureShape> generateDeserializingEventUnion(
@@ -411,10 +411,10 @@ final class HttpProtocolGeneratorUtils {
      * for each returned structures.
      *
      * @param context The generation context.
-     * @param events  The union of of events bond to an event stream
+     * @param events The union of of events bond to an event stream
      * @return A list of all event structure shapes for the event stream that were dispatched to.
      */
-    static Set<StructureShape> generateSerializingEvnetUnion(
+    static Set<StructureShape> generateSerializingEventUnion(
             GenerationContext context,
             UnionShape events
     ) {

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.typescript.codegen.integration.EventStreamGenerator

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,1 +1,1 @@
-software.amazon.smithy.typescript.codegen.integration.EventStreamGenerator
+software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency


### PR DESCRIPTION
This change adds codegen support for eventstream serde. If a member has event stream trait, it will generate specitial event serde functions on top of original ones. Specifically:
* Serializer: 
  * event stream serializer:
```javascript
//TranscribeStreaming.serializeAws_restJson1_1StartStreamTranscriptionCommand
//...
if (input.AudioStream !== undefined) {
    body =
      context.eventStreamMarshaller.serialize(
        input.AudioStream,
        event => serializeAws_restJson1_1AudioStream_event(event, context)
      );
  }
//build request
```
  * if a multi-event event stream, we generate a event dispatcher:
```javascript
const serializeAws_restJson1_1AudioStream_event = (
  input: any,
  context: __SerdeContext
): __Message => {
  return AudioStream.visit(input, {
    AudioEvent: value => serializeAws_restJson1_1AudioEvent_event(value, context),
    _: value => value as any
  });
}
```
  * serializing a single event
```javascript
const serializeAws_restJson1_1AudioEvent_event = (
  input: AudioEvent,
  context: __SerdeContext
): __Message => {
  const message: __Message = {
    headers: {
      ":event-type": { type: "string", value: "AudioEvent" },
      ":message-type": { type: "string", value: "event" }
    },
    body: new Uint8Array()
  }
  message.body = input.AudioChunk!;
  return message;
}
```

* Deserializer
  * event stream deserializer
```javascript
// call eventStreamMarshaller.deserialize() from command deser
// convert eventname -> event message pair to event name -> event response pair
// after this step, individual event is convert to psuedo HTTP response shape
const data: any =
    context.eventStreamMarshaller.deserialize(
      output.body,
      async event => {
        const eventName = Object.keys(event)[0];
        const eventValue = event[eventName];
        const eventHeader = Object.entries(eventValue.headers).reduce(
          (accummulator, curr) => {accummulator[curr[0]] = curr[1].value; return accummulator; },
          {} as {[key: string]: any}
        );
        const eventMessage = {
          headers: eventHeader,
          body: event[eventName].body
        };
        const parsedEvent = {
          [eventName]: eventMessage
        };
        return await deserializeAws_restJson1_1TranscriptResultStream_event(parsedEvent, context);
      }
    );

  contents.TranscriptResultStream = data;
```

  * For multi-event event stream, we generate a event visitor to dispatch individual events
```javascript
const deserializeAws_restJson1_1TranscriptResultStream_event = async (
  output: any,
  context: __SerdeContext
): Promise<TranscriptResultStream> => {
  if (output['TranscriptEvent'] !== undefined) {
    return {
      TranscriptEvent: await deserializeAws_restJson1_1TranscriptEvent_event(output['TranscriptEvent'], context)
    };
  }
  if(/*other events*/){
  /*other events*/
  }
  return {$unknown: output}
}
```

* Deserialize each event like parsing a response
```javascript
const deserializeAws_restJson1_1TranscriptEvent_event = async (
  output: any,
  context: __SerdeContext
): Promise<TranscriptEvent> => {
  let contents: TranscriptEvent = {
    __type: "TranscriptEvent",
  } as any;
  const data: any = await parseBody(output.body, context);
  contents = {
    ...contents,
    ...deserializeAws_restJson1_1TranscriptEvent(data, context)
  } as any
  return contents;
}
```