### PR TITLE
Convert protocol functions to arrow functions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -213,10 +213,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
         String contextType = CodegenUtils.getOperationSerializerContextType(writer, context.getModel(), operation);
 
-        writer.openBlock("export async function $L(\n"
+        writer.openBlock("export const $L = async(\n"
                        + "  input: $T,\n"
                        + "  context: $L\n"
-                       + "): Promise<$T> {", "}", methodName, inputType, contextType, requestType, () -> {
+                       + "): Promise<$T> => {", "}", methodName, inputType, contextType, requestType, () -> {
             writeHeaders(context, operation, bindingIndex);
             writeResolvedPath(context, operation, bindingIndex, trait);
             boolean hasQueryComponents = writeRequestQueryString(context, operation, bindingIndex, trait);
@@ -847,10 +847,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         String contextType = CodegenUtils.getOperationDeserializerContextType(writer, context.getModel(), operation);
 
         // Handle the general response.
-        writer.openBlock("export async function $L(\n"
+        writer.openBlock("export const $L = async(\n"
                        + "  output: $T,\n"
                        + "  context: $L\n"
-                       + "): Promise<$T> {", "}", methodName, responseType, contextType, outputType, () -> {
+                       + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
             // Redirect error deserialization to the dispatcher if we receive an error range
             // status code that's not the modeled code (400 or higher). This allows for
             // returning other 2XX or 3XX codes that don't match the defined value.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -274,10 +274,10 @@ public final class HttpProtocolGeneratorUtils {
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
         String errorMethodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()) + "Error";
 
-        writer.openBlock("async function $L(\n"
+        writer.openBlock("const $L = async(\n"
                        + "  output: $T,\n"
                        + "  context: __SerdeContext,\n"
-                       + "): Promise<$T> {", "}", errorMethodName, responseType, outputType, () -> {
+                       + "): Promise<$T> => {", "}", errorMethodName, responseType, outputType, () -> {
             // Prepare error response for parsing error code. If error code needs to be parsed from response body
             // then we collect body and parse it to JS object, otherwise leave the response body as is.
             if (shouldParseErrorBody) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -166,10 +166,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
 
-        writer.openBlock("export async function $L(\n"
+        writer.openBlock("export const $L = async(\n"
                        + "  input: $T,\n"
                        + "  context: __SerdeContext\n"
-                       + "): Promise<$T> {", "}", methodName, inputType, requestType, () -> {
+                       + "): Promise<$T> => {", "}", methodName, inputType, requestType, () -> {
             writeRequestHeaders(context, operation);
             boolean hasRequestBody = writeRequestBody(context, operation);
             boolean hasHostPrefix = operation.hasTrait(EndpointTrait.class);
@@ -313,10 +313,10 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
 
         // Handle the general response.
-        writer.openBlock("export async function $L(\n"
+        writer.openBlock("export const $L = async(\n"
                        + "  output: $T,\n"
                        + "  context: __SerdeContext\n"
-                       + "): Promise<$T> {", "}", methodName, responseType, outputType, () -> {
+                       + "): Promise<$T> => {", "}", methodName, responseType, outputType, () -> {
             // Redirect error deserialization to the dispatcher
             writer.openBlock("if (output.statusCode >= 400) {", "}", () -> {
                 writer.write("return $L(output, context);", errorMethodName);


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/pull/163

*Description of changes:*
* Converts protocol functions method to an arrow function
* Arrow functions are preferred over classic function expression because of their verbosity, and lexical binding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
