### PR TITLE
Update smithy-client import strategy

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -68,7 +68,7 @@ final class StructureGenerator implements Runnable {
      * <p>The following TypeScript is rendered:
      *
      * <pre>{@code
-     * import * as _smithy from "@aws-sdk/smithy-client";
+     * import { isa as __isa } from "@aws-sdk/smithy-client";
      *
      * export interface Person {
      *   __type?: "Person";
@@ -79,7 +79,7 @@ final class StructureGenerator implements Runnable {
      * export namespace Person {
      *   export const ID = "smithy.example#Person";
      *   export function isa(o: any): o is Person {
-     *     return _smithy.isa(o, ID);
+     *     return __isa(o, ID);
      *   }
      * }
      * }</pre>
@@ -128,9 +128,12 @@ final class StructureGenerator implements Runnable {
      * <p>The following TypeScript is generated:
      *
      * <pre>{@code
-     * import * as _smithy from "@aws-sdk/smithy-client";
+     * import {
+     *     SmithyException as __SmithyException,
+     *     isa as __isa
+     * } from "@aws-sdk/smithy-client";
      *
-     * export interface NoSuchResource extends _smithy.SmithyException, $MetadataBearer {
+     * export interface NoSuchResource extends __SmithyException, $MetadataBearer {
      *   name: "NoSuchResource";
      *   $fault: "client";
      *   resourceType: string | undefined;
@@ -138,7 +141,7 @@ final class StructureGenerator implements Runnable {
      *
      * export namespace Person {
      *   export function isa(o: any): o is NoSuchResource {
-     *     return _smithy.isa(o, "NoSuchResource");
+     *     return __isa(o, "NoSuchResource");
      *   }
      * }
      * }</pre>
@@ -149,8 +152,9 @@ final class StructureGenerator implements Runnable {
         writer.writeShapeDocs(shape);
 
         // Find symbol references with the "extends" property, and add SmithyException.
+        writer.addImport("SmithyException", "__SmithyException", "@aws-sdk/smithy-client");
         String extendsFrom = Stream.concat(
-                Stream.of("_smithy.SmithyException"),
+                Stream.of("__SmithyException"),
                 symbol.getReferences().stream()
                         .filter(ref -> ref.getProperty(SymbolVisitor.IMPLEMENTS_INTERFACE_PROPERTY).isPresent())
                         .map(SymbolReference::getAlias)
@@ -168,10 +172,11 @@ final class StructureGenerator implements Runnable {
     }
 
     private void renderStructureNamespace() {
+        writer.addImport("isa", "__isa", "@aws-sdk/smithy-client");
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
             writer.openBlock("export function isa(o: any): o is $L {", "}", symbol.getName(), () -> {
-                writer.write("return _smithy.isa(o, $S);", shape.getId().getName());
+                writer.write("return __isa(o, $S);", shape.getId().getName());
             });
         });
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -219,7 +219,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return addSmithyImport(createSymbolBuilder(shape, "_smithy.DocumentType.Value")).build();
+        Symbol.Builder builder = createSymbolBuilder(shape, "__DocumentType.Value");
+        return addSmithyUseImport(builder, "DocumentType", "__DocumentType").build();
     }
 
     @Override
@@ -247,7 +248,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         if (mediaTypeTrait.isPresent()) {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
-                return addSmithyImport(createSymbolBuilder(shape, "_smithy.LazyJsonString | string")).build();
+                Symbol.Builder builder = createSymbolBuilder(shape, "__LazyJsonString | string");
+                return addSmithyUseImport(builder, "LazyJsonString", "__LazyJsonString").build();
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
             }
@@ -277,7 +279,6 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol structureShape(StructureShape shape) {
         Symbol.Builder builder = createObjectSymbolBuilder(shape);
-        addSmithyImport(builder);
 
         if (outputShapes.contains(shape)) {
             SymbolReference reference = SymbolReference.builder()
@@ -293,15 +294,15 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         return builder.build();
     }
 
-    private Symbol.Builder addSmithyImport(Symbol.Builder builder) {
+    private Symbol.Builder addSmithyUseImport(Symbol.Builder builder, String name, String as) {
         Symbol importSymbol = Symbol.builder()
-                .name("*")
+                .name(name)
                 .namespace("@aws-sdk/smithy-client", "/")
                 .build();
         SymbolReference reference = SymbolReference.builder()
                 .symbol(importSymbol)
-                .alias("_smithy")
-                .options(SymbolReference.ContextOption.DECLARE)
+                .alias(as)
+                .options(SymbolReference.ContextOption.USE)
                 .build();
         return builder.addReference(reference);
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -17,7 +17,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesEmptyMessageMemberOfException() {
         testErrorStructureCodegen("error-test-empty.smithy",
-                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
+                                  "export interface Err extends __SmithyException, $MetadataBearer {\n"
                                   + "  name: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "}");
@@ -26,7 +26,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesOptionalMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-message.smithy",
-                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
+                                  "export interface Err extends __SmithyException, $MetadataBearer {\n"
                                   + "  name: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message?: string;\n"
@@ -36,7 +36,7 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesRequiredMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-message.smithy",
-                                  "export interface Err extends _smithy.SmithyException, $MetadataBearer {\n"
+                                  "export interface Err extends __SmithyException, $MetadataBearer {\n"
                                   + "  name: \"Err\";\n"
                                   + "  $fault: \"client\";\n"
                                   + "  message: string | undefined;\n"
@@ -62,10 +62,12 @@ public class StructureGeneratorTest {
         new TypeScriptCodegenPlugin().execute(context);
         String contents = manifest.getFileString("/models/index.ts").get();
 
+        assertThat(contents, containsString("as __isa"));
+        assertThat(contents, containsString("as __SmithyException"));
         assertThat(contents, containsString(expectedType));
         assertThat(contents, containsString("namespace Err {\n"
                                             + "  export function isa(o: any): o is Err {\n"
-                                            + "    return _smithy.isa(o, \"Err\");\n"
+                                            + "    return __isa(o, \"Err\");\n"
                                             + "  }\n"
                                             + "}"));
     }
@@ -81,13 +83,14 @@ public class StructureGeneratorTest {
         new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model), writer, struct).run();
         String output = writer.toString();
 
+        assertThat(output, containsString("as __isa"));
         assertThat(output, containsString("export interface Bar {"));
         assertThat(output, containsString("__type?: \"Bar\";"));
         assertThat(output, containsString("foo?: string;"));
         assertThat(output, containsString("export namespace Bar {"));
         assertThat(output, containsString(
                 "export function isa(o: any): o is Bar {\n"
-                + "    return _smithy.isa(o, \"Bar\");\n"
+                + "    return __isa(o, \"Bar\");\n"
                 + "  }"));
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -163,6 +163,6 @@ public class SymbolProviderTest {
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol memberSymbol = provider.toSymbol(member);
 
-        assertThat(memberSymbol.getName(), equalTo("_smithy.LazyJsonString | string"));
+        assertThat(memberSymbol.getName(), equalTo("__LazyJsonString | string"));
     }
 }


### PR DESCRIPTION
This commit updates the `SymbolVisitor`'s import strategy to use only
specific imports instead of a full package aliased import. It also
updates other instances that relied on the full import to specify
their own directly.

The import type for many has been updated to a `USE` style import to
support composed symbols for collection and map shapes.

-----

Codegen examples:

```ts
import {
  LazyJsonString as __LazyJsonString,
  SmithyException as __SmithyException,
  isa as __isa,
} from "@aws-sdk/smithy-client";

export namespace AttributeValue {
  export function isa(o: any): o is AttributeValue {
    return __isa(o, "AttributeValue");
  }
}

export interface ExpiredNextTokenException extends __SmithyException, $MetadataBearer {
  name: "ExpiredNextTokenException";
  $fault: "client";
  Message?: string;
}

export interface GetProductsResponse extends $MetadataBearer {
  __type?: "GetProductsResponse";
  /**
   * <p>The format version of the response. For example, aws_v1.</p>
   */
  FormatVersion?: string;

  /**
   * <p>The pagination token that indicates the next set of results to retrieve.</p>
   */
  NextToken?: string;

  /**
   * <p>The list of products that match your filters. The list contains both the product metadata and
   *          the price information.</p>
   */
  PriceList?: Array<__LazyJsonString | string>;
}
```

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
