### PR TITLE
Update generated RPC code for DRYness

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -91,6 +91,36 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
         HttpProtocolGeneratorUtils.generateCollectBody(context);
         HttpProtocolGeneratorUtils.generateCollectBodyString(context);
+
+        TypeScriptWriter writer = context.getWriter();
+
+        // Write a function to generate HTTP requests since they're so similar.
+        SymbolReference requestType = getApplicationProtocol().getRequestType();
+        writer.addUseImports(requestType);
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
+        writer.openBlock("const buildHttpRpcRequest = (\n"
+                       + "  context: __SerdeContext,\n"
+                       + "  headers: __HeaderBag,\n"
+                       + "  path: string,\n"
+                       + "  resolvedHostname: string | undefined,\n"
+                       + "  body: any,\n"
+                       + "): $T => {", "};", requestType, () -> {
+            writer.openBlock("const contents: any = {", "};", () -> {
+                writer.write("...context.endpoint,");
+                writer.write("protocol: \"https\",");
+                writer.write("method: \"POST\",");
+                writer.write("path: path,");
+                writer.write("headers: headers,");
+            });
+            writer.openBlock("if (resolvedHostname !== undefined) {", "}", () -> {
+                writer.write("contents.hostname = resolvedHostname;");
+            });
+            writer.openBlock("if (body !== undefined) {", "}", () -> {
+                writer.write("contents.body = body;");
+            });
+            writer.write("return new $T(contents);", requestType);
+        });
     }
 
     @Override
@@ -142,19 +172,11 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                 HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
             }
 
-            writer.openBlock("return new $T({", "});", requestType, () -> {
-                writer.write("...context.endpoint,");
-                if (hasHostPrefix) {
-                    writer.write("hostname: resolvedHostname,");
-                }
-                writer.write("protocol: \"https\",");
-                writer.write("method: \"POST\",");
-                writer.write("path: $S,", getOperationPath(context, operation));
-                writer.write("headers: headers,");
-                if (hasRequestBody) {
-                    writer.write("body: body,");
-                }
-            });
+            // Construct the request with the operation's path and optional hostname and body.
+            writer.write("return buildHttpRpcRequest(context, headers, $S, $L, $L);",
+                    getOperationPath(context, operation),
+                    hasHostPrefix ? "resolvedHostname" : "undefined",
+                    hasRequestBody ? "body" : "undefined");
         });
 
         writer.write("");
@@ -164,7 +186,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
 
         // The Content-Type header is always present.
-        writer.write("const headers: any = {};");
+        writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
+        writer.write("const headers: __HeaderBag = {};");
         writer.write("headers['Content-Type'] = $S;", getDocumentContentType());
         writeDefaultHeaders(context, operation);
     }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

-----

From:

```ts
// Many of this:
  return new __HttpRequest({
    ...context.endpoint,
    protocol: "https",
    method: "POST",
    path: "/",
    headers: headers,
    body: body
  });
```

To:

```ts
// Many of this:
  return buildHttpRpcRequest(context, headers, "/", undefined, body);

// One of this:
const buildHttpRpcRequest = (
  context: __SerdeContext,
  headers: __HeaderBag,
  path: string,
  resolvedHostname: string | undefined,
  body: any,
): __HttpRequest => {
  const contents: any = {
    ...context.endpoint,
    protocol: "https",
    method: "POST",
    path: path,
    headers: headers,
  };
  if (resolvedHostname !== undefined) {
    contents.hostname = resolvedHostname;
  }
  if (body !== undefined) {
    contents.body = body;
  }
  return new __HttpRequest(contents);
};
```