### PR TITLE
Update namespace comment for NonErrorStructure

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -77,9 +77,8 @@ final class StructureGenerator implements Runnable {
      * }
      *
      * export namespace Person {
-     *   export const ID = "smithy.example#Person";
      *   export function isa(o: any): o is Person {
-     *     return __isa(o, ID);
+     *     return __isa(o, "Person");
      *   }
      * }
      * }</pre>


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/pull/25

*Description of changes:*
The comment was updated for ErrorStructure in https://github.com/awslabs/smithy-typescript/pull/25, but got missed for NonErrorStructure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
