### PR TITLE
Use @aws-crypto/sha256-js for hasher in RN

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -42,6 +42,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", "^1.0.0-alpha.1", true),
 
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^1.0.0-alpha.0", true),
+    AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.0.0-alpha.0", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^1.0.0-alpha.1", true),
 
     AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^1.0.0-alpha.1", true),

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.rn.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.rn.ts.template
@@ -1,4 +1,5 @@
 import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { streamCollector } from "@aws-sdk/stream-collector-rn";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { name, version } from "./package.json";
@@ -8,6 +9,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   requestHandler: new FetchHttpHandler({ bufferBody: true }),
+  sha256: Sha256,
   streamCollector,
   urlParser: parseUrl,
   defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/929

*Description of changes:*
The `@aws-crypto/sha256-browser` package doesn't work properly in ReactNative. So we use replace it will pure JS hasher(`@aws-crypto/sha256-js`) instead. 

Codegen PR: https://github.com/aws/aws-sdk-js-v3/pull/998

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
