### PR TITLE
fix: typo _smithy.LazyJsonString to __LazyJsonString

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -247,7 +247,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         if (mediaTypeTrait.isPresent()) {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
-                return addSmithyImport(createSymbolBuilder(shape, "_smithy.LazyJsonString | string")).build();
+                return addSmithyImport(createSymbolBuilder(shape, "__LazyJsonString | string")).build();
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
             }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/128

*Description of changes:*
fix: typo _smithy.LazyJsonString to __LazyJsonString

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
