### PR TITLE
client destroy method will call SmithyClient destroy by default

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -324,6 +324,8 @@ final class ServiceGenerator implements Runnable {
         // Generates the destroy() method, and calls the destroy() method of
         // any runtime plugin that claims to have a destroy method.
         writer.openBlock("destroy(): void {", "}", () -> {
+            // Always call destroy() in SmithyClient class. By default, it's optional.
+            writer.write("super.destroy();");
             writer.pushState(CLIENT_DESTROY_SECTION);
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 plugin.getDestroyFunction().ifPresent(destroy -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -324,8 +324,6 @@ final class ServiceGenerator implements Runnable {
         // Generates the destroy() method, and calls the destroy() method of
         // any runtime plugin that claims to have a destroy method.
         writer.openBlock("destroy(): void {", "}", () -> {
-            // Always call destroy() in SmithyClient class. By default, it's optional.
-            writer.write("super.destroy();");
             writer.pushState(CLIENT_DESTROY_SECTION);
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 plugin.getDestroyFunction().ifPresent(destroy -> {
@@ -333,6 +331,8 @@ final class ServiceGenerator implements Runnable {
                 });
             }
             writer.popState();
+            // Always call destroy() in SmithyClient class. By default, it's optional.
+            writer.write("super.destroy();");
         });
     }
 }


### PR DESCRIPTION
Currently all the clientRuntimeCustomization can have a `destroy()` function. But the default configs in smithy client [doesn't have one](https://github.com/aws/aws-sdk-js-v3/blob/77386f6fac5fe2644f1b60a77050975c0327b6e0/packages/smithy-client/src/client.ts#L27). 

This change will make the service client call the `destroy()` from smithy client. By default the `SmithyClient.destroy()` is an empty function. But if the `requestHandler` in SmithyClient has a `destroy`, service client will call the function when callling the destroy on the service client. 

Related: https://github.com/aws/aws-sdk-js-v3/pull/1081

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
