### PR TITLE
Pass logger and filters to HandlerExecutionContext

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -152,8 +152,9 @@ final class CommandGenerator implements Runnable {
 
             // Resolve the middleware stack.
             writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");
+            writer.write("const { logger } = configuration;");
             writer.openBlock("const handlerExecutionContext: HandlerExecutionContext = {", "}", () -> {
-                writer.write("logger: {} as any,");
+                writer.write("logger,");
                 writer.openBlock("inputFilterLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getInput(operation),
                         input -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(input)),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -166,7 +166,7 @@ final class CommandGenerator implements Runnable {
                     if (outputShape.isPresent()) {
                         writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(outputShape.get()));
                     } else {
-                        writer.writeInline("(input) => input");
+                        writer.writeInline("(output) => output");
                     }
                 });
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -155,12 +155,12 @@ final class CommandGenerator implements Runnable {
             writer.write("const { logger } = configuration;");
             writer.openBlock("const handlerExecutionContext: HandlerExecutionContext = {", "}", () -> {
                 writer.write("logger,");
-                writer.openBlock("inputFilterLog: ", ",", () -> {
+                writer.openBlock("inputFilterSensitiveLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getInput(operation),
                         input -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(input)),
                         () -> writer.writeInline("(input: any) => input"));
                 });
-                writer.openBlock("outputFilterLog: ", ",", () -> {
+                writer.openBlock("outputFilterSensitiveLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getOutput(operation),
                         output -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(output)),
                         () -> writer.writeInline("(output: any) => output"));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.OptionalUtils;
 
 /**
  * Generates a client command using plugins.
@@ -154,20 +155,14 @@ final class CommandGenerator implements Runnable {
             writer.openBlock("const handlerExecutionContext: HandlerExecutionContext = {", "}", () -> {
                 writer.write("logger: {} as any,");
                 writer.openBlock("inputFilterLog: ", ",", () -> {
-                    Optional<StructureShape> inputShape = operationIndex.getInput(operation);
-                    if (inputShape.isPresent()) {
-                        writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(inputShape.get()));
-                    } else {
-                        writer.writeInline("(input) => input");
-                    }
+                    OptionalUtils.ifPresentOrElse(operationIndex.getInput(operation),
+                        input -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(input)),
+                        () -> writer.writeInline("(input) => input"));
                 });
                 writer.openBlock("outputFilterLog: ", ",", () -> {
-                    Optional<StructureShape> outputShape = operationIndex.getOutput(operation);
-                    if (outputShape.isPresent()) {
-                        writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(outputShape.get()));
-                    } else {
-                        writer.writeInline("(output) => output");
-                    }
+                    OptionalUtils.ifPresentOrElse(operationIndex.getOutput(operation),
+                        output -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(output)),
+                        () -> writer.writeInline("(output) => output"));
                 });
             });
             writer.write("const { requestHandler } = configuration;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -153,6 +153,22 @@ final class CommandGenerator implements Runnable {
             writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");
             writer.openBlock("const handlerExecutionContext: HandlerExecutionContext = {", "}", () -> {
                 writer.write("logger: {} as any,");
+                writer.openBlock("inputFilterLog: ", ",", () -> {
+                    Optional<StructureShape> inputShape = operationIndex.getInput(operation);
+                    if (inputShape.isPresent()) {
+                        writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(inputShape.get()));
+                    } else {
+                        writer.writeInline("(input) => input");
+                    }
+                });
+                writer.openBlock("outputFilterLog: ", ",", () -> {
+                    Optional<StructureShape> outputShape = operationIndex.getOutput(operation);
+                    if (outputShape.isPresent()) {
+                        writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(outputShape.get()));
+                    } else {
+                        writer.writeInline("(input) => input");
+                    }
+                });
             });
             writer.write("const { requestHandler } = configuration;");
             writer.openBlock("return stack.resolve(", ");", () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -158,12 +158,12 @@ final class CommandGenerator implements Runnable {
                 writer.openBlock("inputFilterLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getInput(operation),
                         input -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(input)),
-                        () -> writer.writeInline("(input) => input"));
+                        () -> writer.writeInline("(input: any) => input"));
                 });
                 writer.openBlock("outputFilterLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getOutput(operation),
                         output -> writer.writeInline("$T.filterSensitiveLog", symbolProvider.toSymbol(output)),
-                        () -> writer.writeInline("(output) => output"));
+                        () -> writer.writeInline("(output: any) => output"));
                 });
             });
             writer.write("const { requestHandler } = configuration;");


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2036

*Description of changes:*
Passes logger and filters to HandlerExecutionContext, which are going to be used by middleware-logger for logging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
