### PR TITLE
Update for Smithy 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+
+jdk:
+- oraclejdk8
+- openjdk8
+- openjdk11
+
+sudo: true
+
+dist: trusty
+
+install: /bin/true
+
+script: ./gradlew clean build -Plog-tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 allprojects {
     group = "software.amazon.smithy"
-    version = "0.1.0"
+    version = "0.2.0"
 }
 
 // The root project doesn't produce a JAR.
@@ -203,6 +203,19 @@ subprojects {
         apply(plugin = "checkstyle")
 
         tasks["checkstyleTest"].enabled = false
+
+        /*
+         * Tests
+         * ====================================================
+         *
+         * Configure the running of tests.
+         */
+        // Log on passed, skipped, and failed test events if the `-Plog-tests` property is set.
+        if (project.hasProperty("log-tests")) {
+            tasks.test {
+                testLogging.events("passed", "skipped", "failed")
+            }
+        }
 
         /*
          * Code coverage

--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -19,7 +19,7 @@ extra["moduleName"] = "software.amazon.smithy.typescript.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.4.3")
+    id("software.amazon.smithy").version("0.5.1")
 }
 
 repositories {
@@ -29,5 +29,5 @@ repositories {
 
 dependencies {
     implementation(project(":smithy-typescript-codegen"))
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:0.9.9")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.0.5")
 }

--- a/smithy-typescript-codegen-test/model/more-nesting.smithy
+++ b/smithy-typescript-codegen-test/model/more-nesting.smithy
@@ -1,4 +1,4 @@
-$version: "0.4.0"
+$version: "1.0"
 namespace example.weather.nested.more
 
 structure Baz {

--- a/smithy-typescript-codegen-test/model/nested.smithy
+++ b/smithy-typescript-codegen-test/model/nested.smithy
@@ -1,4 +1,4 @@
-$version: "0.4.0"
+$version: "1.0"
 namespace example.weather.nested
 
 structure Foo {

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -6,7 +6,6 @@
             "targetNamespace": "Weather",
             "package": "weather",
             "packageVersion": "0.0.1",
-            "protocol": "aws.rest-json-1.1",
             "packageJson": {
                 "license": "Apache-2.0"
             }

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -18,6 +18,6 @@ extra["displayName"] = "Smithy :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.typescript.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:0.9.9")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:0.9.9")
+    api("software.amazon.smithy:smithy-codegen-core:1.0.5")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:1.0.5")
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/EnumGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/EnumGenerator.java
@@ -18,7 +18,7 @@ package software.amazon.smithy.typescript.codegen;
 import java.util.Comparator;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 
 /**
@@ -78,7 +78,7 @@ final class EnumGenerator implements Runnable {
 
     // Unnamed enums generate a union of string literals.
     private void generateUnnamedEnum() {
-        String variants = TypeScriptUtils.getEnumVariants(enumTrait.getValues().keySet());
+        String variants = TypeScriptUtils.getEnumVariants(enumTrait.getEnumDefinitionValues());
         writer.write("export type $L = $L", symbol.getName(), variants);
     }
 
@@ -88,18 +88,17 @@ final class EnumGenerator implements Runnable {
             // Sort the named values to ensure a stable order and sane diffs.
             // TODO: Should we just sort these in the trait itself?
             enumTrait.getValues()
-                    .entrySet()
                     .stream()
-                    .sorted(Comparator.comparing(e -> e.getValue().getName().get()))
-                    .forEach(entry -> writeNamedEnumConstant(entry.getKey(), entry.getValue()));
+                    .sorted(Comparator.comparing(e -> e.getName().get()))
+                    .forEach(this::writeNamedEnumConstant);
         });
     }
 
-    private void writeNamedEnumConstant(String value, EnumConstantBody body) {
+    private void writeNamedEnumConstant(EnumDefinition body) {
         assert body.getName().isPresent();
 
         String name = body.getName().get();
         body.getDocumentation().ifPresent(writer::writeDocs);
-        writer.write("$L = $S,", TypeScriptUtils.sanitizePropertyName(name), value);
+        writer.write("$L = $S,", TypeScriptUtils.sanitizePropertyName(name), body.getValue());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -79,6 +79,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
     private final TypeScriptSettings settings;
     private final Model model;
+    private final ShapeId protocol;
     private final ServiceShape service;
     private final SymbolProvider symbolProvider;
     private final Symbol serviceSymbol;
@@ -93,11 +94,13 @@ final class HttpProtocolTestGenerator implements Runnable {
     HttpProtocolTestGenerator(
             TypeScriptSettings settings,
             Model model,
+            ShapeId protocol,
             SymbolProvider symbolProvider,
             TypeScriptDelegator delegator
     ) {
         this.settings = settings;
         this.model = model;
+        this.protocol = protocol;
         this.service = settings.getService(model);
         this.symbolProvider = symbolProvider;
         this.delegator = delegator;
@@ -146,7 +149,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
     // Only generate test cases when its protocol matches the target protocol.
     private <T extends HttpMessageTestCase> void onlyIfProtocolMatches(T testCase, Runnable runnable) {
-        if (testCase.getProtocol().equals(settings.getProtocol())) {
+        if (testCase.getProtocol().equals(protocol)) {
             LOGGER.fine(() -> format("Generating protocol test case for %s.%s", service.getId(), testCase.getId()));
             allocateWriterIfNeeded();
             runnable.run();
@@ -164,7 +167,7 @@ final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private String createTestCaseFilename() {
-        String baseName = settings.getProtocol().toLowerCase(Locale.ENGLISH)
+        String baseName = protocol.getName().toLowerCase(Locale.US)
                 .replace("-", "_")
                 .replace(".", "_");
         return TEST_CASE_FILE_TEMPLATE.replace("%s", baseName);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
-import software.amazon.smithy.model.pattern.Pattern;
+import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -386,10 +386,10 @@ public final class HttpProtocolGeneratorUtils {
             writer.addImport("isValidHostname", "__isValidHostname",
                     TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP.packageName);
             writer.write("resolvedHostname = $S + resolvedHostname;", trait.getHostPrefix().toString());
-            List<Pattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();
+            List<SmithyPattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();
             StructureShape inputShape = context.getModel().expectShape(operation.getInput()
                     .get(), StructureShape.class);
-            for (Pattern.Segment label : prefixLabels) {
+            for (SmithyPattern.Segment label : prefixLabels) {
                 MemberShape member = inputShape.getMember(label.getContent()).get();
                 String memberName = symbolProvider.toMemberName(member);
                 writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L)",

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -103,6 +103,8 @@ public class CodegenVisitorTest {
     @Test void throwsOnShapesThatCannotBeCondensed() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("simple-service-with-shape-conflict.smithy"))
+                .addImport(getClass().getResource("simple-service-with-shape-conflict-2.smithy"))
+                .addImport(getClass().getResource("simple-service-with-shape-conflict-3.smithy"))
                 .assemble()
                 .unwrap();
         MockManifest manifest = new MockManifest();
@@ -122,6 +124,8 @@ public class CodegenVisitorTest {
     @Test void successfullyCondensesShapesThatMatch() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("simple-service-with-condensible-shapes.smithy"))
+                .addImport(getClass().getResource("simple-service-with-condensible-shapes-2.smithy"))
+                .addImport(getClass().getResource("simple-service-with-condensible-shapes-3.smithy"))
                 .assemble()
                 .unwrap();
         MockManifest manifest = new MockManifest();

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
@@ -7,15 +7,15 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.traits.EnumConstantBody;
+import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
 
 public class EnumGeneratorTest {
     @Test
     public void generatesNamedEnums() {
         EnumTrait trait = EnumTrait.builder()
-                .addEnum("FOO", EnumConstantBody.builder().name("FOO").build())
-                .addEnum("BAR", EnumConstantBody.builder().name("BAR").build())
+                .addEnum(EnumDefinition.builder().value("FOO").name("FOO").build())
+                .addEnum(EnumDefinition.builder().value("BAR").name("BAR").build())
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
@@ -30,8 +30,8 @@ public class EnumGeneratorTest {
     @Test
     public void generatesUnnamedEnums() {
         EnumTrait trait = EnumTrait.builder()
-                .addEnum("FOO", EnumConstantBody.builder().build())
-                .addEnum("BAR", EnumConstantBody.builder().build())
+                .addEnum(EnumDefinition.builder().value("FOO").build())
+                .addEnum(EnumDefinition.builder().value("BAR").build())
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-empty.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-empty.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [DoSomething]
 }
 
-operation DoSomething() errors [Err]
+operation DoSomething{
+    errors: [Err]
+}
 
 @error("client")
 structure Err {}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-optional-message.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-optional-message.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [DoSomething]
 }
 
-operation DoSomething() errors [Err]
+operation DoSomething {
+    errors: [Err]
+}
 
 @error("client")
 structure Err {

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-required-message.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-required-message.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [DoSomething]
 }
 
-operation DoSomething() errors [Err]
+operation DoSomething {
+    errors: [Err]
+}
 
 @error("client")
 structure Err {

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-retryable-throttling.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-retryable-throttling.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [DoSomething]
 }
 
-operation DoSomething() errors [Err]
+operation DoSomething {
+    errors: [Err]
+}
 
 @error("client")
 @retryable(throttling: true)

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-retryable.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/error-test-retryable.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [DoSomething]
 }
 
-operation DoSomething() errors [Err]
+operation DoSomething {
+    errors: [Err]
+}
 
 @error("client")
 @retryable

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/endpoint-trait.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/endpoint-trait.smithy
@@ -1,6 +1,5 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
@@ -8,7 +7,11 @@ service Example {
 
 @readonly
 @endpoint(hostPrefix: "{foo}.data.")
-operation GetFoo(GetFooInput) -> GetFooOutput
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
 structure GetFooInput {
     @required
     @hostLabel

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/output-structure.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/output-structure.smithy
@@ -1,12 +1,16 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput) -> GetFooOutput errors [GetFooError]
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
 structure GetFooInput {}
 structure GetFooOutput {}
 

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes-2.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes-2.smithy
@@ -1,0 +1,7 @@
+namespace smithy.example
+
+@suppress(["Service"])
+structure Bar {
+    @required
+    baz: String
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes-3.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes-3.smithy
@@ -1,0 +1,7 @@
+namespace another.example
+
+@suppress(["Service"])
+structure Bar {
+    @required
+    baz: String
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-condensible-shapes.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     @required
@@ -15,18 +16,3 @@ structure GetFooInput {
     @required
     baz: another.example#Bar
 }
-
-namespace smithy.example
-
-structure Bar {
-    @required
-    baz: String
-}
-
-namespace another.example
-
-structure Bar {
-    @required
-    baz: String
-}
-

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-operation.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-operation.smithy
@@ -1,11 +1,10 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo()
+operation GetFoo {}
 
 

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict-2.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict-2.smithy
@@ -1,0 +1,7 @@
+namespace smithy.example
+
+@suppress(["Service"])
+structure Bar {
+    @required
+    baz: String
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict-3.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict-3.smithy
@@ -1,0 +1,7 @@
+namespace another.example
+
+@suppress(["Service"])
+structure Bar {
+    @required
+    qux: String
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service-with-shape-conflict.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     @required
@@ -15,18 +16,3 @@ structure GetFooInput {
     @required
     baz: another.example#Bar
 }
-
-namespace smithy.example
-
-structure Bar {
-    @required
-    baz: String
-}
-
-namespace another.example
-
-structure Bar {
-    @required
-    qux: String
-}
-

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/simple-service.smithy
@@ -1,6 +1,5 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0"
 }

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-list.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-list.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: NamesList

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-map.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-map.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: NamesMap

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-simple-shape.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-simple-shape.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     firstname: String,

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-structure.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-insensitive-structure.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: User

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-list-with-sensitive-data.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-list-with-sensitive-data.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: UserList

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-list-with-sensitive-member.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-list-with-sensitive-member.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: PhoneNumbersList

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-map-with-sensitive-data.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-map-with-sensitive-data.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: UserMap

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-map-with-sensitive-member.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-map-with-sensitive-member.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: PhoneNumbersMap

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-recursive-shapes.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-recursive-shapes.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: User

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-list.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-list.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: SecretNamesList

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-map.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-map.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: SecretNamesMap

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-list.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-list.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     @sensitive

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-map.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-map.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     @sensitive

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-structure.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-member-pointing-to-structure.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     @sensitive

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-simple-shape.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-simple-shape.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     username: String,

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-structure.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-sensitive-structure.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: SecretUser

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-structure-with-sensitive-data.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-structure-with-sensitive-data.smithy
@@ -1,12 +1,13 @@
 namespace smithy.example
 
-@protocols([{name: "aws.rest-json-1.1"}])
 service Example {
     version: "1.0.0",
     operations: [GetFoo]
 }
 
-operation GetFoo(GetFooInput)
+operation GetFoo {
+    input: GetFooInput
+}
 
 structure GetFooInput {
     foo: User


### PR DESCRIPTION
This commit updates the build plugin to version 0.2.0.

This commit updates to the GA version of Smithy tooling. It includes
necessary updates to handle changes in protocol traits, enums, streaming
components, and other assorted breaks.

Minor updates to the HttpProtocolTestGenerator have been made so that
tests are generated for supported protocols even if not specified
explicitly in the smithy-build.json file.

A .travis.yml configuration file has also been added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
