### PR TITLE
fix: use lowercased header name in readHeaders

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -717,10 +717,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Model model = context.getModel();
         for (HttpBinding binding : bindingIndex.getResponseBindings(operationOrError, Location.HEADER)) {
             String memberName = symbolProvider.toMemberName(binding.getMember());
-            writer.openBlock("if (output.headers[$S] !== undefined) {", "}", binding.getLocationName(), () -> {
+            String headerName = binding.getLocationName().toLowerCase();
+            writer.openBlock("if (output.headers[$S] !== undefined) {", "}", headerName, () -> {
                 Shape target = model.expectShape(binding.getMember().getTarget());
                 String headerValue = getOutputValue(context, binding.getLocation(),
-                        "output.headers['" + binding.getLocationName() + "']", binding.getMember(), target);
+                        "output.headers['" + headerName + "']", binding.getMember(), target);
                 writer.write("contents.$L = $L;", memberName, headerValue);
             });
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/825

*Description of changes:*
Current deserializer uses case-sensitive member local name for parser the headers. However, the header should be case-insensitive(low-cased) by default. 

Wrong(current):
```javascript
  if (output.headers["ETag"] !== undefined) {
    contents.ETag = output.headers["ETag"];
  }
```

Right(fixed):
```javascript
  if (output.headers["etag"] !== undefined) {
    contents.ETag = output.headers["etag"];
  }
```

This change fix the issue above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
