### PR TITLE
Initialize body, but do not set to empty object

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -374,13 +374,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (!documentBindings.isEmpty()) {
             // Write the default `body` property.
-            writer.write("let body: any = {};");
+            writer.write("let body: any;");
             serializeInputDocument(context, operation, documentBindings);
             return documentBindings;
         }
         if (!payloadBindings.isEmpty()) {
             // Write the default `body` property.
-            writer.write("let body: any = {};");
+            writer.write("let body: any;");
             // There can only be one payload binding.
             HttpBinding payloadBinding = payloadBindings.get(0);
             serializeInputPayload(context, operation, payloadBinding);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -202,7 +202,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             serializingDocumentShapes.add(inputShape);
 
             // Write the default `body` property.
-            context.getWriter().write("let body: any = {};");
+            context.getWriter().write("let body: any;");
             serializeInputDocument(context, operation, inputShape);
             return true;
         }


### PR DESCRIPTION
Body should only be initialized, but not set to empty object.

Empty objects that do not get replaced with actual body content cause errors when sending requests.

Part of fix for https://github.com/aws/aws-sdk-js-v3/issues/838

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
