### PR TITLE
Add build:cjs command

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -6,13 +6,14 @@
     "clean": "npm run remove-definitions && npm run remove-dist",
     "build-documentation": "npm run clean && typedoc ./",
     "prepublishOnly": "yarn build",
-    "pretest": "tsc",
+    "pretest": "yarn build:cjs",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",
     "test": "yarn build && jest --coverage --passWithNoTests",
+    "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn pretest && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1410

*Description of changes:*
Add build:cjs command to standardize scripts between clients and packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
