### PR TITLE
fix: use Object spread instead of Object.assign

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -248,7 +248,7 @@ final class HttpProtocolGeneratorUtils {
             writer.write("response.message = message;");
             writer.write("delete response.Message;");
 
-            writer.write("return Promise.reject(Object.assign(new Error(message), response));");
+            writer.write("return Promise.reject({...new Error(message), response}));");
         });
         writer.write("");
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/864#issuecomment-583653105

*Description of changes:*
Primary reasons we're switching to Object spread:
* Spread operate doesn't mutate any argument
* Spread operator is less verbose
* Spread operator is more performant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
