### PR TITLE
Fix streaming type types when they are required

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -211,7 +211,8 @@ final class CommandGenerator implements Runnable {
         Symbol inputSymbol = symbolProvider.toSymbol(inputShape);
         writer.openBlock("export type $L = Omit<$T, $S> & {", "};", typeName, inputSymbol,
                 streamingMember.getMemberName(), () -> {
-            writer.write("$1L?: $2T[$1S]|string|Uint8Array|Buffer;", streamingMember.getMemberName(), inputSymbol);
+            writer.write("$1L$2L: $3T[$1S]|string|Uint8Array|Buffer;", streamingMember.getMemberName(),
+                    streamingMember.isRequired() ? "" : "?", inputSymbol);
         });
     }
 


### PR DESCRIPTION
* Fix a bug when streaming member shape is required:
before:
```typescript
export type UploadDocumentsCommandInput = Omit<UploadDocumentsRequest,"documents"> & {
  documents?: UploadDocumentsRequest["documents"] | string | Uint8Array | Buffer;
};
```
now:
```typescript
export type UploadDocumentsCommandInput = Omit<UploadDocumentsRequest,"documents"> & {
  documents: UploadDocumentsRequest["documents"] | string | Uint8Array | Buffer;
};
```

* Because command input and output shape is now possibly different to the ones exported from `models/index.ts`. So now SDK client uses the ones exported from commands to compose input/output type union, instead of those exported from `models/index.ts`. Although in most cases they should be the same types

Codegen: https://github.com/aws/aws-sdk-js-v3/pull/968/commits/ee375697e8b7bd5d878dc96290306445185cc895


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
