### PR TITLE
toposort models and chunk big model files

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.TopologicalIndex;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
@@ -152,13 +153,16 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         // Generate models that are connected to the service being generated.
         LOGGER.fine("Walking shapes from " + service.getId() + " to find shapes to generate");
-        Set<Shape> serviceShapes = new TreeSet<>(new Walker(nonTraits).walkShapes(service));
-
-        // Condense duplicate shapes
-        Map<String, Shape> shapeMap = condenseShapes(serviceShapes);
+        // Walk the tree and condense duplicate shapes
+        Collection<Shape> shapeSet = condenseShapes(new Walker(nonTraits).walkShapes(service));
+        Model shapeSetModel = Model.builder().addShapes(shapeSet).build();
 
         // Generate models from condensed shapes
-        for (Shape shape : shapeMap.values()) {
+        for (Shape shape : TopologicalIndex.of(shapeSetModel).getOrderedShapes()) {
+            shape.accept(this);
+        }
+
+        for (Shape shape : TopologicalIndex.of(shapeSetModel).getRecursiveShapes()) {
             shape.accept(this);
         }
 
@@ -325,7 +329,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         return null;
     }
 
-    private Map<String, Shape> condenseShapes(Set<Shape> shapes) {
+    private Collection<Shape> condenseShapes(Set<Shape> shapes) {
         Map<String, Shape> shapeMap = new LinkedHashMap<>();
 
         // Check for colliding shapes and prune non-unique shapes
@@ -342,7 +346,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             }
         }
 
-        return shapeMap;
+        return shapeMap.values();
     }
 
     private boolean isShapeCollision(Shape shapeA, Shape shapeB) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -155,16 +155,16 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         LOGGER.fine("Walking shapes from " + service.getId() + " to find shapes to generate");
         // Walk the tree and condense duplicate shapes
         Collection<Shape> shapeSet = condenseShapes(new Walker(nonTraits).walkShapes(service));
-        Model shapeSetModel = Model.builder().addShapes(shapeSet).build();
+        Model prunedModel = Model.builder().addShapes(shapeSet).build();
 
         // Generate models from condensed shapes
-        for (Shape shape : TopologicalIndex.of(shapeSetModel).getOrderedShapes()) {
+        for (Shape shape : TopologicalIndex.of(prunedModel).getOrderedShapes()) {
             shape.accept(this);
         }
-
-        for (Shape shape : TopologicalIndex.of(shapeSetModel).getRecursiveShapes()) {
+        for (Shape shape : TopologicalIndex.of(prunedModel).getRecursiveShapes()) {
             shape.accept(this);
         }
+        SymbolVisitor.writeModelIndex(prunedModel, symbolProvider, fileManifest);
 
         // Generate the client Node and Browser configuration files. These
         // files are switched between in package.json based on the targeted

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -141,7 +141,10 @@ public class CodegenVisitorTest {
         new TypeScriptCodegenPlugin().execute(context);
 
         Assertions.assertTrue(manifest.hasFile("models/index.ts"));
+        Assertions.assertTrue(manifest.hasFile("models/models_0.ts"));
         assertThat(manifest.getFileString("models/index.ts").get(),
+                containsString("export * from \"./models_0\";"));
+        assertThat(manifest.getFileString("models/models_0.ts").get(),
                 containsString("export interface Bar {\n" +
                         "  baz: string | undefined;\n" +
                         "}"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -471,7 +471,7 @@ public class StructureGeneratorTest {
                 .build();
 
         new TypeScriptCodegenPlugin().execute(context);
-        String contents = manifest.getFileString("/models/index.ts").get();
+        String contents = manifest.getFileString("/models/models_0.ts").get();
 
         assertThat(contents, containsString(expectedType));
         return contents;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -1,10 +1,12 @@
 package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -25,9 +27,9 @@ public class SymbolProviderTest {
         Symbol symbol = provider.toSymbol(shape);
 
         assertThat(symbol.getName(), equalTo("Hello"));
-        assertThat(symbol.getNamespace(), equalTo("./models/index"));
+        assertThat(symbol.getNamespace(), equalTo("./models/models_0"));
         assertThat(symbol.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol.getDefinitionFile(), equalTo("./models/index.ts"));
+        assertThat(symbol.getDefinitionFile(), equalTo("./models/models_0.ts"));
     }
 
     @Test
@@ -38,16 +40,20 @@ public class SymbolProviderTest {
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
+        MockManifest manifest = new MockManifest();
+        SymbolVisitor.writeModelIndex(model, provider, manifest);
 
         assertThat(symbol1.getName(), equalTo("Hello"));
-        assertThat(symbol1.getNamespace(), equalTo("./models/index"));
+        assertThat(symbol1.getNamespace(), equalTo("./models/models_0"));
         assertThat(symbol1.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol1.getDefinitionFile(), equalTo("./models/index.ts"));
+        assertThat(symbol1.getDefinitionFile(), equalTo("./models/models_0.ts"));
 
         assertThat(symbol2.getName(), equalTo("Hello"));
-        assertThat(symbol2.getNamespace(), equalTo("./models/index"));
+        assertThat(symbol2.getNamespace(), equalTo("./models/models_0"));
         assertThat(symbol2.getNamespaceDelimiter(), equalTo("/"));
-        assertThat(symbol2.getDefinitionFile(), equalTo("./models/index.ts"));
+        assertThat(symbol2.getDefinitionFile(), equalTo("./models/models_0.ts"));
+        assertThat(manifest.getFileString("models/index.ts").get(),
+                containsString("export * from \"./models_0\";"));
     }
 
     @Test
@@ -78,7 +84,7 @@ public class SymbolProviderTest {
 
         // Normal structure with escaping.
         assertThat(structSymbol.getName(), equalTo("_Object"));
-        assertThat(structSymbol.getNamespace(), equalTo("./models/index"));
+        assertThat(structSymbol.getNamespace(), equalTo("./models/models_0"));
 
         // Reference to built-in type with no escaping.
         assertThat(memberSymbol.getName(), equalTo("string"));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1460

Related: https://github.com/aws/aws-sdk-js-v3/pull/1510

*Description of changes:*
This change exports shapes in topological order, and chunk them into `models/models_0.ts`, `models/models_1.ts`, `models/models_2.ts`..., `models/models_x.ts`. A `models/index.ts` will re-export shapes from each chunks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
