### PR TITLE
Collect unused stream bodies

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -782,6 +782,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         if (!payloadBindings.isEmpty()) {
             return readResponsePayload(context, operationOrError, payloadBindings);
         }
+
+        // If there are no payload or document bindings, the body still needs collected so the process can exit.
+        writer.write("await collectBody(output.body, context);");
         return ListUtils.of();
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -382,9 +382,9 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     }
 
     private void readResponseBody(GenerationContext context, OperationShape operation) {
+        TypeScriptWriter writer = context.getWriter();
         operation.getOutput().ifPresent(outputId -> {
             // We only need to load the body and prepare a contents object if there is a response.
-            TypeScriptWriter writer = context.getWriter();
             writer.write("const data: any = await parseBody(output.body, context)");
             writer.write("let contents: any = {};");
 
@@ -396,6 +396,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
             deserializeOutputDocument(context, operation, outputShape);
         });
+        if (!operation.getOutput().isPresent()) {
+            // If there is no output, the body still needs to be collected so the process can exit.
+            writer.write("await collectBody(output.body, context);");
+        }
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.OptionalUtils;
 
 /**
  * Abstract implementation useful for all HTTP protocols without bindings.
@@ -383,23 +384,25 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
     private void readResponseBody(GenerationContext context, OperationShape operation) {
         TypeScriptWriter writer = context.getWriter();
-        operation.getOutput().ifPresent(outputId -> {
-            // We only need to load the body and prepare a contents object if there is a response.
-            writer.write("const data: any = await parseBody(output.body, context)");
-            writer.write("let contents: any = {};");
+        OptionalUtils.ifPresentOrElse(
+                operation.getOutput(),
+                outputId -> {
+                    // We only need to load the body and prepare a contents object if there is a response.
+                    writer.write("const data: any = await parseBody(output.body, context)");
+                    writer.write("let contents: any = {};");
 
-            // If there's an output present, we know it's a structure.
-            StructureShape outputShape = context.getModel().expectShape(outputId).asStructureShape().get();
+                    // If there's an output present, we know it's a structure.
+                    StructureShape outputShape = context.getModel().expectShape(outputId).asStructureShape().get();
 
-            // Track output shapes so their deserializers may be generated.
-            deserializingDocumentShapes.add(outputShape);
+                    // Track output shapes so their deserializers may be generated.
+                    deserializingDocumentShapes.add(outputShape);
 
-            deserializeOutputDocument(context, operation, outputShape);
-        });
-        if (!operation.getOutput().isPresent()) {
-            // If there is no output, the body still needs to be collected so the process can exit.
-            writer.write("await collectBody(output.body, context);");
-        }
+                    deserializeOutputDocument(context, operation, outputShape);
+                },
+                () -> {
+                    // If there is no output, the body still needs to be collected so the process can exit.
+                    writer.write("await collectBody(output.body, context);");
+                });
     }
 
     /**


### PR DESCRIPTION
Fixes aws/aws-sdk-js-v3/issues/918

Operations without document or payload bindings still need to have their bodies collected so that node process will exit promptly without waiting for the stream to close on its own.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
