### PR TITLE
Bump typescript to ~4.0.2

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.17.8",
-    "typescript": "~3.9.3"
+    "typescript": "~4.0.2"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1456

*Description of changes:*
Bump typescript to ~4.0.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
