### PR TITLE
URIencode label values

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -61,8 +61,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "^1.0.0-alpha.1", true),
     AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "^1.0.0-alpha.1", true),
 
-    AWS_SDK_UTIL_URI_ESCAPE("dependencies", "@aws-sdk/util-uri-excape", "^1.0.0-alpha.2", true),
-
     // Conditionally added when using an HTTP application protocol.
     AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", "^1.0.0-alpha.1", false),
     AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "^1.0.0-alpha.1", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -61,6 +61,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "^1.0.0-alpha.1", true),
     AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "^1.0.0-alpha.1", true),
 
+    AWS_SDK_UTIL_URI_ESCAPE("dependencies", "@aws-sdk/util-uri-excape", "^1.0.0-alpha.2", true),
+
     // Conditionally added when using an HTTP application protocol.
     AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", "^1.0.0-alpha.1", false),
     AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "^1.0.0-alpha.1", false),


### PR DESCRIPTION
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/866

Add encode the labels before inserting them into the request path. 

Reference: [here](https://github.com/aws/aws-sdk-js-v3/blob/17e85a9a4021b4f26118853ae5a0c8d76f66e354/packages/protocol-rest/src/RestSerializer.ts#L188-L202)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
