### PR TITLE
Update protocol test code generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -377,7 +377,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
             writer.openBlock("Object.keys(paramsToValidate).forEach(param => {", "});", () -> {
                 writer.write("expect(r[param]).toBeDefined();");
-                writer.write("expect(r[param]).toBe(paramsToValidate[param]);");
+                writer.write("expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);");
             });
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -477,6 +477,17 @@ final class HttpProtocolTestGenerator implements Runnable {
                     }
                     writer.write("\n");
                 });
+                // Check for setting a potentially unspecified member value for the
+                // idempotency token.
+                // TODO Move a check to validation instead of filling here?
+                if (node.getMembers().isEmpty() && wrapperShape.isStructureShape()) {
+                    StructureShape structureShape = wrapperShape.asStructureShape().get();
+                    for (Map.Entry<String, MemberShape> entry : structureShape.getAllMembers().entrySet()) {
+                        if (entry.getValue().hasTrait(IdempotencyTokenTrait.class)) {
+                            writer.write("$L: \"00000000-0000-4000-8000-000000000000\",", entry.getKey());
+                        }
+                    }
+                }
                 this.workingShape = wrapperShape;
             });
             return null;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -454,7 +454,8 @@ final class HttpProtocolTestGenerator implements Runnable {
         @Override
         public Void objectNode(ObjectNode node) {
             // Both objects and maps can use a majority of the same logic.
-            writer.openBlock("{", "},\n", () -> {
+            // Use "as any" to have TS complain less about undefined entries.
+            writer.openBlock("{", "} as any,\n", () -> {
                 Shape wrapperShape = this.workingShape;
                 node.getMembers().forEach((keyNode, valueNode) -> {
                     writer.write("$L: ", keyNode.getValue());


### PR DESCRIPTION
The following is a collection of fixes, broken down to individual commits, to protocol test code generation discovered while generating and running the AWS protocol tests.

* Update name and tests for cleanliness
* Fix typing issues via 'as any'
* Add idempotency autofilling
* Use new response param comparator
* Update response content validation methods
* Improve request body and payload testing
* Update response body validation handling
This commit adds a private CommandOutputNodeVisitor class to handle
writing target output bodies to match their TS specific types.
This handles properly generating Date types for numbers that are
Timestamp shapes, "undefined" for nulls, boolean values, Uint8Array
types for blobs, and error Message field standardization.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
