### PR TITLE
Remove redundant return from collectBodyString and isSerializableHeaderValue

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -226,11 +226,8 @@ public final class HttpProtocolGeneratorUtils {
 
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.write("// Encode Uint8Array data into string with utf-8.");
-        writer.openBlock("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => {",
-                "};", () -> {
-            writer.write("return collectBody(streamBody, context).then(body => context.utf8Encoder(body));");
-        });
-
+        writer.write("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => " +
+            "collectBody(streamBody, context).then(body => context.utf8Encoder(body))");
         writer.write("");
     }
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-binding-utils.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-binding-utils.ts
@@ -1,6 +1,6 @@
-function isSerializableHeaderValue(value: any): boolean {
-  return value !== undefined
-      && value !== ""
-      && (!Object.getOwnPropertyNames(value).includes("length") || value.length != 0)
-      && (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);
-}
+const isSerializableHeaderValue = (value: any): boolean =>
+  value !== undefined &&
+  value !== "" &&
+  (!Object.getOwnPropertyNames(value).includes("length") ||
+    value.length != 0) &&
+  (!Object.getOwnPropertyNames(value).includes("size") || value.size != 0);


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/aws/aws-sdk-js-v3/pull/1145

*Description of changes:*
Remove redundant return from collectBodyString and isSerializableHeaderValue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
