### PR TITLE
Define headers while declaring

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -356,7 +356,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.openBlock("const headers: any = {", "};",
             () -> {
                 writer.write("'Content-Type': $S,", bindingIndex.determineRequestContentType(
-                    operation, getDocumentContentType()));
+                        operation, getDocumentContentType()));
                 writeDefaultHeaders(context, operation);
 
                 operation.getInput().ifPresent(outputId -> {
@@ -365,9 +365,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         String memberLocation = "input." + symbolProvider.toMemberName(binding.getMember());
                         Shape target = model.expectShape(binding.getMember().getTarget());
                         String headerValue = getInputValue(context, binding.getLocation(), memberLocation + "!",
-                            binding.getMember(), target);
+                                binding.getMember(), target);
                         writer.write("...isSerializableHeaderValue($L) && { $S: $L },",
-                            memberLocation, binding.getLocationName(), headerValue);
+                                memberLocation, binding.getLocationName(), headerValue);
                     }
         
                     // Handle assembling prefix headers.
@@ -385,7 +385,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                                     () -> {
                                         // Use a ! since we already validated the input member is defined above.
                                         String headerValue = getInputValue(context, binding.getLocation(),
-                                            memberLocation + "![suffix]", binding.getMember(), target);
+                                                memberLocation + "![suffix]", binding.getMember(), target);
                                         // Append the prefix to key.
                                         writer.write("acc[$S + suffix] = $L;", binding.getLocationName(), headerValue);
                                         writer.write("return acc;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -353,40 +353,49 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         // Headers are always present either from the default document or the payload.
-        writer.write("const headers: any = {};");
-        writer.write("headers['Content-Type'] = $S;", bindingIndex.determineRequestContentType(
-                operation, getDocumentContentType()));
-        writeDefaultHeaders(context, operation);
+        writer.openBlock("const headers: any = {", "};",
+            () -> {
+                writer.write("'Content-Type': $S,", bindingIndex.determineRequestContentType(
+                    operation, getDocumentContentType()));
+                writeDefaultHeaders(context, operation);
 
-        operation.getInput().ifPresent(outputId -> {
-            Model model = context.getModel();
-            for (HttpBinding binding : bindingIndex.getRequestBindings(operation, Location.HEADER)) {
-                String memberLocation = "input." + symbolProvider.toMemberName(binding.getMember());
-                writer.openBlock("if (isSerializableHeaderValue($1L)) {", "}", memberLocation, () -> {
-                    Shape target = model.expectShape(binding.getMember().getTarget());
-                    String headerValue = getInputValue(context, binding.getLocation(), memberLocation + "!",
+                operation.getInput().ifPresent(outputId -> {
+                    Model model = context.getModel();
+                    for (HttpBinding binding : bindingIndex.getRequestBindings(operation, Location.HEADER)) {
+                        String memberLocation = "input." + symbolProvider.toMemberName(binding.getMember());
+                        Shape target = model.expectShape(binding.getMember().getTarget());
+                        String headerValue = getInputValue(context, binding.getLocation(), memberLocation + "!",
                             binding.getMember(), target);
-                    writer.write("headers[$S] = $L;", binding.getLocationName(), headerValue);
+                        writer.write("...isSerializableHeaderValue($L) && { $S: $L },",
+                            memberLocation, binding.getLocationName(), headerValue);
+                    }
+        
+                    // Handle assembling prefix headers.
+                    for (HttpBinding binding : bindingIndex.getRequestBindings(operation, Location.PREFIX_HEADERS)) {
+                        String memberLocation = "input." + symbolProvider.toMemberName(binding.getMember());
+                        MapShape prefixMap = model.expectShape(binding.getMember().getTarget()).asMapShape().get();
+                        Shape target = model.expectShape(prefixMap.getValue().getTarget());
+                        // Iterate through each entry in the member.
+                        writer.openBlock(
+                            "...($L !== undefined) && Object.keys($L).reduce(",
+                            "),",
+                            memberLocation, memberLocation,
+                            () -> {
+                                writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
+                                    () -> {
+                                        // Use a ! since we already validated the input member is defined above.
+                                        String headerValue = getInputValue(context, binding.getLocation(),
+                                            memberLocation + "![suffix]", binding.getMember(), target);
+                                        // Append the prefix to key.
+                                        writer.write("acc[$S + suffix] = $L;", binding.getLocationName(), headerValue);
+                                        writer.write("return acc;");
+                                    });
+                            }
+                        );
+                    }
                 });
             }
-
-            // Handle assembling prefix headers.
-            for (HttpBinding binding : bindingIndex.getRequestBindings(operation, Location.PREFIX_HEADERS)) {
-                String memberLocation = "input." + symbolProvider.toMemberName(binding.getMember());
-                writer.openBlock("if ($L !== undefined) {", "}", memberLocation, () -> {
-                    MapShape prefixMap = model.expectShape(binding.getMember().getTarget()).asMapShape().get();
-                    Shape target = model.expectShape(prefixMap.getValue().getTarget());
-                    // Iterate through each entry in the member.
-                    writer.openBlock("Object.keys($L).forEach(suffix => {", "});", memberLocation, () -> {
-                        // Use a ! since we already validated the input member is defined above.
-                        String headerValue = getInputValue(context, binding.getLocation(),
-                                memberLocation + "![suffix]", binding.getMember(), target);
-                        // Append the suffix to the defined prefix and serialize the value in to that key.
-                        writer.write("headers[$S + suffix] = $L;", binding.getLocationName(), headerValue);
-                    });
-                });
-            }
-        });
+        );
     }
 
     private List<HttpBinding> writeRequestBody(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -611,7 +611,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * <p>For example:
      *
      * <pre>{@code
-     * headers['foo'] = "This is a custom header";
+     *   "foo": "This is a custom header",
      * }</pre>
      *
      * @param context The generation context.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -376,10 +376,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         MapShape prefixMap = model.expectShape(binding.getMember().getTarget()).asMapShape().get();
                         Shape target = model.expectShape(prefixMap.getValue().getTarget());
                         // Iterate through each entry in the member.
-                        writer.openBlock(
-                            "...($L !== undefined) && Object.keys($L).reduce(",
-                            "),",
-                            memberLocation, memberLocation,
+                        writer.openBlock("...($1L !== undefined) && Object.keys($1L).reduce(", "),", memberLocation,
                             () -> {
                                 writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
                                     () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -240,7 +240,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      * <p>For example:
      *
      * <pre>{@code
-     * headers['foo'] = "This is a custom header";
+     *   "foo": "This is a custom header",
      * }</pre>
      *
      * @param context The generation context.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -193,9 +193,12 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // The Content-Type header is always present.
         writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
-        writer.write("const headers: __HeaderBag = {};");
-        writer.write("headers['Content-Type'] = $S;", getDocumentContentType());
-        writeDefaultHeaders(context, operation);
+        writer.openBlock("const headers: __HeaderBag = {", "};",
+            () -> {
+                writer.write("'Content-Type': $S,", getDocumentContentType());
+                writeDefaultHeaders(context, operation);
+            }
+        );
     }
 
     private boolean writeRequestBody(GenerationContext context, OperationShape operation) {


### PR DESCRIPTION
*Issue #, if available:*
Solution encouraged from https://github.com/awslabs/smithy-typescript/pull/170

*Description of changes:*
* Simple headers:
  * Before:
  ```javascript
  const headers: __HeaderBag = {};
  headers["Content-Type"] = "application/x-amz-json-1.0";
  headers["X-Amz-Target"] = "DynamoDB_20120810.DescribeEndpoints";
  ```
  * After:
  ```javascript
  const headers: __HeaderBag = {
    "Content-Type": "application/x-amz-json-1.0",
    "X-Amz-Target": "DynamoDB_20120810.DescribeEndpoints"
  };
  ```
* headers with if statements:
  * Before:
  ```javascript
  const headers: any = {};
  headers["Content-Type"] = "";
  if (isSerializableHeaderValue(input.ACL)) {
    headers["x-amz-acl"] = input.ACL!;
  }
  if (input.Metadata !== undefined) {
    Object.keys(input.Metadata).forEach(suffix => {
      headers["x-amz-meta-" + suffix] = input.Metadata![suffix];
    });
  }
  ```
  * After:
  ```javascript
  const headers: any = {
    "Content-Type": "",
    ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
    ...(input.Metadata !== undefined &&
      Object.keys(input.Metadata).reduce(
        (acc: __HeaderBag, suffix: string) => {
          acc["x-amz-meta-" + suffix] = input.Metadata![suffix];
          return acc;
        },
        {}
      ))
  };
  ```

Tested in TypeScript playground: https://tiny.amazon.com/13gpi1fsk

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
