### PR TITLE
add required client configs to protocol test

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -181,8 +181,8 @@ final class HttpProtocolTestGenerator implements Runnable {
         writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
             // Create a client with a custom request handler that intercepts requests.
             writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () -> {
-                writer.write("...clientParams,");
-                writer.write("requestHandler: new RequestSerializationTestHandler(),");
+                    writer.write("...clientParams,");
+                    writer.write("requestHandler: new RequestSerializationTestHandler(),");
             });
 
             // Run the parameters through a visitor to adjust for TS specific inputs.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -180,8 +180,10 @@ final class HttpProtocolTestGenerator implements Runnable {
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
             // Create a client with a custom request handler that intercepts requests.
-            writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () ->
-                    writer.write("requestHandler: new RequestSerializationTestHandler()"));
+            writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () -> {
+                writer.write("...clientParams,");
+                writer.write("requestHandler: new RequestSerializationTestHandler(),");
+            });
 
             // Run the parameters through a visitor to adjust for TS specific inputs.
             ObjectNode params = testCase.getParams();
@@ -387,7 +389,8 @@ final class HttpProtocolTestGenerator implements Runnable {
         String body = testCase.getBody().orElse(null);
 
         // Create a client with a custom request handler that intercepts requests.
-        writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () ->
+        writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () -> {
+                writer.write("...clientParams,");
                 writer.openBlock("requestHandler: new ResponseDeserializationTestHandler(", ")", () -> {
                     writer.write("$L,", isSuccess);
                     writer.write("$L,", testCase.getCode());
@@ -395,7 +398,8 @@ final class HttpProtocolTestGenerator implements Runnable {
                     if (body != null) {
                         writer.write("`$L`,", body);
                     }
-                }));
+                });
+            });
 
         // Set the command's parameters to empty, using the any type to
         // trick TS in to letting us send this command through.

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -132,3 +132,8 @@ const equivalentContents = (expected: any, generated: any): boolean => {
 
   return true;
 }
+
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" }
+}


### PR DESCRIPTION
So that the protocol test can be run in environment without existing AWS configs

Related: https://github.com/aws/aws-sdk-js-v3/pull/1513


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
