### PR TITLE
refactor http request handlers

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -66,9 +66,9 @@ final class RuntimeConfigGenerator {
                 writer.write("bodyLengthChecker: calculateBodyLength,");
             },
             "streamCollector", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE);
+                writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_NODE.packageName);
+                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
                 writer.write("streamCollector,");
             },
             "base64Decoder", writer -> {
@@ -130,9 +130,9 @@ final class RuntimeConfigGenerator {
                 writer.write("bodyLengthChecker: calculateBodyLength,");
             },
             "streamCollector", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_WEB);
+                writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_WEB.packageName);
+                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
                 writer.write("streamCollector,");
             },
             "base64Decoder", writer -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -130,9 +130,9 @@ final class RuntimeConfigGenerator {
                 writer.write("bodyLengthChecker: calculateBodyLength,");
             },
             "streamCollector", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER);
+                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_WEB);
                 writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_BROWSER.packageName);
+                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_WEB.packageName);
                 writer.write("streamCollector,");
             },
             "base64Decoder", writer -> {
@@ -169,12 +169,6 @@ final class RuntimeConfigGenerator {
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
-            "requestHandler", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
-                writer.addImport("FetchHttpHandler", "FetchHttpHandler",
-                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
-                writer.write("requestHandler: new FetchHttpHandler({ bufferBody: true }),");
-            },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
                 writer.addImport("Sha256", "Sha256",
@@ -186,12 +180,6 @@ final class RuntimeConfigGenerator {
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
                 writer.write("urlParser: parseUrl,");
-            },
-            "streamCollector", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN);
-                writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_STREAM_COLLECTOR_RN.packageName);
-                writer.write("streamCollector,");
             },
             "defaultUserAgent", writer -> {
                 writer.addImport("name", "name", "./package.json");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -46,8 +46,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^1.0.0-beta.0", true),
 
     AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^1.0.0-beta.0", true),
-    AWS_SDK_STREAM_COLLECTOR_BROWSER("dependencies", "@aws-sdk/stream-collector-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_STREAM_COLLECTOR_RN("dependencies", "@aws-sdk/stream-collector-native", "^1.0.0-beta.0", true),
+    AWS_SDK_STREAM_COLLECTOR_WEB("dependencies", "@aws-sdk/stream-collector-web", "^1.0.0-beta.0", true),
 
     AWS_SDK_URL_PARSER_BROWSER("dependencies", "@aws-sdk/url-parser-browser", "^1.0.0-beta.0", true),
     AWS_SDK_URL_PARSER_NODE("dependencies", "@aws-sdk/url-parser-node", "^1.0.0-beta.0", true),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -45,9 +45,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.0.0-alpha.0", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^1.0.0-beta.0", true),
 
-    AWS_SDK_STREAM_COLLECTOR_NODE("dependencies", "@aws-sdk/stream-collector-node", "^1.0.0-beta.0", true),
-    AWS_SDK_STREAM_COLLECTOR_WEB("dependencies", "@aws-sdk/stream-collector-web", "^1.0.0-beta.0", true),
-
     AWS_SDK_URL_PARSER_BROWSER("dependencies", "@aws-sdk/url-parser-browser", "^1.0.0-beta.0", true),
     AWS_SDK_URL_PARSER_NODE("dependencies", "@aws-sdk/url-parser-node", "^1.0.0-beta.0", true),
 


### PR DESCRIPTION
Related: https://github.com/aws/aws-sdk-js-v3/pull/1186

1. Merge `stream-collector-native` with `stream-collector-native`;
1. Move stream collectors into corresponding http handler;
1. Use the same `fetch-http-handler` for both RN and browsers.

See the linked PR's description for more context. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
