### PR TITLE
Convert visit method to an arrow function

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -92,10 +92,10 @@ import software.amazon.smithy.utils.StringUtils;
  *     bear: (value: Bear) => T;
  *     _: (name: string, value: any) => T;
  *   }
- *   export function visit<T>(
+ *   export const visit = <T>(
  *     value: Attacker,
  *     visitor: Visitor<T>
- *   ): T {
+ *   ): T => {
  *     if (value.lion !== undefined) return visitor.lion(value.lion);
  *     if (value.tiger !== undefined) return visitor.tiger(value.tiger);
  *     if (value.bear !== undefined) return visitor.bear(value.bear);
@@ -193,10 +193,10 @@ final class UnionGenerator implements Runnable {
 
     private void writeVisitorFunction() {
         // Create the visitor dispatcher for the union.
-        writer.write("export function visit<T>(").indent();
+        writer.write("export const visit = <T>(").indent();
         writer.write("value: $L,", symbol.getName());
         writer.write("visitor: Visitor<T>");
-        writer.dedent().write("): T {").indent();
+        writer.dedent().write("): T => {").indent();
         for (MemberShape member : shape.getAllMembers().values()) {
             String memberName = symbolProvider.toMemberName(member);
             writer.write("if (value.${1L} !== undefined) return visitor.$1L(value.${1L});", memberName);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
@@ -85,10 +85,10 @@ public class UnionGeneratorTest {
                                           + "  }"));
 
         // It generates the actual visitor function.
-        assertThat(output, containsString("export function visit<T>(\n"
+        assertThat(output, containsString("export const visit = <T>(\n"
                                           + "    value: Example,\n"
                                           + "    visitor: Visitor<T>\n"
-                                          + "  ): T {\n"
+                                          + "  ): T => {\n"
                                           + "    if (value.A !== undefined) return visitor.A(value.A);\n"
                                           + "    if (value.B !== undefined) return visitor.B(value.B);\n"
                                           + "    if (value.C !== undefined) return visitor.C(value.C);\n"


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/awslabs/smithy-typescript/pull/163

*Description of changes:*
* Converts visit method to an arrow function
* Arrow functions are preferred over classic function expression because of their verbosity, and lexical binding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
