### PR TITLE
Add serde support for application/json String

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+/**
+ * Utility methods needed across Java packages.
+ */
+public final class CodegenUtils {
+
+    private CodegenUtils() {}
+
+    /**
+     * Detects if an annotated mediatype indicates JSON contents.
+     *
+     * @param mediaType The media type to inspect.
+     * @return If the media type indicates JSON contents.
+     */
+    public static boolean isJsonMediaType(String mediaType) {
+        return mediaType.equals("application/json") || mediaType.endsWith("+json");
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -62,8 +62,6 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *     <b>Not overridable.</b></li>
  *   <li>All other types: unmodified.</li>
  * </ul>
- *
- * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
  */
 public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     private final GenerationContext context;
@@ -159,7 +157,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String stringShape(StringShape shape) {
-        return deserializeUnmodified();
+        return HttpProtocolGeneratorUtils.getStringOutputParam(context, shape, deserializeUnmodified());
     }
 
     private String deserializeUnmodified() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -61,8 +61,6 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *     <b>Not overridable.</b></li>
  *   <li>All other types: unmodified.</li>
  * </ul>
- *
- * TODO: Update this with a mechanism to handle String and Blob shapes with the @mediatype trait.
  */
 public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     private final GenerationContext context;
@@ -158,7 +156,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
 
     @Override
     public String stringShape(StringShape shape) {
-        return serializeUnmodified();
+        return HttpProtocolGeneratorUtils.getStringInputParam(context, shape, serializeUnmodified());
     }
 
     private String serializeUnmodified() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.logging.Logger;
-
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -411,7 +410,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             MemberShape member,
             Shape target
     ) {
-        if (isNativeSimpleType(target)) {
+        if (target instanceof StringShape) {
+            return HttpProtocolGeneratorUtils.getStringInputParam(context, target, dataSource);
+        } else if (isNativeSimpleType(target)) {
             return dataSource + ".toString()";
         } else if (target instanceof TimestampShape) {
             HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
@@ -845,7 +846,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             return getNumberOutputParam(bindingType, dataSource, target);
         } else if (target instanceof BooleanShape) {
             return getBooleanOutputParam(bindingType, dataSource);
-        } else if (target instanceof StringShape || target instanceof DocumentShape) {
+        } else if (target instanceof StringShape) {
+            return HttpProtocolGeneratorUtils.getStringOutputParam(context, target, dataSource);
+        } else if (target instanceof DocumentShape) {
             return dataSource;
         } else if (target instanceof TimestampShape) {
             HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenUtilsTest.java
@@ -1,0 +1,13 @@
+package software.amazon.smithy.typescript.codegen;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CodegenUtilsTest {
+    @Test
+    public void detectsJsonMediaTypes() {
+        Assertions.assertTrue(CodegenUtils.isJsonMediaType("application/json"));
+        Assertions.assertTrue(CodegenUtils.isJsonMediaType("custom+json"));
+        Assertions.assertFalse(CodegenUtils.isJsonMediaType("application/xml"));
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -33,8 +33,10 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -48,6 +50,7 @@ public class DocumentMemberDeserVisitorTest {
         mockContext = new GenerationContext();
         mockContext.setProtocolName(PROTOCOL);
         mockContext.setSymbolProvider(new MockProvider());
+        mockContext.setWriter(new TypeScriptWriter("foo"));
     }
 
     @ParameterizedTest
@@ -75,6 +78,10 @@ public class DocumentMemberDeserVisitorTest {
                 {LongShape.builder().id(id).build(), DATA_SOURCE},
                 {ShortShape.builder().id(id).build(), DATA_SOURCE},
                 {StringShape.builder().id(id).build(), DATA_SOURCE},
+                {
+                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                    "new __LazyJsonString(" + DATA_SOURCE + ")"
+                },
                 {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")"},
                 {DocumentShape.builder().id(id).build(), delegate},
                 {ListShape.builder().id(id).member(member).build(), delegate},

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -35,7 +35,9 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -49,6 +51,7 @@ public class DocumentMemberSerVisitorTest {
         mockContext = new GenerationContext();
         mockContext.setProtocolName(PROTOCOL);
         mockContext.setSymbolProvider(new MockProvider());
+        mockContext.setWriter(new TypeScriptWriter("foo"));
     }
 
     @ParameterizedTest
@@ -78,6 +81,10 @@ public class DocumentMemberSerVisitorTest {
                 {LongShape.builder().id(id).build(), DATA_SOURCE},
                 {ShortShape.builder().id(id).build(), DATA_SOURCE},
                 {StringShape.builder().id(id).build(), DATA_SOURCE},
+                {
+                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                    "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
+                },
                 {BlobShape.builder().id(id).build(), "context.base64Encoder(" + DATA_SOURCE + ")"},
                 {DocumentShape.builder().id(id).build(), delegate},
                 {ListShape.builder().id(id).member(member).build(), delegate},


### PR DESCRIPTION
This commit adds support for serializing and deserializing String
shapes as the `LazyJsonString` when they are marked with the `@mediatype`
trait with the value of `"application/json"`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
