### PR TITLE
Update to JS error standards

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -131,7 +131,7 @@ final class StructureGenerator implements Runnable {
      * import * as _smithy from "@aws-sdk/smithy-client";
      *
      * export interface NoSuchResource extends _smithy.SmithyException, $MetadataBearer {
-     *   __type: "NoSuchResource";
+     *   name: "NoSuchResource";
      *   $fault: "client";
      *   resourceType: string | undefined;
      * }


### PR DESCRIPTION
This commit makes updates to align error deserialization with JS
conventions around the message and name properties. It also opens
the type signature to allow for additional properties on errors.

Partial of aws/aws-sdk-js-v3#763

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
