### PR TITLE
fix: resolve endpoint in command serializer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -227,16 +227,19 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
             }
 
+            writer.write("const {hostname, protocol = \"https\", port} = await context.endpoint();");
             writer.openBlock("return new $T({", "});", requestType, () -> {
                 if (hasHostPrefix) {
                     writer.write("hostname: resolvedHostname,");
                 }
-                writer.write("protocol: \"https\",");
+                writer.write("protocol,");
+                writer.write("hostname,");
+                writer.write("port,");
                 writer.write("method: $S,", trait.getMethod());
-                writer.write("headers: headers,");
+                writer.write("headers,");
                 writer.write("path: resolvedPath,");
                 if (hasQueryComponents) {
-                    writer.write("query: query,");
+                    writer.write("query,");
                 }
                 if (!bodyBindings.isEmpty()) {
                     // Track all shapes bound to the body so their serializers may be generated.
@@ -246,8 +249,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             .forEach(serializingDocumentShapes::add);
                 }
                 // Always set the body,
-                writer.write("body: body,");
-                writer.write("...context.endpoint,");
+                writer.write("body,");
             });
         });
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -227,6 +227,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
             }
 
+            // Get the hostname, port, and scheme from client's resolved endpoint. Then construct the request from
+            // them. The client's resolved endpoint can be default one or supplied by users.
             writer.write("const {hostname, protocol = \"https\", port} = await context.endpoint();");
             writer.openBlock("return new $T({", "});", requestType, () -> {
                 if (hasHostPrefix) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -107,6 +107,8 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                        + "  resolvedHostname: string | undefined,\n"
                        + "  body: any,\n"
                        + "): Promise<$T> => {", "};", requestType, () -> {
+            // Get the hostname, port, and scheme from client's resolved endpoint. Then construct the request from
+            // them. The client's resolved endpoint can be default one or supplied by users.
             writer.write("const {hostname, protocol = \"https\", port} = await context.endpoint();");
             writer.openBlock("const contents: any = {", "};", () -> {
                 writer.write("protocol,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -100,19 +100,21 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         writer.addUseImports(requestType);
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
-        writer.openBlock("const buildHttpRpcRequest = (\n"
+        writer.openBlock("const buildHttpRpcRequest = async (\n"
                        + "  context: __SerdeContext,\n"
                        + "  headers: __HeaderBag,\n"
                        + "  path: string,\n"
                        + "  resolvedHostname: string | undefined,\n"
                        + "  body: any,\n"
-                       + "): $T => {", "};", requestType, () -> {
+                       + "): Promise<$T> => {", "};", requestType, () -> {
+            writer.write("const {hostname, protocol = \"https\", port} = await context.endpoint();");
             writer.openBlock("const contents: any = {", "};", () -> {
-                writer.write("protocol: \"https\",");
+                writer.write("protocol,");
+                writer.write("hostname,");
+                writer.write("port,");
                 writer.write("method: \"POST\",");
-                writer.write("path: path,");
-                writer.write("headers: headers,");
-                writer.write("...context.endpoint,");
+                writer.write("path,");
+                writer.write("headers,");
             });
             writer.openBlock("if (resolvedHostname !== undefined) {", "}", () -> {
                 writer.write("contents.hostname = resolvedHostname;");


### PR DESCRIPTION
Replaces: #161 
Fixes: #158
CodeGen: https://github.com/aws/aws-sdk-js-v3/pull/1106

The SerDeContext contains endpoint config that used to be [a provider
function returning a promise of Endpoint](https://github.com/aws/aws-sdk-js-v3/blob/fde80bf7a538ebf8739c80254d5df529333d7093/packages/types/src/serde.ts#L9-L11),
and it is resolved in [serializer middleware](https://github.com/aws/aws-sdk-js-v3/blob/fde80bf7a538ebf8739c80254d5df529333d7093/packages/middleware-serde/src/serializerMiddleware.ts#L23-L26). It introduces mismatch
between SerDeContext type and the value, where the value contains
resolved endpoint but the type is a provider function returning Endpoint
promise. This change assumes the SerDeContext.endpoint is actually
a provider function and only resolve the promise when constructing
a request.

This change also fixes a bug introduced in #160. By default the parsed
endpoint will have a default `path`: `/`, which will then incorrectly 
override the path from operation model. By this change, the default 
endpoint or endpoint supplied from client constructor can only override 
[the `hostname`, `protocol`, and `port` part of the request](https://github.com/aws/aws-sdk-js-v3/blob/fde80bf7a538ebf8739c80254d5df529333d7093/packages/types/src/http.ts#L66-L68). 
Whereas `path` and `query` will always be generated from the model. 
This behavior will also [be align with V2 SDK](https://github.com/aws/aws-sdk-js/blob/c59526b78241e63b15b15554c66c5e22411edcd0/lib/protocol/rest.js#L67)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
