### PR TITLE
Remove __type and isa function 

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -361,7 +361,7 @@ final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  if (!$T.isa(err)) {\n"
+                       + "  if (err.name !== \"$T\") {\n"
                        + "    console.log(err);\n"
                        + "    fail(`Expected a $L to be thrown, got $${err.name} instead`);\n"
                        + "    return;\n"

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -70,7 +70,6 @@ final class StructureGenerator implements Runnable {
      *
      * <pre>{@code
      * export interface Person {
-     *   __type?: "Person";
      *   name: string | undefined;
      *   age?: number | null;
      * }
@@ -96,7 +95,6 @@ final class StructureGenerator implements Runnable {
             writer.openBlock("export interface $L extends $L {", symbol.getName(), extendsFrom);
         }
 
-        writer.write("__type?: $S;", shape.getId().getName());
         StructuredMemberWriter config = new StructuredMemberWriter(
                 model, symbolProvider, shape.getAllMembers().values());
         config.writeMembers(writer, shape);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -69,8 +69,6 @@ final class StructureGenerator implements Runnable {
      * <p>The following TypeScript is rendered:
      *
      * <pre>{@code
-     * import { isa as __isa } from "@aws-sdk/smithy-client";
-     *
      * export interface Person {
      *   __type?: "Person";
      *   name: string | undefined;
@@ -78,7 +76,7 @@ final class StructureGenerator implements Runnable {
      * }
      *
      * export namespace Person {
-     *   export const isa = (o: any): o is Person => __isa(o, "Person");
+     *   export const filterSensitiveLog = (obj: Person): any => ({...obj});
      * }
      * }</pre>
      */
@@ -127,8 +125,7 @@ final class StructureGenerator implements Runnable {
      *
      * <pre>{@code
      * import {
-     *     SmithyException as __SmithyException,
-     *     isa as __isa
+     *     SmithyException as __SmithyException
      * } from "@aws-sdk/smithy-client";
      *
      * export interface NoSuchResource extends __SmithyException, $MetadataBearer {
@@ -138,7 +135,7 @@ final class StructureGenerator implements Runnable {
      * }
      *
      * export namespace NoSuchResource {
-     *   export const isa = (o: any): o is NoSuchResource => __isa(o, "NoSuchResource");
+     *   export const filterSensitiveLog = (obj: NoSuchResource): any => ({...obj});
      * }
      * }</pre>
      */

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -169,7 +169,6 @@ final class StructureGenerator implements Runnable {
     }
 
     private void renderStructureNamespace() {
-        writer.addImport("isa", "__isa", "@aws-sdk/smithy-client");
         writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
@@ -181,9 +180,6 @@ final class StructureGenerator implements Runnable {
                         model, symbolProvider, shape.getAllMembers().values());
                     structuredMemberWriter.writeFilterSensitiveLog(writer, objectParam);
                 }
-            );
-            writer.write("export const isa = (o: any): o is $L => __isa(o, $S);",
-                symbol.getName(), shape.getId().getName()
             );
         });
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -220,7 +220,6 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      *
      * <pre>{@code
      * let contents: any = {
-     *   __type: "Field",
      *   fooValue: undefined,
      *   barValue: undefined,
      * };
@@ -479,7 +478,6 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      *   context: SerdeContext
      * ): Field => {
      *   let field: any = {
-     *     __type: "Field",
      *     fooValue: undefined,
      *     barValue: undefined,
      *   };

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -845,7 +845,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                 // Only set a type and the members if we have output.
                 operation.getOutput().ifPresent(outputId -> {
-                    writer.write("__type: $S,", outputId.getName());
                     // Set all the members to undefined to meet type constraints.
                     StructureShape target = model.expectShape(outputId).asStructureShape().get();
                     new TreeMap<>(target.getAllMembers())
@@ -1141,11 +1140,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (event.hasTrait(ErrorTrait.class)) {
                 generateErrorEventDeserializer(context, event);
             } else {
-                writer.openBlock("let contents: $L = {", "} as any;", symbol.getName(), () -> {
-                    if (!event.getAllMembers().values().isEmpty()) {
-                        writer.write("__type: $S,", event.getId().getName());
-                    }
-                });
+                writer.write("let contents: $L = {} as any;", symbol.getName());
                 readEventHeaders(context, event);
                 readEventBody(context, event);
                 writer.write("return contents;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -332,7 +332,6 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
             writer.openBlock("const response: $T = {", "};", outputType, () -> {
                 writer.write("$$metadata: deserializeMetadata(output),");
                 operation.getOutput().ifPresent(outputId -> {
-                    writer.write("__type: $S,", outputId.getName());
                     writer.write("...contents,");
                 });
             });

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -95,7 +95,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
 
 /**
  * Compares all types for equivalent contents, doing nested
- * equality checks based on non-'__type', non-`$$metadata`
+ * equality checks based on non-`$$metadata`
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
@@ -109,8 +109,6 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   // If a test fails with an issue in the below 6 lines, it's likely
   // due to an issue in the nestedness or existence of the property
   // being compared.
-  delete localExpected['__type'];
-  delete generated['__type'];
   delete localExpected['$$metadata'];
   delete generated['$$metadata'];
   Object.keys(localExpected).forEach(key => localExpected[key] === undefined && delete localExpected[key])

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -143,7 +143,6 @@ public class CodegenVisitorTest {
         Assertions.assertTrue(manifest.hasFile("models/index.ts"));
         assertThat(manifest.getFileString("models/index.ts").get(),
                 containsString("export interface Bar {\n" +
-                        "  __type?: \"Bar\";\n" +
                         "  baz: string | undefined;\n" +
                         "}"));
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -496,7 +496,6 @@ public class StructureGeneratorTest {
         String output = writer.toString();
 
         assertThat(output, containsString("export interface Bar {"));
-        assertThat(output, containsString("__type?: \"Bar\";"));
         assertThat(output, containsString("foo?: string;"));
         assertThat(output, containsString("export namespace Bar {"));
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -480,11 +480,8 @@ public class StructureGeneratorTest {
     private void testErrorStructureCodegen(String file, String expectedType) {
         String contents = testStructureCodegen(file, expectedType);
 
-        assertThat(contents, containsString("as __isa"));
         assertThat(contents, containsString("as __SmithyException"));
         assertThat(contents, containsString("namespace Err {"));
-        assertThat(contents, containsString("  export const isa = (o: any): o is Err => "
-                                            + "__isa(o, \"Err\");\n"));
     }
 
     @Test
@@ -498,13 +495,10 @@ public class StructureGeneratorTest {
         new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model), writer, struct).run();
         String output = writer.toString();
 
-        assertThat(output, containsString("as __isa"));
         assertThat(output, containsString("export interface Bar {"));
         assertThat(output, containsString("__type?: \"Bar\";"));
         assertThat(output, containsString("foo?: string;"));
         assertThat(output, containsString("export namespace Bar {"));
-        assertThat(output, containsString(
-                "export const isa = (o: any): o is Bar => __isa(o, \"Bar\");"));
     }
 
     private StructureShape createNonErrorStructure() {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
@@ -47,7 +47,7 @@ public class UnionGeneratorTest {
         assertThat(output, containsString("export namespace Example {"));
 
         // It generates an unknown variant
-        assertThat(output, containsString("export interface $UnknownMember extends $Base {\n"
+        assertThat(output, containsString("export interface $UnknownMember {\n"
                                           + "    A?: never;\n"
                                           + "    B?: never;\n"
                                           + "    C?: never;\n"
@@ -55,21 +55,21 @@ public class UnionGeneratorTest {
                                           + "  }"));
 
         // It generates a variant for each member.
-        assertThat(output, containsString("export interface AMember extends $Base {\n"
+        assertThat(output, containsString("export interface AMember {\n"
                                           + "    A: string;\n"
                                           + "    B?: never;\n"
                                           + "    C?: never;\n"
                                           + "    $unknown?: never;\n"
                                           + "  }"));
 
-        assertThat(output, containsString("export interface BMember extends $Base {\n"
+        assertThat(output, containsString("export interface BMember {\n"
                                           + "    A?: never;\n"
                                           + "    B: number;\n"
                                           + "    C?: never;\n"
                                           + "    $unknown?: never;\n"
                                           + "  }"));
 
-        assertThat(output, containsString("export interface CMember extends $Base {\n"
+        assertThat(output, containsString("export interface CMember {\n"
                                           + "    A?: never;\n"
                                           + "    B?: never;\n"
                                           + "    C: boolean;\n"


### PR DESCRIPTION
*Issue #, if available:*
Internal issue JS-1906

*Description of changes:*
Removes __type and isa function.
As described in JS-1906, `__type` will only be added only for types that are or have subtypes or when inheritance is introduced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
