### PR TITLE
[WIP]fix: not to override path and query from serializer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -227,6 +227,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
             }
 
+            writer.write("const endpoint = {...context.endpoint, path: undefined, query: undefined};");
             writer.openBlock("return new $T({", "});", requestType, () -> {
                 if (hasHostPrefix) {
                     writer.write("hostname: resolvedHostname,");
@@ -247,7 +248,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 }
                 // Always set the body,
                 writer.write("body: body,");
-                writer.write("...context.endpoint,");
+                writer.write("...endpoint,");
             });
         });
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -107,12 +107,13 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                        + "  resolvedHostname: string | undefined,\n"
                        + "  body: any,\n"
                        + "): $T => {", "};", requestType, () -> {
+            writer.write("const endpoint = {...context.endpoint, path: undefined, query: undefined};");
             writer.openBlock("const contents: any = {", "};", () -> {
                 writer.write("protocol: \"https\",");
                 writer.write("method: \"POST\",");
                 writer.write("path: path,");
                 writer.write("headers: headers,");
-                writer.write("...context.endpoint,");
+                writer.write("...endpoint,");
             });
             writer.openBlock("if (resolvedHostname !== undefined) {", "}", () -> {
                 writer.write("contents.hostname = resolvedHostname;");


### PR DESCRIPTION
**This PR is WIP**

Fix a bug introduced in #158. By default the parsed endpoint will have a default `path`: `/`, which will then incorrectly override the path from operation model. By this change, the default endpoint or endpoint supplied from client constructor can only override [the `hostname`, `protocol`, and `port` part of the request](https://github.com/aws/aws-sdk-js-v3/blob/fde80bf7a538ebf8739c80254d5df529333d7093/packages/types/src/http.ts#L66-L68). Whereas `path` and `query` will always be generated from the model.  This behavior will also [be align with V2 SDK](https://github.com/aws/aws-sdk-js/blob/c59526b78241e63b15b15554c66c5e22411edcd0/lib/protocol/rest.js#L67).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
