### PR TITLE
remove eventstream prohibition in reactnative

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -93,17 +93,6 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
                     writer.write("eventStreamSerdeProvider,");
                 });
-            case REACT_NATIVE:
-                // TODO: add ReactNative eventstream support
-                return MapUtils.of("eventStreamSerdeProvider", writer -> {
-                    writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                    writer.addImport("invalidFunction", "invalidFunction",
-                            TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                    writer.openBlock("eventStreamSerdeProvider: () => ({", "}),", () -> {
-                        writer.write("serialize: invalidFunction(\"event stream is not supported in ReactNative.\"),");
-                        writer.write("deserialize: invalidFunction(\"event stream is not supported in ReactNative.\")");
-                    });
-                });
             default:
                 return Collections.emptyMap();
         }


### PR DESCRIPTION
As https://github.com/aws/aws-sdk-js-v3/pull/1216 lands, JS SDK has a eventstream serde package compatible with RN. So we need to remove the RN prohibition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
