### PR TITLE
update runtime config customization to be fully overridable

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -95,6 +96,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                         runtimePlugins.add(runtimePlugin);
                     });
                 });
+        // Sort the integrations in specified order.
+        integrations.sort(Comparator.comparingInt(TypeScriptIntegration::getOrder));
 
         // Decorate the symbol provider using integrations.
         SymbolProvider resolvedProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -46,54 +46,55 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("NodeHttpHandler", "NodeHttpHandler",
                         TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                writer.write("new NodeHttpHandler()");
+                writer.write("requestHandler: new NodeHttpHandler(),");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_HASH_NODE);
                 writer.addImport("Hash", "Hash",
                         TypeScriptDependency.AWS_SDK_HASH_NODE.packageName);
-                writer.write("Hash.bind(null, \"sha256\")");
+                writer.write("sha256: Hash.bind(null, \"sha256\"),");
             },
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NODE);
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
-                writer.write("parseUrl");
+                writer.write("urlParser: parseUrl,");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
                         TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE.packageName);
-                writer.write("calculateBodyLength");
+                writer.write("bodyLengthChecker: calculateBodyLength,");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE);
                 writer.addImport("streamCollector", "streamCollector",
                         TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE.packageName);
+                writer.write("streamCollector,");
             },
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
                 writer.addImport("fromBase64", "fromBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
-                writer.write("fromBase64");
+                writer.write("base64Decoder: fromBase64,");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
                 writer.addImport("toBase64", "toBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
-                writer.write("toBase64");
+                writer.write("base64Encoder: toBase64,");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
                 writer.addImport("fromUtf8", "fromUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
-                writer.write("fromUtf8");
+                writer.write("utf8Decoder: fromUtf8,");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
-                writer.write("toUtf8");
+                writer.write("utf8Encoder: toUtf8,");
             },
             "defaultUserAgent", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
@@ -101,7 +102,7 @@ final class RuntimeConfigGenerator {
                         TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName);
                 writer.addImport("name", "name", "./package.json");
                 writer.addImport("version", "version", "./package.json");
-                writer.write("defaultUserAgent(name, version)");
+                writer.write("defaultUserAgent: defaultUserAgent(name, version),");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> browserRuntimeConfigDefaults = MapUtils.of(
@@ -109,54 +110,55 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("FetchHttpHandler", "FetchHttpHandler",
                         TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
-                writer.write("new FetchHttpHandler()");
+                writer.write("requestHandler: new FetchHttpHandler(),");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
                 writer.addImport("Sha256", "Sha256",
                         TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER.packageName);
-                writer.write("Sha256");
+                writer.write("sha256: Sha256,");
             },
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER);
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER.packageName);
-                writer.write("parseUrl");
+                writer.write("urlParser: parseUrl,");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
                         TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER.packageName);
-                writer.write("calculateBodyLength");
+                writer.write("bodyLengthChecker: calculateBodyLength,");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER);
                 writer.addImport("streamCollector", "streamCollector",
                         TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER.packageName);
+                writer.write("streamCollector,");
             },
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
                 writer.addImport("fromBase64", "fromBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
-                writer.write("fromBase64");
+                writer.write("base64Decoder: fromBase64,");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
                 writer.addImport("toBase64", "toBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
-                writer.write("toBase64");
+                writer.write("base64Encoder: toBase64,");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
                 writer.addImport("fromUtf8", "fromUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
-                writer.write("fromUtf8");
+                writer.write("utf8Decoder: fromUtf8,");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
-                writer.write("toUtf8");
+                writer.write("utf8Encoder: toUtf8,");
             },
             "defaultUserAgent", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER);
@@ -164,7 +166,7 @@ final class RuntimeConfigGenerator {
                         TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.packageName);
                 writer.addImport("name", "name", "./package.json");
                 writer.addImport("version", "version", "./package.json");
-                writer.write("defaultUserAgent(name, version)");
+                writer.write("defaultUserAgent: defaultUserAgent(name, version),");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
@@ -172,34 +174,35 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("FetchHttpHandler", "FetchHttpHandler",
                         TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
-                writer.write("new FetchHttpHandler({ bufferBody: true })");
+                writer.write("requestHandler: new FetchHttpHandler({ bufferBody: true }),");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
                 writer.addImport("Sha256", "Sha256",
                         TypeScriptDependency.AWS_CRYPTO_SHA256_JS.packageName);
-                writer.write("Sha256");
+                writer.write("sha256: Sha256,");
             },
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER);
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER.packageName);
-                writer.write("parseUrl");
+                writer.write("urlParser: parseUrl,");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN);
                 writer.addImport("streamCollector", "streamCollector",
                         TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN.packageName);
+                writer.write("streamCollector,");
             },
             "defaultUserAgent", writer -> {
                 writer.addImport("name", "name", "./package.json");
                 writer.addImport("version", "version", "./package.json");
-                writer.write("`aws-sdk-js-v3-react-native-$${name}/$${version}`");
+                writer.write("defaultUserAgent: `aws-sdk-js-v3-react-native-$${name}/$${version}`,");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(
             "disableHostPrefix", writer -> {
-                writer.write("false");
+                writer.write("disableHostPrefix: false,");
             }
     );
 
@@ -232,9 +235,10 @@ final class RuntimeConfigGenerator {
                 writer.indent();
                 Map<String, Consumer<TypeScriptWriter>> defaultConfigs =
                         new HashMap(getDefaultRuntimeConfigs(target));
-                //TODO: ensure integrations order is always desired.
                 Map<String, Consumer<TypeScriptWriter>> aggregatedConfigs = integrations.stream()
-                        .map(integration -> integration.addRuntimeConfigValues(settings, model, symbolProvider, target))
+                        .sorted(Comparator.comparingInt(TypeScriptIntegration::getOrder))
+                        .map(integration -> integration.getRuntimeConfigWriters(
+                                settings, model, symbolProvider, target))
                         .reduce(defaultConfigs, (aggregated, configMap) -> {
                             aggregated.putAll(configMap);
                             return aggregated;
@@ -242,10 +246,7 @@ final class RuntimeConfigGenerator {
                 aggregatedConfigs.entrySet().stream()
                         .sorted(Comparator.comparing(Map.Entry::getKey))
                         .forEach(entry -> {
-                            writer.onSection(entry.getKey(), text -> {
-                                entry.getValue().accept(writer);
-                            });
-                            writer.write(String.format("%s: ${L@%s},", entry.getKey(), entry.getKey()), "");
+                            entry.getValue().accept(writer);
                         });
                 writer.dedent();
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -15,11 +15,18 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import software.amazon.smithy.build.SmithyBuildException;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Generates runtime configuration files, files that are used to
@@ -34,6 +41,167 @@ final class RuntimeConfigGenerator {
     private final SymbolProvider symbolProvider;
     private final TypeScriptDelegator delegator;
     private final List<TypeScriptIntegration> integrations;
+    private final Map<String, Consumer<TypeScriptWriter>> nodeRuntimeConfigDefaults = MapUtils.of(
+            "requestHandler", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
+                writer.addImport("NodeHttpHandler", "NodeHttpHandler",
+                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
+                writer.write("new NodeHttpHandler()");
+            },
+            "sha256", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_HASH_NODE);
+                writer.addImport("Hash", "Hash",
+                        TypeScriptDependency.AWS_SDK_HASH_NODE.packageName);
+                writer.write("Hash.bind(null, \"sha256\")");
+            },
+            "urlParser", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NODE);
+                writer.addImport("parseUrl", "parseUrl",
+                        TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
+                writer.write("parseUrl");
+            },
+            "bodyLengthChecker", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
+                writer.addImport("calculateBodyLength", "calculateBodyLength",
+                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE.packageName);
+                writer.write("calculateBodyLength");
+            },
+            "streamCollector", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE);
+                writer.addImport("streamCollector", "streamCollector",
+                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE.packageName);
+            },
+            "base64Decoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
+                writer.addImport("fromBase64", "fromBase64",
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
+                writer.write("fromBase64");
+            },
+            "base64Encoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
+                writer.addImport("toBase64", "toBase64",
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
+                writer.write("toBase64");
+            },
+            "utf8Decoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
+                writer.addImport("fromUtf8", "fromUtf8",
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
+                writer.write("fromUtf8");
+            },
+            "utf8Encoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
+                writer.addImport("toUtf8", "toUtf8",
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
+                writer.write("toUtf8");
+            },
+            "defaultUserAgent", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
+                writer.addImport("defaultUserAgent", "defaultUserAgent",
+                        TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName);
+                writer.addImport("name", "name", "./package.json");
+                writer.addImport("version", "version", "./package.json");
+                writer.write("defaultUserAgent(name, version)");
+            }
+    );
+    private final Map<String, Consumer<TypeScriptWriter>> browserRuntimeConfigDefaults = MapUtils.of(
+            "requestHandler", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
+                writer.addImport("FetchHttpHandler", "FetchHttpHandler",
+                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
+                writer.write("new FetchHttpHandler()");
+            },
+            "sha256", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
+                writer.addImport("Sha256", "Sha256",
+                        TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER.packageName);
+                writer.write("Sha256");
+            },
+            "urlParser", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER);
+                writer.addImport("parseUrl", "parseUrl",
+                        TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER.packageName);
+                writer.write("parseUrl");
+            },
+            "bodyLengthChecker", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
+                writer.addImport("calculateBodyLength", "calculateBodyLength",
+                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER.packageName);
+                writer.write("calculateBodyLength");
+            },
+            "streamCollector", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER);
+                writer.addImport("streamCollector", "streamCollector",
+                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER.packageName);
+            },
+            "base64Decoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
+                writer.addImport("fromBase64", "fromBase64",
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
+                writer.write("fromBase64");
+            },
+            "base64Encoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
+                writer.addImport("toBase64", "toBase64",
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
+                writer.write("toBase64");
+            },
+            "utf8Decoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
+                writer.addImport("fromUtf8", "fromUtf8",
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
+                writer.write("fromUtf8");
+            },
+            "utf8Encoder", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
+                writer.addImport("toUtf8", "toUtf8",
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
+                writer.write("toUtf8");
+            },
+            "defaultUserAgent", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER);
+                writer.addImport("defaultUserAgent", "defaultUserAgent",
+                        TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.packageName);
+                writer.addImport("name", "name", "./package.json");
+                writer.addImport("version", "version", "./package.json");
+                writer.write("defaultUserAgent(name, version)");
+            }
+    );
+    private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
+            "requestHandler", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
+                writer.addImport("FetchHttpHandler", "FetchHttpHandler",
+                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
+                writer.write("new FetchHttpHandler({ bufferBody: true })");
+            },
+            "sha256", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
+                writer.addImport("Sha256", "Sha256",
+                        TypeScriptDependency.AWS_CRYPTO_SHA256_JS.packageName);
+                writer.write("Sha256");
+            },
+            "urlParser", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER);
+                writer.addImport("parseUrl", "parseUrl",
+                        TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER.packageName);
+                writer.write("parseUrl");
+            },
+            "streamCollector", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN);
+                writer.addImport("streamCollector", "streamCollector",
+                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN.packageName);
+            },
+            "defaultUserAgent", writer -> {
+                writer.addImport("name", "name", "./package.json");
+                writer.addImport("version", "version", "./package.json");
+                writer.write("`aws-sdk-js-v3-react-native-$${name}/$${version}`");
+            }
+    );
+    private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(
+            "disableHostPrefix", writer -> {
+                writer.write("false");
+            }
+    );
 
     RuntimeConfigGenerator(
             TypeScriptSettings settings,
@@ -62,12 +230,41 @@ final class RuntimeConfigGenerator {
             // Inject customizations into the ~template.
             writer.onSection("customizations", original -> {
                 writer.indent();
-                for (TypeScriptIntegration integration : integrations) {
-                    integration.addRuntimeConfigValues(settings, model, symbolProvider, writer, target);
-                }
+                Map<String, Consumer<TypeScriptWriter>> defaultConfigs =
+                        new HashMap(getDefaultRuntimeConfigs(target));
+                //TODO: ensure integrations order is always desired.
+                Map<String, Consumer<TypeScriptWriter>> aggregatedConfigs = integrations.stream()
+                        .map(integration -> integration.addRuntimeConfigValues(settings, model, symbolProvider, target))
+                        .reduce(defaultConfigs, (aggregated, configMap) -> {
+                            aggregated.putAll(configMap);
+                            return aggregated;
+                        });
+                aggregatedConfigs.entrySet().stream()
+                        .sorted(Comparator.comparing(Map.Entry::getKey))
+                        .forEach(entry -> {
+                            writer.onSection(entry.getKey(), text -> {
+                                entry.getValue().accept(writer);
+                            });
+                            writer.write(String.format("%s: ${L@%s},", entry.getKey(), entry.getKey()), "");
+                        });
                 writer.dedent();
             });
             writer.write(contents, "");
         });
+    }
+
+    private Map<String, Consumer<TypeScriptWriter>> getDefaultRuntimeConfigs(LanguageTarget target) {
+        switch (target) {
+            case NODE:
+                return nodeRuntimeConfigDefaults;
+            case BROWSER:
+                return browserRuntimeConfigDefaults;
+            case REACT_NATIVE:
+                return reactNativeRuntimeConfigDefaults;
+            case SHARED:
+                return sharedRuntimeConfigDefaults;
+            default:
+                throw new SmithyBuildException("Unknown target: " + target);
+        }
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -15,8 +15,11 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -29,6 +32,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 /**
  * Adds event streams if needed.
@@ -65,42 +69,43 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
     }
 
     @Override
-    public void addRuntimeConfigValues(
+    public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,
-            TypeScriptWriter writer,
             LanguageTarget target
     ) {
         if (!hasEventStream(model, settings.getService(model))) {
-            return;
+            return Collections.emptyMap();
         }
-
         switch (target) {
             case NODE:
-                writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
-                writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
-                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
-                writer.write("eventStreamSerdeProvider");
-                break;
+                return MapUtils.of("eventStreamSerdeProvider", writer -> {
+                    writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
+                    writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
+                    writer.write("eventStreamSerdeProvider");
+                });
             case BROWSER:
-                writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
-                writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
-                        TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
-                writer.write("eventStreamSerdeProvider");
-                break;
+                return MapUtils.of("eventStreamSerdeProvider", writer -> {
+                    writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
+                    writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
+                    writer.write("eventStreamSerdeProvider");
+                });
             case REACT_NATIVE:
                 // TODO: add ReactNative eventstream support
-                writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                writer.addImport("invalidFunction", "invalidFunction",
-                        TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                writer.openBlock("eventStreamSerdeProvider: () => ({", "})", () -> {
-                    writer.write("serialize: invalidFunction(\"event stream is not supported in ReactNative.\"),");
-                    writer.write("deserialize: invalidFunction(\"event stream is not supported in ReactNative.\")");
+                return MapUtils.of("eventStreamSerdeProvider", writer -> {
+                    writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
+                    writer.addImport("invalidFunction", "invalidFunction",
+                            TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                    writer.openBlock("eventStreamSerdeProvider: () => ({", "})", () -> {
+                        writer.write("serialize: invalidFunction(\"event stream is not supported in ReactNative.\"),");
+                        writer.write("deserialize: invalidFunction(\"event stream is not supported in ReactNative.\")");
+                    });
                 });
-                break;
             default:
-                // do nothing
+                return Collections.emptyMap();
         }
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -69,7 +69,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
     }
 
     @Override
-    public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
+    public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,
@@ -84,14 +84,14 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
-                    writer.write("eventStreamSerdeProvider");
+                    writer.write("eventStreamSerdeProvider,");
                 });
             case BROWSER:
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
-                    writer.write("eventStreamSerdeProvider");
+                    writer.write("eventStreamSerdeProvider,");
                 });
             case REACT_NATIVE:
                 // TODO: add ReactNative eventstream support
@@ -99,7 +99,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                     writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
                     writer.addImport("invalidFunction", "invalidFunction",
                             TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                    writer.openBlock("eventStreamSerdeProvider: () => ({", "})", () -> {
+                    writer.openBlock("eventStreamSerdeProvider: () => ({", "}),", () -> {
                         writer.write("serialize: invalidFunction(\"event stream is not supported in ReactNative.\"),");
                         writer.write("deserialize: invalidFunction(\"event stream is not supported in ReactNative.\")");
                     });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -261,7 +261,7 @@ public interface TypeScriptIntegration {
      *         // runtimeConfig file.
      *         Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
      *         config.put("foo", writer -> {
-     *            writer.write("foo: some static value,");
+     *            writer.write("foo: some static value,"); // Note the trailing comma!
      *         });
      *
      *         switch (target) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -261,18 +261,18 @@ public interface TypeScriptIntegration {
      *         // runtimeConfig file.
      *         Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
      *         config.put("foo", writer -> {
-     *            writer.write("some static value");
+     *            writer.write("foo: some static value,");
      *         });
      *
      *         switch (target) {
      *             case NODE:
      *                 config.put("bar", writer -> {
-     *                     writer.write("someNodeValue");
+     *                     writer.write("bar: someNodeValue,");
      *                 });
      *                 break;
      *             case BROWSER:
      *                 config.put("bar", writer -> {
-     *                     writer.write("someBrowserValue");
+     *                     writer.write("bar: someBrowserValue,");
      *                 });
      *                 break;
      *             case SHARED:

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -38,6 +38,22 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
  */
 public interface TypeScriptIntegration {
     /**
+     * Gets the sort order of the customization from -128 to 127.
+     *
+     * <p>Customizations are applied according to this sort order. Lower values
+     * are executed before higher values (for example, -128 comes before 0,
+     * comes before 127). Customizations default to 0, which is the middle point
+     * between the minimum and maximum order values. The customization
+     * applied later can override the runtime configurations that provided
+     * by customizations applied earlier.
+     *
+     * @return Returns the sort order, defaulting to 0.
+     */
+    default byte getOrder() {
+        return 0;
+    }
+
+    /**
      * Preprocess the model before code generation.
      *
      * <p>This can be used to remove unsupported features, remove traits
@@ -235,7 +251,7 @@ public interface TypeScriptIntegration {
      *
      *     private static final Logger LOGGER = Logger.getLogger(CodegenVisitor.class.getName());
      *
-     *     public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
+     *     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
      *             TypeScriptSettings settings,
      *             Model model,
      *             SymbolProvider symbolProvider,
@@ -279,7 +295,7 @@ public interface TypeScriptIntegration {
      * <pre>
      * {@code
      * public final class MyIntegration2 implements TypeScriptIntegration {
-     *     public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
+     *     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
      *             TypeScriptSettings settings,
      *             Model model,
      *             SymbolProvider symbolProvider,
@@ -303,7 +319,7 @@ public interface TypeScriptIntegration {
      * @param target The TypeScript language target.
      * @return Returns a map of config property name and a consumer function with TypeScriptWriter parameter.
      */
-    default Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
+    default Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.build.PluginContext;
@@ -234,29 +235,36 @@ public interface TypeScriptIntegration {
      *
      *     private static final Logger LOGGER = Logger.getLogger(CodegenVisitor.class.getName());
      *
-     *     public void addRuntimeConfigValues(
+     *     public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
      *             TypeScriptSettings settings,
      *             Model model,
      *             SymbolProvider symbolProvider,
-     *             TypeScriptWriter writer,
      *             LanguageTarget target
      *     ) {
      *         // This is a static value that is added to every generated
      *         // runtimeConfig file.
-     *         writer.write("foo: 'some-static-value',"); // Note the trailing comma!
+     *         Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
+     *         config.put("foo", writer -> {
+     *            writer.write("some static value");
+     *         });
      *
      *         switch (target) {
      *             case NODE:
-     *                 writer.write("bar: someNodeValue,");
+     *                 config.put("bar", writer -> {
+     *                     writer.write("someNodeValue");
+     *                 });
      *                 break;
      *             case BROWSER:
-     *                 writer.write("bar: someBrowserValue,");
+     *                 config.put("bar", writer -> {
+     *                     writer.write("someBrowserValue");
+     *                 });
      *                 break;
      *             case SHARED:
      *                 break;
      *             default:
      *                 LOGGER.warn("Unknown target: " + target);
      *         }
+     *         return config;
      *     }
      * }
      * }</pre>
@@ -271,18 +279,19 @@ public interface TypeScriptIntegration {
      * <pre>
      * {@code
      * public final class MyIntegration2 implements TypeScriptIntegration {
-     *     public void addRuntimeConfigValues(
+     *     public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
      *             TypeScriptSettings settings,
      *             Model model,
      *             SymbolProvider symbolProvider,
-     *             TypeScriptWriter writer,
      *             LanguageTarget target
      *     ) {
      *         if (target == LanguageTarget.SHARED) {
-     *             String someTraitValue = settings.getModel(model).getTrait(SomeTrait.class)
-     *                          .map(SomeTrait::getValue)
-     *                          .orElse("");
-     *             writer.write("someTraitValue: $S,", someTraitValue);
+     *             return MapUtils.of("someTraitValue", writer -> {
+     *                 String someTraitValue = settings.getModel(model).getTrait(SomeTrait.class)
+     *                             .map(SomeTrait::getValue)
+     *                             .orElse("");
+     *                 writer.write("someTraitValue: $S,", someTraitValue);
+     *             });
      *         }
      *     }
      * }
@@ -291,16 +300,15 @@ public interface TypeScriptIntegration {
      * @param settings Settings used to generate.
      * @param model Model to generate from.
      * @param symbolProvider Symbol provider used for codegen.
-     * @param writer TypeScript writer to write to.
      * @param target The TypeScript language target.
+     * @return Returns a map of config property name and a consumer function with TypeScriptWriter parameter.
      */
-    default void addRuntimeConfigValues(
+    default Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,
-            TypeScriptWriter writer,
             LanguageTarget target
     ) {
-        // pass
+        return Collections.emptyMap();
     }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -1,27 +1,8 @@
-import { Sha256 } from "@aws-crypto/sha256-browser";
-import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
-import { parseUrl } from "@aws-sdk/url-parser-browser";
-import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
-import { streamCollector } from "@aws-sdk/stream-collector-browser";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
-import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
-import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
-import { name, version } from "./package.json";
 import { ClientDefaults } from "${clientModuleName}";
 import { ClientSharedValues } from "./runtimeConfig.shared";
 
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...ClientSharedValues,
-  requestHandler: new FetchHttpHandler(),
-  sha256: Sha256,
-  urlParser: parseUrl,
-  bodyLengthChecker: calculateBodyLength,
-  streamCollector,
-  base64Decoder: fromBase64,
-  base64Encoder: toBase64,
-  utf8Decoder: fromUtf8,
-  utf8Encoder: toUtf8,
-  defaultUserAgent: defaultUserAgent(name, version),
   runtime: "browser",
 ${customizations}
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
@@ -1,18 +1,8 @@
-import { FetchHttpHandler } from "@aws-sdk/fetch-http-handler";
-import { Sha256 } from "@aws-crypto/sha256-js";
-import { streamCollector } from "@aws-sdk/stream-collector-native";
-import { parseUrl } from "@aws-sdk/url-parser-node";
-import { name, version } from "./package.json";
 import { ClientDefaults } from "${clientModuleName}";
 import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
 
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
-  requestHandler: new FetchHttpHandler({ bufferBody: true }),
-  sha256: Sha256,
-  streamCollector,
-  urlParser: parseUrl,
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
   runtime: "react-native",
 ${customizations}
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
@@ -1,5 +1,4 @@
 export const ClientSharedValues = {
   apiVersion: "${apiVersion}",
-  disableHostPrefix: false,
 ${customizations}
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -1,27 +1,8 @@
-import { Hash } from "@aws-sdk/hash-node";
-import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
-import { parseUrl } from "@aws-sdk/url-parser-node";
-import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
-import { streamCollector } from "@aws-sdk/stream-collector-node";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
-import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
-import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
-import { name, version } from "./package.json";
 import { ClientDefaults } from "${clientModuleName}";
 import { ClientSharedValues } from "./runtimeConfig.shared";
 
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...ClientSharedValues,
-  requestHandler: new NodeHttpHandler(),
-  sha256: Hash.bind(null, "sha256"),
-  urlParser: parseUrl,
-  bodyLengthChecker: calculateBodyLength,
-  streamCollector,
-  base64Decoder: fromBase64,
-  base64Encoder: toBase64,
-  utf8Decoder: fromUtf8,
-  utf8Encoder: toUtf8,
-  defaultUserAgent: defaultUserAgent(name, version),
   runtime: "node",
 ${customizations}
 };

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -4,7 +4,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
@@ -22,14 +26,17 @@ public class RuntimeConfigGeneratorTest {
         List<TypeScriptIntegration> integrations = new ArrayList<>();
         integrations.add(new TypeScriptIntegration() {
             @Override
-            public void addRuntimeConfigValues(
+            public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
                     TypeScriptSettings settings,
                     Model model,
                     SymbolProvider symbolProvider,
-                    TypeScriptWriter writer,
                     LanguageTarget target
             ) {
-                writer.write("syn: 'ack',");
+                Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
+                config.put("syn", writer -> {
+                    writer.write("'ack'");
+                });
+                return config;
             }
         });
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -26,7 +26,7 @@ public class RuntimeConfigGeneratorTest {
         List<TypeScriptIntegration> integrations = new ArrayList<>();
         integrations.add(new TypeScriptIntegration() {
             @Override
-            public Map<String, Consumer<TypeScriptWriter>> addRuntimeConfigValues(
+            public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
                     TypeScriptSettings settings,
                     Model model,
                     SymbolProvider symbolProvider,
@@ -34,7 +34,27 @@ public class RuntimeConfigGeneratorTest {
             ) {
                 Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
                 config.put("syn", writer -> {
-                    writer.write("'ack'");
+                    writer.write("syn: 'ack1',");
+                });
+                return config;
+            }
+        });
+
+        integrations.add(new TypeScriptIntegration() {
+            @Override
+            public byte getOrder() {
+                return 1;
+            }
+            @Override
+            public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
+                    TypeScriptSettings settings,
+                    Model model,
+                    SymbolProvider symbolProvider,
+                    LanguageTarget target
+            ) {
+                Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
+                config.put("syn", writer -> {
+                    writer.write("syn: 'ack2',");
                 });
                 return config;
             }
@@ -64,19 +84,19 @@ public class RuntimeConfigGeneratorTest {
         // Does the runtimeConfig.shared.ts file expand the template properties properly?
         String runtimeConfigSharedContents = manifest.getFileString("runtimeConfig.shared.ts").get();
         assertThat(runtimeConfigSharedContents, containsString("apiVersion: \"1.0.0\","));
-        assertThat(runtimeConfigSharedContents, containsString("syn: 'ack',"));
+        assertThat(runtimeConfigSharedContents, containsString("syn: 'ack2',"));
 
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack',"));
+        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.browser.ts").get();
         assertThat(runtimeConfigBrowserContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack',"));
+        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
 
         // Does the runtimeConfig.native.ts file expand the browser template properties properly?
         String runtimeConfigNativeContents = manifest.getFileString("runtimeConfig.native.ts").get();
@@ -84,6 +104,6 @@ public class RuntimeConfigGeneratorTest {
                 containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigNativeContents,
                 containsString("import { ClientDefaultValues as BrowserDefaults } from \"./runtimeConfig.browser\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack',"));
+        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -36,6 +36,9 @@ public class RuntimeConfigGeneratorTest {
                 config.put("syn", writer -> {
                     writer.write("syn: 'ack1',");
                 });
+                config.put("foo", writer -> {
+                    writer.write("foo: 'bar',");
+                });
                 return config;
             }
         });
@@ -85,18 +88,21 @@ public class RuntimeConfigGeneratorTest {
         String runtimeConfigSharedContents = manifest.getFileString("runtimeConfig.shared.ts").get();
         assertThat(runtimeConfigSharedContents, containsString("apiVersion: \"1.0.0\","));
         assertThat(runtimeConfigSharedContents, containsString("syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
 
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.browser.ts").get();
         assertThat(runtimeConfigBrowserContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
 
         // Does the runtimeConfig.native.ts file expand the browser template properties properly?
         String runtimeConfigNativeContents = manifest.getFileString("runtimeConfig.native.ts").get();
@@ -105,5 +111,6 @@ public class RuntimeConfigGeneratorTest {
         assertThat(runtimeConfigNativeContents,
                 containsString("import { ClientDefaultValues as BrowserDefaults } from \"./runtimeConfig.browser\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
     }
 }


### PR DESCRIPTION
Previously, some default runtime config values are hard-coded into
templates. This change makes each one of the properties(e.g. requestHandler)
to be overridable by customizations from SDK side. If no customization
exists, the generator can still generate SDK with proper dependencies.

This change is added to support the customization of using WebSocket
requestHandler.

This change also brings in the capability that customization applied
later can override the runtime config values added in earlier
customization. This is necessary sometimes. For example, if customization
A adds runtime config: {x: X, y: Y}. x and y are deeply coupled that
they need to be in the same customization. If there's a single client
needs runtime config {x: X, y: Y-update}, we should be able to make
a new customization overriding the original customization.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
