### PR TITLE
Add Troubleshooting section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ repository:
 You can find the build artifacts of the test package at:
 `build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen`
 
+## Troubleshooting
+
+Most of the issues with Gradle can be fixed by stopping the daemon by running `./gradlew --stop`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can find the build artifacts of the test package at:
 
 ## Troubleshooting
 
-Most of the issues with Gradle can be fixed by stopping the daemon by running `./gradlew --stop`
+Many Gradle issues can be fixed by stopping the daemon by running `./gradlew --stop`
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add Troubleshooting section in README with instructions to run `./gradlew --stop`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
