### PR TITLE
Update dependencies to match that in aws-sdk-js-v3

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -29,54 +29,54 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "1.0.0-gamma.3", true),
-    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "^1.0.0-beta.0", true),
-    AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "^1.0.0-beta.0", true),
-    INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", "^1.0.0-beta.0", true),
-    CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", "^1.0.0-beta.0", true),
+    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "1.0.0-gamma.0", true),
+    AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "1.0.0-gamma.0", true),
+    INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", "1.0.0-gamma.0", true),
+    CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", "1.0.0-gamma.0", true),
     TYPES_NODE("devDependencies", "@types/node", "^12.7.5", true),
 
-    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", "^1.0.0-beta.0", true),
-    MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", "^1.0.0-beta.0", true),
-    MIDDLEWARE_USER_AGENT("dependencies", "@aws-sdk/middleware-user-agent", "^1.0.0-beta.0", true),
-    MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", "^1.0.0-beta.0", true),
-    MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", "^1.0.0-beta.0", true),
+    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", "1.0.0-gamma.0", true),
+    MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", "1.0.0-gamma.0", true),
+    MIDDLEWARE_USER_AGENT("dependencies", "@aws-sdk/middleware-user-agent", "1.0.0-gamma.0", true),
+    MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", "1.0.0-gamma.0", true),
+    MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", "1.0.0-gamma.0", true),
 
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^1.0.0-alpha.0", true),
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.0.0-alpha.0", true),
-    AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "^1.0.0-beta.0", true),
+    AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "1.0.0-gamma.0", true),
 
-    AWS_SDK_URL_PARSER_BROWSER("dependencies", "@aws-sdk/url-parser-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_URL_PARSER_NODE("dependencies", "@aws-sdk/url-parser-node", "^1.0.0-beta.0", true),
+    AWS_SDK_URL_PARSER_BROWSER("dependencies", "@aws-sdk/url-parser-browser", "1.0.0-gamma.0", true),
+    AWS_SDK_URL_PARSER_NODE("dependencies", "@aws-sdk/url-parser-node", "1.0.0-gamma.0", true),
 
-    AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", "^1.0.0-beta.0", true),
+    AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", "1.0.0-gamma.0", true),
+    AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", "1.0.0-gamma.0", true),
 
-    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", "^1.0.0-beta.0", true),
+    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", "1.0.0-gamma.0", true),
+    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", "1.0.0-gamma.0", true),
 
-    AWS_SDK_UTIL_USER_AGENT_BROWSER("dependencies", "@aws-sdk/util-user-agent-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_UTIL_USER_AGENT_NODE("dependencies", "@aws-sdk/util-user-agent-node", "^1.0.0-beta.0", true),
+    AWS_SDK_UTIL_USER_AGENT_BROWSER("dependencies", "@aws-sdk/util-user-agent-browser", "1.0.0-gamma.0", true),
+    AWS_SDK_UTIL_USER_AGENT_NODE("dependencies", "@aws-sdk/util-user-agent-node", "1.0.0-gamma.0", true),
 
-    AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "^1.0.0-beta.0", true),
-    AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "^1.0.0-beta.0", true),
+    AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "1.0.0-gamma.0", true),
+    AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "1.0.0-gamma.0", true),
 
     // Conditionally added when using an HTTP application protocol.
-    AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", "^1.0.0-beta.0", false),
-    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "^1.0.0-beta.0", false),
-    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", "^1.0.0-beta.0", false),
+    AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", "1.0.0-gamma.0", false),
+    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "1.0.0-gamma.0", false),
+    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", "1.0.0-gamma.0", false),
 
     // Conditionally added if a event stream shape is found anywhere in the model
     AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
-            "^1.0.0-beta.0", false),
-    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "^1.0.0-beta.0", false),
-    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "^1.0.0-beta.0", false),
+            "1.0.0-gamma.0", false),
+    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "1.0.0-gamma.0", false),
+    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "1.0.0-gamma.0", false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^5.2.2", false),
     TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false),
 
     // Conditionally added when interacting with specific protocol test bodyMediaType values.
-    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", "^1.0.0-beta.0", false),
+    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", "1.0.0-gamma.0", false),
     XML_PARSER("dependencies", "fast-xml-parser", "^3.16.0", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -26,13 +26,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^1.8.0"
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "jest": "^25.1.0",
+    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "typedoc": "^0.15.0",
-    "typescript": "~3.8.3"
+    "typedoc": "^0.17.8",
+    "typescript": "~3.9.3"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update dependencies to match that in aws-sdk-js-v3. This is required before updating clients with updated models.

In future, this needs to be updated every time a dependency is updated in aws-sdk-js-v3
Example client-accessanalyzer package.json for reference https://github.com/aws/aws-sdk-js-v3/blob/master/clients/client-accessanalyzer/package.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
