### PR TITLE
Remove devDependency tslib

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
  */
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
-    TS_LIB("devDependencies", "tslib", "^1.8.0", true),
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "1.0.0-gamma.3", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "^1.0.0-beta.0", true),
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "^1.0.0-beta.0", true),

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDependencyTest.java
@@ -21,8 +21,6 @@ public class TypeScriptDependencyTest {
     @Test
     public void getsUnconditionalDependencies() {
         assertThat(TypeScriptDependency.getUnconditionalDependencies(),
-                   hasItem(TypeScriptDependency.TS_LIB.dependency));
-        assertThat(TypeScriptDependency.getUnconditionalDependencies(),
                    hasItem(TypeScriptDependency.AWS_SDK_CLIENT_DOCGEN.dependency));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1416

*Description of changes:*
tslib needs to be a dependency and not a devDependency https://www.npmjs.com/package/tslib

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
