### PR TITLE
Undo query encoding

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -329,13 +329,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     Shape target = model.expectShape(binding.getMember().getTarget());
                     String queryValue = getInputValue(context, binding.getLocation(), "input." + memberName,
                             binding.getMember(), target);
-                    if (target instanceof CollectionShape) {
-                        writer.write("query[__extendedEncodeURIComponent($S)] = $L.map(entry => "
-                                + "__extendedEncodeURIComponent(entry));", binding.getLocationName(), queryValue);
-                    } else {
-                        writer.write("query[__extendedEncodeURIComponent($S)] = __extendedEncodeURIComponent($L);",
-                                binding.getLocationName(), queryValue);
-                    }
+                    writer.write("query['$L'] = $L;", binding.getLocationName(), queryValue);
                 });
             }
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -329,7 +329,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     Shape target = model.expectShape(binding.getMember().getTarget());
                     String queryValue = getInputValue(context, binding.getLocation(), "input." + memberName,
                             binding.getMember(), target);
-                    writer.write("query['$L'] = $L;", binding.getLocationName(), queryValue);
+                    writer.write("query[$S] = $L;", binding.getLocationName(), queryValue);
                 });
             }
         }


### PR DESCRIPTION
This PR reverts uri component encoding being handled during protocol serialization.  Instead, query encoding is performed in the individual handlers.

This change, with aws/aws-sdk-js-v3/pull/935, fixes https://github.com/aws/aws-sdk-js-v3/issues/930

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
