### PR TITLE
Protocol codegen fixes via protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -185,11 +185,13 @@ final class CommandGenerator implements Runnable {
     }
 
     private void writeOutputType(String typeName, Optional<StructureShape> outputShape) {
+        // Output types should always be MetadataBearers, possibly in addition
+        // to a defined output shape.
+        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         if (outputShape.isPresent()) {
-            writer.write("export type $L = $T;", typeName, symbolProvider.toSymbol(outputShape.get()));
+            writer.write("export type $L = $T & __MetadataBearer;",
+                    typeName, symbolProvider.toSymbol(outputShape.get()));
         } else {
-            // A command output should be at least a MetadataBearer
-            writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
             writer.write("export type $L = __MetadataBearer", typeName);
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -204,7 +204,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     public String timestampShape(TimestampShape shape) {
         HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
         Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
-        return HttpProtocolGeneratorUtils.getTimestampOutputParam(dataSource, shape, format);
+        return HttpProtocolGeneratorUtils.getTimestampOutputParam(dataSource, Location.DOCUMENT, shape, format);
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1384,7 +1384,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         switch (bindingType) {
             case HEADER:
                 if (target instanceof FloatShape || target instanceof DoubleShape) {
-                    return "parseFloat(" + dataSource + ", 10)";
+                    return "parseFloat(" + dataSource + ")";
                 }
                 return "parseInt(" + dataSource + ", 10)";
             default:

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -289,8 +289,11 @@ final class HttpProtocolGeneratorUtils {
                             context.getProtocolName()) + "Response";
                     writer.openBlock("case $S:\ncase $S:", "  break;", errorId.getName(), errorId.toString(), () -> {
                         // Dispatch to the error deserialization function.
-                        writer.write("response = await $L($L, context);",
-                                errorDeserMethodName, shouldParseErrorBody ? "parsedOutput" : "output");
+                        String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
+                        writer.openBlock("response = {", "}", () -> {
+                            writer.write("...await $L($L, context),", errorDeserMethodName, outputParam);
+                            writer.write("$$metadata: deserializeMetadata(output),");
+                        });
                     });
                 });
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.model.knowledge.HttpBinding.Location;
 import software.amazon.smithy.model.pattern.Pattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -78,11 +79,12 @@ final class HttpProtocolGeneratorUtils {
      *
      * @param dataSource The in-code location of the data to provide an output of
      *                   ({@code output.foo}, {@code entry}, etc.)
+     * @param bindingType How this value is bound to the operation output.
      * @param shape The shape that represents the value being received.
      * @param format The timestamp format to provide.
      * @return Returns a value or expression of the output timestamp.
      */
-    static String getTimestampOutputParam(String dataSource, Shape shape, Format format) {
+    static String getTimestampOutputParam(String dataSource, Location bindingType, Shape shape, Format format) {
         String modifiedSource;
         switch (format) {
             case DATE_TIME:
@@ -90,8 +92,13 @@ final class HttpProtocolGeneratorUtils {
                 modifiedSource = dataSource;
                 break;
             case EPOCH_SECONDS:
+                modifiedSource = dataSource;
+                // Make sure we turn a header's forced string into a number.
+                if (bindingType.equals(Location.HEADER)) {
+                    modifiedSource = "parseInt(" + modifiedSource + ", 10)";
+                }
                 // Convert whole and decimal numbers to milliseconds.
-                modifiedSource = "Math.round(" + dataSource + " * 1000)";
+                modifiedSource = "Math.round(" + modifiedSource + " * 1000)";
                 break;
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -1,20 +1,66 @@
 package software.amazon.smithy.typescript.codegen;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 
 public class CommandGeneratorTest {
     @Test
     public void addsCommandSpecificPlugins() {
-        // TODO
+        testCommmandCodegen("output-structure.smithy",
+                "  resolveMiddleware(\n" +
+                "    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,\n" +
+                "    configuration: ExampleClientResolvedConfig,\n" +
+                "    options?: __HttpHandlerOptions\n" +
+                "  ): Handler<GetFooCommandInput, GetFooCommandOutput> {\n" +
+                "    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));\n" +
+                "\n" +
+                "    const stack = clientStack.concat(this.middlewareStack);");
     }
 
     @Test
     public void writesSerializer() {
-        // TODO
+        testCommmandCodegen("output-structure.smithy",
+                "  private serialize(\n" +
+                "    input: GetFooCommandInput,\n" +
+                "    context: __SerdeContext\n" +
+                "  ): Promise<__HttpRequest> {");
     }
 
     @Test
     public void writesDeserializer() {
-        // TODO
+        testCommmandCodegen("output-structure.smithy",
+                "  private deserialize(\n" +
+                "    output: __HttpResponse,\n" +
+                "    context: __SerdeContext\n" +
+                "  ): Promise<GetFooCommandOutput> {");
+    }
+
+    private void testCommmandCodegen(String file, String expectedType) {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource(file))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .model(model)
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                                  .withMember("service", Node.from("smithy.example#Example"))
+                                  .withMember("package", Node.from("example"))
+                                  .withMember("packageVersion", Node.from("1.0.0"))
+                                  .build())
+                .build();
+
+        new TypeScriptCodegenPlugin().execute(context);
+        String contents = manifest.getFileString("/commands/GetFooCommand.ts").get();
+
+        assertThat(contents, containsString("as __MetadataBearer"));
+        assertThat(contents, containsString(expectedType));
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -114,6 +114,6 @@ public class StructureGeneratorTest {
         new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model), writer, struct).run();
         String output = writer.toString();
 
-        assertThat(output, containsString("export interface Bar extends $MetadataBearer {"));
+        assertThat(output, containsString("export interface Bar {"));
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -105,7 +105,7 @@ public class SymbolProviderTest {
     }
 
     @Test
-    public void outputStructuresAreMetadataBearers() {
+    public void errorStructuresAreMetadataBearers() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("output-structure.smithy"))
                 .assemble()
@@ -113,20 +113,25 @@ public class SymbolProviderTest {
 
         Shape input = model.expectShape(ShapeId.from("smithy.example#GetFooInput"));
         Shape output = model.expectShape(ShapeId.from("smithy.example#GetFooOutput"));
+        Shape error = model.expectShape(ShapeId.from("smithy.example#GetFooError"));
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol inputSymbol = provider.toSymbol(input);
         Symbol outputSymbol = provider.toSymbol(output);
+        Symbol errorSymbol = provider.toSymbol(error);
 
-        // Input does not use MetadataBearer
+        // Input and Output does not use MetadataBearer
         assertThat(inputSymbol.getReferences().stream()
                 .filter(ref -> ref.getProperty("extends").isPresent())
                 .count(), equalTo(0L));
+        assertThat(outputSymbol.getReferences().stream()
+                 .filter(ref -> ref.getAlias().equals("$MetadataBearer"))
+                 .count(), equalTo(0L));
 
         // Output uses MetadataBearer
-        assertThat(outputSymbol.getReferences().stream()
+        assertThat(errorSymbol.getReferences().stream()
                 .filter(ref -> ref.getProperty(SymbolVisitor.IMPLEMENTS_INTERFACE_PROPERTY).isPresent())
                 .count(), greaterThan(0L));
-        assertThat(outputSymbol.getReferences().stream()
+        assertThat(errorSymbol.getReferences().stream()
                  .filter(ref -> ref.getAlias().equals("$MetadataBearer"))
                  .count(), greaterThan(0L));
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.HttpBinding.Location;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -37,11 +38,11 @@ public class HttpProtocolGeneratorUtilsTest {
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
 
         assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.DATE_TIME)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME)));
         assertThat("new Date(Math.round(" + DATA_SOURCE + " * 1000))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS)));
         assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, shape, Format.HTTP_DATE)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE)));
     }
 
     @Test

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/output-structure.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/output-structure.smithy
@@ -1,5 +1,14 @@
 namespace smithy.example
 
-operation GetFoo(GetFooInput) -> GetFooOutput
+@protocols([{name: "aws.rest-json-1.1"}])
+service Example {
+    version: "1.0.0",
+    operations: [GetFoo]
+}
+
+operation GetFoo(GetFooInput) -> GetFooOutput errors [GetFooError]
 structure GetFooInput {}
 structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}


### PR DESCRIPTION
Contains the following fixes, each in their own commit for ease of review:

* Fix timestamp serde around TS string types
```ts
const labelValue: string = Math.round(input.memberEpochSeconds.getTime() / 1000).toString();
```
* Update parseFloat call to remove second param
```ts
contents.headerDouble = parseFloat(output.headers['x-double']);
```
* Add metadata to modeled error outputs
```ts
response = {
    ...await deserializeAws_restJson1_1ComplexErrorResponse(output, context),
    $metadata: deserializeMetadata(output),
}
```
* Update output shapes being MetadataBearers 
This commit removes the MetadataBearer type for non-error output
shapes in the model. This makes them not require having a metadata
property when being reused as non-response shapes (batches, etc.)
Output shapes instead become MetadataBearers as part of compound
types in the Command and Client codegen.
```ts
// Command specific alias shape is also the MetadataBearer
export type RecursiveShapesCommandOutput = RecursiveShapesInputOutput & __MetadataBearer;

// Client output union uses output MetadataBearers as well
export type ServiceOutputTypes =
  | __MetadataBearer
//  ...
  | RecursiveShapesInputOutput & __MetadataBearer;
```
* Fix handling for query collection deserialization
This commit updates query collection serialization to properly create
Set types. It also fixes an issue where query collections of non-string
simple types were not deserializing to their proper primitive type.
```ts
// Handle query collections of non-strings
contents.headerBooleanList = (output.headers['x-booleanlist'] || "").split(',').map(_entry => _entry === 'true');

// And handle sets
contents.headerStringSet = new Set((output.headers['x-stringset'] || "").split(',').map(_entry => _entry));
```
* Fix header handling in pre-parsed errors
```ts
if (parsedOutput.headers["x-header"] !== undefined) {
    contents.Header = parsedOutput.headers['x-header'];
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.