### PR TITLE
Use array for SetShape

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -457,12 +457,6 @@ final class HttpProtocolTestGenerator implements Runnable {
             String openElement = "[";
             String closeElement = "]";
 
-            // Handle sets needing to use the Set typing instead of standard array syntax.
-            if (workingShape.isSetShape()) {
-                openElement = "new Set(" + openElement;
-                closeElement = closeElement + ")";
-            }
-
             // Write the value out directly.
             writer.openBlock("$L\n", closeElement + ",\n", openElement, () -> {
                 Shape wrapperShape = this.workingShape;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -132,7 +132,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol setShape(SetShape shape) {
         Symbol reference = toSymbol(shape.getMember());
-        return createSymbolBuilder(shape, format("Set<%s>", reference.getName()), null)
+        return createSymbolBuilder(shape, format("(%s)[]", reference.getName()), null)
                 .addReference(reference)
                 .build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -442,7 +442,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      * const deserializeAws_restJson1_1ParameterSet = (
      *   output: any,
      *   context: SerdeContext
-     * ): Set<Parameter> => {
+     * ): Parameter[] => {
      *   return (output || []).map((entry: any) =>
      *     deserializeAws_restJson1_1Parameter(entry, context)
      *   );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -437,7 +437,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *
      * <pre>{@code
      * const serializeAws_restJson1_1ParametersSet = (
-     *   input: Set<Parameter>,
+     *   input: Parameter[],
      *   context: SerdeContext
      * ): any => {
      *   return (input || []).map(entry =>

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1397,10 +1397,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 // Iterate over each entry and do deser work.
                 outputParam += ".map(_entry => " + collectionTargetValue + ")";
 
-                // Make sets when necessary.
-                if (target.isSetShape()) {
-                    outputParam = "new Set(" + outputParam + ")";
-                }
                 return outputParam;
             default:
                 throw new CodegenException("Unexpected collection binding location `" + bindingType + "`");

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -100,10 +100,6 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
   let localExpected = expected;
-  // Handle comparing sets to arrays properly.
-  if (expected instanceof Set) {
-    localExpected = Array.from(expected);
-  }
 
   // Short circuit on equality.
   if (localExpected == generated) {


### PR DESCRIPTION
*Issue #, if available:*
We decided to use Array for SetShape in internal discussions for similar reasons to why Objects are used instead of Map:
* new Set needs to be created by calling `new Set()`, just like `new Map()`
* `setObj.has(value)` is similar to `objMap.get(key)`

Smithy specification for Set https://awslabs.github.io/smithy/spec/core.html#set

```console
Not all languages support set data structures with non-scalar values. Such languages SHOULD represent sets as a custom set data structure that can interpret value hash codes and equality. Alternatively, clients MAY store the values of a set data structure in a list and rely on the service to ensure uniqueness.
```

*Description of changes:*
Use array for SetShape

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
