### PR TITLE
fix uriencoding path with greedy label

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -265,8 +265,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 // Get the correct label to use.
                 Segment uriLabel = uriLabels.stream().filter(s -> s.getContent().equals(memberName)).findFirst().get();
                 String encodedSegment = uriLabel.isGreedyLabel()
-                        ? "encodeURIComponent(labelValue)"
-                        : "labelValue.split(\"/\").map(segment => encodeURIComponent(segment)).join(\"/\")";
+                        ? "labelValue.split(\"/\").map(segment => encodeURIComponent(segment)).join(\"/\")"
+                        : "encodeURIComponent(labelValue)";
 
                 // Set the label's value and throw a clear error if empty or undefined.
                 writer.write("if (input.$L !== undefined) {", memberName).indent()


### PR DESCRIPTION
redo: https://github.com/awslabs/smithy-typescript/pull/121


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
