### PR TITLE
fix: set errorCode to parsedBody.code in default case

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -295,7 +295,7 @@ final class HttpProtocolGeneratorUtils {
 
                         // Get the protocol specific error location for retrieving contents.
                         String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                        writer.write("errorCode = errorCode || \"UnknownError\";");
+                        writer.write("errorCode = errorCode;");
                         writer.openBlock("response = {", "} as any;", () -> {
                             writer.write("...$L,", errorLocation);
                             writer.write("name: `$${errorCode}`,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -295,7 +295,7 @@ final class HttpProtocolGeneratorUtils {
 
                         // Get the protocol specific error location for retrieving contents.
                         String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                        writer.write("errorCode = errorCode;");
+                        writer.write("errorCode = parsedBody.code || errorCode;");
                         writer.openBlock("response = {", "} as any;", () -> {
                             writer.write("...$L,", errorLocation);
                             writer.write("name: `$${errorCode}`,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -295,7 +295,7 @@ final class HttpProtocolGeneratorUtils {
 
                         // Get the protocol specific error location for retrieving contents.
                         String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                        writer.write("errorCode = parsedBody.code || errorCode;");
+                        writer.write("errorCode = $1L.code || $1L.Code || errorCode;", errorLocation);
                         writer.openBlock("response = {", "} as any;", () -> {
                             writer.write("...$L,", errorLocation);
                             writer.write("name: `$${errorCode}`,");


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/851

*Description of changes:*
* set errorCode to parsedBody.name in default case
* removes "UnknownError" assignment, as it's initialized on line 268

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
