### PR TITLE
Remove duplicate hostname when hasHostPrefix is true

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -229,9 +229,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.openBlock("return new $T({", "});", requestType, () -> {
                 if (hasHostPrefix) {
                     writer.write("hostname: resolvedHostname,");
+                } else {
+                    writer.write("hostname,");
                 }
                 writer.write("protocol,");
-                writer.write("hostname,");
                 writer.write("port,");
                 writer.write("method: $S,", trait.getMethod());
                 writer.write("headers,");


### PR DESCRIPTION
*Issue #, if available:*
Internal issue JS-2014

*Description of changes:*
Remove duplicate hostname when hasHostPrefix is true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
