### PR TITLE
fix serializer throwing at adding host prefix

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -380,7 +380,7 @@ public final class HttpProtocolGeneratorUtils {
         TypeScriptWriter writer = context.getWriter();
         SymbolProvider symbolProvider = context.getSymbolProvider();
         EndpointTrait trait = operation.getTrait(EndpointTrait.class).get();
-        writer.write("let resolvedHostname = (context.endpoint as any).hostname;");
+        writer.write("let { hostname: resolvedHostname } = await context.endpoint();");
         // Check if disableHostPrefixInjection has been set to true at runtime
         writer.openBlock("if (context.disableHostPrefix !== true) {", "}", () -> {
             writer.addImport("isValidHostname", "__isValidHostname",

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -64,7 +64,7 @@ public class HttpProtocolGeneratorUtilsTest {
 
         OperationShape operation = (OperationShape) model.expectShape(ShapeId.from("smithy.example#GetFoo"));
         HttpProtocolGeneratorUtils.writeHostPrefix(mockContext, operation);
-        assertThat(writer.toString(), containsString("let resolvedHostname = (context.endpoint as any).hostname;"));
+        assertThat(writer.toString(), containsString("let { hostname: resolvedHostname } = await context.endpoint();"));
         assertThat(writer.toString(), containsString("if (context.disableHostPrefix !== true) {"));
         assertThat(writer.toString(), containsString("resolvedHostname = \"{foo}.data.\" + resolvedHostname;"));
         assertThat(writer.toString(), containsString("resolvedHostname = resolvedHostname.replace(\"{foo}\", input.foo)"));


### PR DESCRIPTION
The hostname prefix is not generated correctly. It results in serializer throwing when trying to add hostname prefix because  `(context.endpoint as any).hostname` returns `undefined`. The pull request fixes the bug


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
