### PR TITLE
cast host prefix member to be non-optional

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -392,7 +392,7 @@ public final class HttpProtocolGeneratorUtils {
             for (SmithyPattern.Segment label : prefixLabels) {
                 MemberShape member = inputShape.getMember(label.getContent()).get();
                 String memberName = symbolProvider.toMemberName(member);
-                writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L)",
+                writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L!)",
                         label.getContent(), memberName);
             }
             writer.openBlock("if (!__isValidHostname(resolvedHostname)) {", "}", () -> {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -67,7 +67,7 @@ public class HttpProtocolGeneratorUtilsTest {
         assertThat(writer.toString(), containsString("let { hostname: resolvedHostname } = await context.endpoint();"));
         assertThat(writer.toString(), containsString("if (context.disableHostPrefix !== true) {"));
         assertThat(writer.toString(), containsString("resolvedHostname = \"{foo}.data.\" + resolvedHostname;"));
-        assertThat(writer.toString(), containsString("resolvedHostname = resolvedHostname.replace(\"{foo}\", input.foo)"));
+        assertThat(writer.toString(), containsString("resolvedHostname = resolvedHostname.replace(\"{foo}\", input.foo!)"));
         assertThat(writer.toString(), containsString("if (!__isValidHostname(resolvedHostname)) {"));
         assertThat(writer.toString(), containsString(
                 "throw new Error(\"ValidationError: prefixed hostname must be hostname compatible."));


### PR DESCRIPTION
Per the SDK protocol requirement, members bound to host prefix must
be required. In JS SDK, required members are modeled as `string|undefined`.
It makes `resolvedHostname.replace(hostPrefix, input)` panic because
replace() doesn't allow `undefined`.

This change casts the type to `string` with `!`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
