### PR TITLE
Use Array shorthand - Type[] instead of Array<Type>

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -124,7 +124,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol listShape(ListShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return createSymbolBuilder(shape, format("%s[]", reference.getName()), null)
+        return createSymbolBuilder(shape, format("(%s)[]", reference.getName()), null)
                 .addReference(reference)
                 .build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -124,7 +124,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol listShape(ListShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return createSymbolBuilder(shape, format("Array<%s>", reference.getName()), null)
+        return createSymbolBuilder(shape, format("%s[]", reference.getName()), null)
                 .addReference(reference)
                 .build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -372,7 +372,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      * const deserializeAws_restJson1_1ParameterList = (
      *   output: any,
      *   context: SerdeContext
-     * ): Array<Parameter> => {
+     * ): Parameter[] => {
      *   return (output || []).map((entry: any) =>
      *     deserializeAws_restJson1_1Parameter(entry, context)
      *   );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -366,7 +366,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *
      * <pre>{@code
      * const serializeAws_restJson1_1ParametersList = (
-     *   input: Array<Parameter>,
+     *   input: Parameter[],
      *   context: SerdeContext
      * ): any => {
      *   return (input || []).map(entry =>

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -101,7 +101,7 @@ public class SymbolProviderTest {
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol listSymbol = provider.toSymbol(list);
 
-        assertThat(listSymbol.getName(), equalTo("Array<_Record>"));
+        assertThat(listSymbol.getName(), equalTo("(_Record)[]"));
     }
 
     @Test

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -118,7 +118,7 @@ public class DocumentMemberDeserVisitorTest {
                 .namespace("com.smithy.example", "/")
                 .build();
         private Symbol collectionMock = Symbol.builder()
-                .name("Array<Foo>")
+                .name("Foo[]")
                 .namespace("com.smithy.example", "/")
                 .build();
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -121,7 +121,7 @@ public class DocumentMemberSerVisitorTest {
                 .namespace("com.smithy.example", "/")
                 .build();
         private Symbol collectionMock = Symbol.builder()
-                .name("Array<Foo>")
+                .name("Foo[]")
                 .namespace("com.smithy.example", "/")
                 .build();
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGeneratorTest.java
@@ -39,7 +39,7 @@ public class ProtocolGeneratorTest {
                 .member(member)
                 .build();
         Symbol symbol = Symbol.builder()
-                .name("Array<Foo>")
+                .name("Foo[]")
                 .namespace("com.smithy.example", ".")
                 .putProperty("shape", list)
                 .build();
@@ -72,7 +72,7 @@ public class ProtocolGeneratorTest {
                 .member(member)
                 .build();
         Symbol symbol = Symbol.builder()
-                .name("Array<Foo>")
+                .name("Foo[]")
                 .namespace("com.smithy.example", ".")
                 .putProperty("shape", list)
                 .build();


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1126

*Description of changes:*
Use Array shorthand - `Type[]` instead of `Array<Type>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
