### PR TITLE
Additional test and protocol codegen fixes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -40,6 +40,7 @@ import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.IoUtils;
 
 /**
  * Utility methods for generating HTTP protocols.
@@ -231,6 +232,16 @@ public final class HttpProtocolGeneratorUtils {
         });
 
         writer.write("");
+    }
+
+    /**
+     * Writes any additional utils needed for HTTP protocols with bindings.
+     *
+     * @param context The generation context.
+     */
+    static void generateHttpBindingUtils(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+        writer.write(IoUtils.readUtf8Resource(HttpProtocolGeneratorUtils.class, "http-binding-utils.ts"));
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-binding-utils.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-binding-utils.ts
@@ -1,0 +1,6 @@
+function isSerializableHeaderValue(value: any): boolean {
+  return value !== undefined
+      && value !== ""
+      && (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0)
+      && (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
+}


### PR DESCRIPTION
### Fix issues with output node visitor
This commit updates the CommandOutputNodeVisitor to downcase any
keys in ObjectNode that represent HttpPrefixHeaders. It also fixes
an issue writing NullNode entries.

### Fix issue filling idempotency tokens

### Fix several serde issues with HTTP headers

This commit fixes casing comparison issues related to fetch for HTTP
bindings of headers and prefix headers for both request and response.
It also includes a fix to more robustly validate headers before
serialization.

### Fix issue parsing lists of HTTP_DATE timestamps

### Skip generating tests marked server-only

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
