### PR TITLE
Handle HTTP binding protocol requests with no HTTP bindings

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -108,7 +108,8 @@ final class HttpProtocolTestGenerator implements Runnable {
         OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
         TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
 
-        for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+        // Use a TreeSet to have a fixed ordering of tests.
+        for (OperationShape operation : new TreeSet<>(topDownIndex.getContainedOperations(service))) {
             // 1. Generate test cases for each request.
             operation.getTrait(HttpRequestTestsTrait.class).ifPresent(trait -> {
                 for (HttpRequestTestCase testCase : trait.getTestCases()) {


### PR DESCRIPTION
The main commit in this PR provides request bodies for operations that have no request bindings whatsoever. An additional small commit has been added to enforce sorting of operations when generating tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
