### PR TITLE
add default body value before collecting body stream

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -204,8 +204,8 @@ public final class HttpProtocolGeneratorUtils {
 
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.write("// Collect low-level response body stream to Uint8Array.");
-        writer.openBlock("const collectBody = (streamBody: any, context: __SerdeContext): Promise<Uint8Array> => {",
-                "};", () -> {
+        writer.openBlock("const collectBody = (streamBody: any = new Uint8Array(), context: __SerdeContext): "
+                + "Promise<Uint8Array> => {", "};", () -> {
             writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
                 writer.write("return Promise.resolve(streamBody);");
             });


### PR DESCRIPTION
*Description of changes:*
This changle makes parseBody() function handles empty body. It is useful when testing or request hendler fakes response.

Related: https://github.com/aws/aws-sdk-js-v3/pull/1131

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
