### PR TITLE
Export models in index.ts

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -55,6 +55,9 @@ final class IndexGenerator {
         for (OperationShape operation : containedOperations) {
             writer.write("export * from \"./commands/" + symbolProvider.toSymbol(operation).getName() + "\";");
         }
+
+        // write export statement for models
+        writer.write("export * from \"./models/index\";");
         fileManifest.writeFile("index.ts", writer.toString());
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
@@ -29,5 +29,6 @@ public class IndexGeneratorTest {
         assertThat(contents, containsString("export * from \"./Example\";"));
         assertThat(contents, containsString("export * from \"./ExampleClient\";"));
         assertThat(contents, containsString("export * from \"./commands/GetFooCommand\";"));
+        assertThat(contents, containsString("export * from \"./models/index\";"));
     }
 }


### PR DESCRIPTION
Resolves: aws/aws-sdk-js-v3/issues/847

Export all shapes from models/index.ts in root index.ts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
