### PR TITLE
Fix doc for event stream serde provider

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -74,8 +74,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
             "^1.0.0-beta.0", false),
     AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-beta.0", false),
     AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "^1.0.0-beta.0", false),
-    AWS_SDK_EVENTSTREAM_SIGNER_NODE("dependencies", "@aws-sdk/eventstream-signer-node","^1.0.0-alpha.0", false),
-    MIDDLEWARE_EVENTSTREAM_SIGNING("dependencies", "@aws-sdk/middleware-eventstream-signing", "^1.0.0-alpha.0", false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^5.2.2", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -74,6 +74,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
             "^1.0.0-beta.0", false),
     AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-beta.0", false),
     AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "^1.0.0-beta.0", false),
+    AWS_SDK_EVENTSTREAM_SIGNER_NODE("dependencies", "@aws-sdk/eventstream-signer-node","^1.0.0-alpha.0", false),
+    MIDDLEWARE_EVENTSTREAM_SIGNING("dependencies", "@aws-sdk/middleware-eventstream-signing", "^1.0.0-alpha.0", false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^5.2.2", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -64,7 +64,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
         writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER);
         writer.addImport("EventStreamSerdeProvider", "__EventStreamSerdeProvider",
                 TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.writeDocs("The function that provides necessary utilities for generating and signing event stream");
+        writer.writeDocs("The function that provides necessary utilities for generating and parsing event stream");
         writer.write("eventStreamSerdeProvider?: __EventStreamSerdeProvider;\n");
     }
 


### PR DESCRIPTION
Because event stream signing is not a Smithy implementation. So make the doc clear about this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
