### PR TITLE
Delete unnecessary commands remove-js and remove-map from package.json

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -3,15 +3,13 @@
   "description": "${packageDescription}",
   "version": "${packageVersion}",
   "scripts": {
-    "clean": "npm run remove-definitions && npm run remove-dist && npm run remove-js && npm run remove-maps",
+    "clean": "npm run remove-definitions && npm run remove-dist",
     "build-documentation": "npm run clean && typedoc ./",
     "prepublishOnly": "yarn build",
     "pretest": "tsc",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
-    "remove-js": "rimraf *.js && rimraf ./commands/*.js && rimraf ./models/*.js && rimraf ./protocols/*.js",
-    "remove-maps": "rimraf *.js.map && rimraf ./commands/*.js.map && rimraf ./models/*.js.map && rimraf ./protocols/*.js.map",
     "test": "yarn build && jest --coverage --passWithNoTests",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn pretest && yarn build:es"


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1409

*Description of changes:*
Delete unnecessary commands remove-js and remove-map from package.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
