### PR TITLE
fix streaming members shape

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -22,9 +22,11 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 
@@ -169,7 +171,13 @@ final class CommandGenerator implements Runnable {
 
     private void writeInputType(String typeName, Optional<StructureShape> inputShape) {
         if (inputShape.isPresent()) {
-            writer.write("export type $L = $T;", typeName, symbolProvider.toSymbol(inputShape.get()));
+            StructureShape input = inputShape.get();
+            List<MemberShape> streamingMembers = getStramingMembers(input);
+            if (!streamingMembers.isEmpty()) {
+                writeStreamingInputType(typeName, inputShape, streamingMembers.get(0));
+            } else {
+                writer.write("export type $L = $T;", typeName, symbolProvider.toSymbol(input));
+            }
         } else {
             // If the input is non-existent, then use an empty object.
             writer.write("export type $L = {}", typeName);
@@ -184,6 +192,29 @@ final class CommandGenerator implements Runnable {
             writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
             writer.write("export type $L = __MetadataBearer", typeName);
         }
+    }
+
+    private List<MemberShape> getStramingMembers(StructureShape shape) {
+        return shape.getAllMembers().values().stream().filter(memberShape -> memberShape.hasTrait(StreamingTrait.class))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Ease the input streaming member restriction so that users don't need to construct a stream every time.
+     * This type decoration is allowed in Smithy because it makes input type more permissive than output type
+     * for the same member.
+     * Refer here for more rationales: https://github.com/aws/aws-sdk-js-v3/issues/843
+     */
+    private void writeStreamingInputType(
+            String typeName,
+            Optional<StructureShape> inputShape,
+            MemberShape streamingMember
+    ) {
+        Symbol inputSymbol = symbolProvider.toSymbol(inputShape.get());
+        writer.openBlock("export type $L = Omit<$T, $S> & {", "};", typeName, inputSymbol,
+                streamingMember.getMemberName(), () -> {
+            writer.write("$1L?: $2T[$1S]|string|Uint8Array|Buffer;", streamingMember.getMemberName(), inputSymbol);
+        });
     }
 
     private void addCommandSpecificPlugins() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -114,14 +114,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol blobShape(BlobShape shape) {
-        if (!shape.hasTrait(StreamingTrait.class)) {
-            return createSymbolBuilder(shape, "Uint8Array").build();
-        }
-
-        // Note: `Readable` needs an import and a dependency.
-        return createSymbolBuilder(shape, "ArrayBuffer | ArrayBufferView | string | Readable | Blob", null)
-                .addReference(Symbol.builder().name("Readable").namespace("stream", "/").build())
-                .build();
+        return createSymbolBuilder(shape, "Uint8Array").build();
     }
 
     @Override
@@ -327,6 +320,10 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             return createMemberSymbolWithEventStream(targetSymbol);
         }
 
+        if (shape.hasTrait(StreamingTrait.class)) {
+            return createMemberSymbolWithStreaming(targetSymbol);
+        }
+
         return targetSymbol;
     }
 
@@ -343,6 +340,15 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .namespace(null, "/")
                 .name(String.format("AsyncIterable<%s>", targetSymbol.getName()))
                 .addReference(targetSymbol)
+                .build();
+    }
+
+    private Symbol createMemberSymbolWithStreaming(Symbol targetSymbol) {
+        // Note: `Readable` needs an import and a dependency.
+        return targetSymbol.toBuilder()
+                .namespace(null, "/")
+                .name("Readable | ReadableStream | Blob")
+                .addReference(Symbol.builder().name("Readable").namespace("stream", "/").build())
                 .build();
     }
 


### PR DESCRIPTION
* Fix the streaming member's shape from Uint8Array to Readable|ReadableStream|Blob
* For streaming members in command input, ease the restriction to allow
  Uint8Array, Buffer and string

updated `PutObjectCommandInput`: 
```typescript
export type PutObjectCommandInput = Omit<PutObjectRequest, "Body"> & {
  Body?: PutObjectRequest["Body"] | string | Uint8Array | Buffer;
};
```
Only command input that has streaming member is updated.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/843


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
