### PR TITLE
Fix whole seconds to milliseconds

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -82,8 +82,8 @@ final class HttpProtocolGeneratorUtils {
                 modifiedSource = dataSource;
                 break;
             case EPOCH_SECONDS:
-                // Account for seconds being sent over the wire in some cases where milliseconds are required.
-                modifiedSource = dataSource + " % 1 != 0 ? Math.round(" + dataSource + " * 1000) : " + dataSource;
+                // Convert whole and decimal numbers to milliseconds.
+                modifiedSource = "Math.round(" + dataSource + " * 1000)";
                 break;
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -38,8 +38,7 @@ public class HttpProtocolGeneratorUtilsTest {
 
         assertThat("new Date(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.DATE_TIME)));
-        assertThat("new Date(" + DATA_SOURCE + " % 1 != 0 ? Math.round("
-                        + DATA_SOURCE + " * 1000) : " + DATA_SOURCE + ")",
+        assertThat("new Date(Math.round(" + DATA_SOURCE + " * 1000))",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
         assertThat("new Date(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.HTTP_DATE)));


### PR DESCRIPTION
Fixes: aws/aws-sdk-js-v3/issues/809

Convert whole seconds to milliseconds when creating Date from epoch timestamps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
