### PR TITLE
apply command middleware plugins to concatenated stack

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -143,12 +143,12 @@ final class CommandGenerator implements Runnable {
         writer.openBlock("): Handler<$T, $T> {", "}", inputType, outputType, () -> {
             // Add serialization and deserialization plugin.
             writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
+            writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");
 
             // Add customizations.
             addCommandSpecificPlugins();
 
             // Resolve the middleware stack.
-            writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");
             writer.openBlock("const handlerExecutionContext: HandlerExecutionContext = {", "}", () -> {
                 writer.write("logger: {} as any,");
             });
@@ -194,7 +194,7 @@ final class CommandGenerator implements Runnable {
         // the service's middleware stack.
         for (RuntimeClientPlugin plugin : runtimePlugins) {
             plugin.getPluginFunction().ifPresent(symbol -> {
-                writer.write("this.middlewareStack.use($T(configuration));", symbol);
+                writer.write("stack.use($T(configuration));", symbol);
             });
         }
     }


### PR DESCRIPTION
Previously, command customization plugins are applied to command's middleware
stack only. It doesn't provide the ability to modify the middlewares inserted
from client's middleware stack.

This change enables command customization plugins to the modify middleware stack
concatenated from both command and client. Thus we can have more flexibility
for command customizations, including undoing customizations in client from
individual command.

Current commands resolveMiddleware method:
```javascript
  function resolveMiddleware(clientStack, configuration,  options) {
    this.middlewareStack.use(getSerdePlugin(/*...*/));
    this.middlewareStack.use(getCustomizationPlugin(configuration));

    const stack = clientStack.concat(this.middlewareStack);

    const handlerExecutionContext = {
      logger: {} as any,
    }
    //...
    );
  }
```

After change
```javascript
function resolveMiddleware(clientStack, configuration,  options) {
    this.middlewareStack.use(getSerdePlugin(/*...*/));

    const stack = clientStack.concat(this.middlewareStack);

    stack.use(getCustomizationPlugin(configuration));
    const handlerExecutionContext = {
      logger: {} as any,
    }
    //...
    );
  }
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
