### PR TITLE
Convert isa method to an arrow function

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -174,9 +174,9 @@ final class StructureGenerator implements Runnable {
         writer.addImport("isa", "__isa", "@aws-sdk/smithy-client");
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
-            writer.openBlock("export function isa(o: any): o is $L {", "}", symbol.getName(), () -> {
-                writer.write("return __isa(o, $S);", shape.getId().getName());
-            });
+            writer.write("export const isa = (o: any): o is $L => __isa(o, $S);",
+                symbol.getName(), shape.getId().getName()
+            );
         });
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Converts isa method to an arrow function
* Arrow functions are preferred over classic function expression because of their verbosity, and lexical binding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
