### PR TITLE
Update shared protocol/test codegen code

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -58,6 +58,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     /** A mapping of static resource files to copy over to a new filename. */
     private static final Map<String, String> STATIC_FILE_COPIES = MapUtils.of(
+            "jest.config.js", "jest.config.js",
             "tsconfig.es.json", "tsconfig.es.json",
             "tsconfig.json", "tsconfig.json"
     );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -201,7 +201,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     public String timestampShape(TimestampShape shape) {
         HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
         Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
-        return HttpProtocolGeneratorUtils.getTimestampInputParam(dataSource, shape, format);
+        return HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, shape, format);
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -26,7 +26,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -547,17 +546,23 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             MemberShape member
     ) {
         HttpBindingIndex httpIndex = context.getModel().getKnowledge(HttpBindingIndex.class);
-        Format format = httpIndex.determineTimestampFormat(member, bindingType, getDocumentTimestampFormat());
-        String baseParam = HttpProtocolGeneratorUtils.getTimestampInputParam(dataSource, member, format);
-
+        Format format;
         switch (bindingType) {
             case HEADER:
+                format = httpIndex.determineTimestampFormat(member, bindingType, Format.HTTP_DATE);
+                break;
             case LABEL:
+                format = httpIndex.determineTimestampFormat(member, bindingType, getDocumentTimestampFormat());
+                break;
             case QUERY:
-                return baseParam + ".toString()";
+                format = httpIndex.determineTimestampFormat(member, bindingType, Format.DATE_TIME);
+                break;
             default:
                 throw new CodegenException("Unexpected named member shape binding location `" + bindingType + "`");
         }
+
+        String baseParam = HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, member, format);
+        return baseParam + ".toString()";
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1346,7 +1346,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         MemberShape targetMember = target.getMember();
         Shape collectionTarget = context.getModel().expectShape(targetMember.getTarget());
-        String collectionTargetValue = getOutputValue(context, bindingType, "_entry", targetMember, collectionTarget);
+        String collectionTargetValue = getOutputValue(context, bindingType, "_entry.trim()",
+                targetMember, collectionTarget);
         switch (bindingType) {
             case HEADER:
                 // Split these values on commas.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -433,6 +433,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         if (target instanceof StringShape) {
             return HttpProtocolGeneratorUtils.getStringInputParam(context, target, dataSource);
+        } else if (target instanceof FloatShape || target instanceof DoubleShape) {
+            // Handle decimal numbers needing to have .0 in their value when whole numbers.
+            return "((" + dataSource + " % 1 == 0) ? " + dataSource + " + \".0\" : " + dataSource + ".toString())";
         } else if (isNativeSimpleType(target)) {
             return dataSource + ".toString()";
         } else if (target instanceof TimestampShape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -284,7 +284,7 @@ public final class HttpProtocolGeneratorUtils {
                     TypeScriptDependency.AWS_SDK_TYPES.packageName);
             // These responses will also have additional properties, so enable that on the interface.
             writer.write("let response: __SmithyException & __MetadataBearer & {[key: string]: any};");
-            writer.write("let errorCode: String = \"UnknownError\";");
+            writer.write("let errorCode: string = \"UnknownError\";");
             errorCodeGenerator.accept(context);
             writer.openBlock("switch (errorCode) {", "}", () -> {
                 // Generate the case statement for each error, invoking the specific deserializer.
@@ -300,6 +300,7 @@ public final class HttpProtocolGeneratorUtils {
                         String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
                         writer.openBlock("response = {", "}", () -> {
                             writer.write("...await $L($L, context),", errorDeserMethodName, outputParam);
+                            writer.write("name: errorCode,");
                             writer.write("$$metadata: deserializeMetadata(output),");
                         });
                     });

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/jest.config.js
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/jest.config.js
@@ -1,0 +1,7 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+    ...base,
+    // Only test cjs dist, avoid testing the package twice
+    testPathIgnorePatterns: ["/node_modules/", "/es/"]
+};

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -29,7 +29,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     isSuccess: boolean;
     code: number;
     headers: HeaderBag;
-    body: Readable;
+    body: String;
 
     constructor(
         isSuccess: boolean,
@@ -45,9 +45,9 @@ class ResponseDeserializationTestHandler implements HttpHandler {
             this.headers = headers;
         }
         if (body === undefined) {
-          body = "";
+            body = "";
         }
-        this.body = Readable.from([body]);
+        this.body = body;
     }
 
     handle(
@@ -58,7 +58,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
             response: {
                 statusCode: this.code,
                 headers: this.headers,
-                body: this.body
+                body: Readable.from([this.body])
             }
         });
     }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -19,8 +19,20 @@ const compareEquivalentBodies = (expectedBody: string, generatedBody: string): O
     tagValueProcessor: (val: any, tagName: any) => decodeEscapedXml(val)
   };
 
-  const expectedParts = xmlParse(expectedBody, parseConfig);
-  const generatedParts = xmlParse(generatedBody, parseConfig);
+  const parseXmlBody = (body: string) => {
+    const parsedObj = xmlParse(body, parseConfig);
+    const textNodeName = "#text";
+    const key = Object.keys(parsedObj)[0];
+    const parsedObjToReturn = parsedObj[key];
+    if (parsedObjToReturn[textNodeName]) {
+      parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
+      delete parsedObjToReturn[textNodeName];
+    }
+    return parsedObjToReturn;
+  };
+
+  const expectedParts = parseXmlBody(expectedBody);
+  const generatedParts = parseXmlBody(generatedBody);
 
   return compareParts(expectedParts, generatedParts);
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -23,14 +23,17 @@ public class HttpProtocolGeneratorUtilsTest {
 
     @Test
     public void givesCorrectTimestampSerialization() {
+        GenerationContext mockContext = new GenerationContext();
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
+        mockContext.setWriter(writer);
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
 
-        assertThat(DATA_SOURCE + ".toISOString()",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.DATE_TIME)));
+        assertThat("(" + DATA_SOURCE + ".toISOString().split('.')[0]+\"Z\")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.DATE_TIME)));
         assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
-        assertThat(DATA_SOURCE + ".toUTCString()",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(DATA_SOURCE, shape, Format.HTTP_DATE)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
+        assertThat("__dateToUtcString(" + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.HTTP_DATE)));
     }
 
     @Test


### PR DESCRIPTION
The following is a collection of fixes, broken down to individual commits, to common protocol code generation discovered while running the AWS protocol tests.

* Add default jest config to packages
* Fix issue with reusing body stream
* Update compareParts methodology
* Update parseXmlBody for comparisons
* Resolve several timestamp serde issues
This commit fixes default formatting for timestamps in headers
and query strings, defaulting to the protocol's setting for label
serialization. It also fixes input serialization issues, most notably
around serializing HTTP_DATE formatted timestamps. These methods (and
therefore their class) are made public so that protocols interact
with the timestampFormat trait can use them.
* Fix naming issues in error deserialization
* Serialize deicmals with '.0' when whole
* Trim collection header values on deser
* Always set a map for prefix headers
* Update collection input serialization
This commit updates collection serialization to properly handle
serializing from native Sets, to handle target value serialization,
and to join with ', ' for header values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
