### PR TITLE
fix eventstream dependency placeholder in reactnative

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -94,8 +94,10 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                 writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
                 writer.addImport("invalidFunction", "invalidFunction",
                         TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                writer.write("eventStreamSerdeProvider: invalidFunction(\"event stream is not supported in "
-                                + "ReactNative\") as any,");
+                writer.openBlock("eventStreamSerdeProvider: () => ({", "})", () -> {
+                    writer.write("serialize: invalidFunction(\"event stream is not supported in ReactNative.\"),");
+                    writer.write("deserialize: invalidFunction(\"event stream is not supported in ReactNative.\")");
+                });
                 break;
             default:
                 // do nothing


### PR DESCRIPTION
The current invalid dependency function throws error in client constructor. This will block RN users even they are not using event stream. After this fix, the invalid dependency function throws when event stream serde is called. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
