### PR TITLE
bump typescript to ~3.8.3

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -34,7 +34,7 @@
     "jest": "^24.7.1",
     "rimraf": "^3.0.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.6.3"
+    "typescript": "~3.8.3"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1015

*Description of changes:*
bump typescript to ~3.8.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
