### PR TITLE
Apply preprocessModel customization to the models

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -98,12 +98,15 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         integrations.sort(Comparator.comparingInt(TypeScriptIntegration::getOrder));
 
         // Preprocess model using integrations.
-        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
-        Model baseModel = context.getModel();
         for (TypeScriptIntegration integration : integrations) {
-            baseModel = integration.preprocessModel(context, settings);
+            Model modifiedModel = integration.preprocessModel(context,
+                    TypeScriptSettings.from(context.getModel(), context.getSettings()));
+            if (modifiedModel != context.getModel()) {
+                context = context.toBuilder().model(modifiedModel).build();
+            }
         }
-        model = baseModel;
+        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
+        model = context.getModel();
         nonTraits = context.getModelWithoutTraitShapes();
         service = settings.getService(model);
         fileManifest = context.getFileManifest();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -84,8 +84,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     CodegenVisitor(PluginContext context) {
         settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
         nonTraits = context.getModelWithoutTraitShapes();
-        model = context.getModel();
-        service = settings.getService(model);
+        Model baseModel = context.getModel();
+        service = settings.getService(baseModel);
         fileManifest = context.getFileManifest();
         LOGGER.info(() -> "Generating TypeScript client for service " + service.getId());
 
@@ -103,6 +103,12 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 });
         // Sort the integrations in specified order.
         integrations.sort(Comparator.comparingInt(TypeScriptIntegration::getOrder));
+
+        // Preprocess model using integrations.
+        for (TypeScriptIntegration integration : integrations) {
+            baseModel = integration.preprocessModel(context, settings);
+        }
+        model = baseModel;
 
         // Decorate the symbol provider using integrations.
         SymbolProvider resolvedProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -82,13 +82,6 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private final ApplicationProtocol applicationProtocol;
 
     CodegenVisitor(PluginContext context) {
-        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
-        nonTraits = context.getModelWithoutTraitShapes();
-        Model baseModel = context.getModel();
-        service = settings.getService(baseModel);
-        fileManifest = context.getFileManifest();
-        LOGGER.info(() -> "Generating TypeScript client for service " + service.getId());
-
         // Load all integrations.
         ClassLoader loader = context.getPluginClassLoader().orElse(getClass().getClassLoader());
         LOGGER.info("Attempting to discover TypeScriptIntegration from the classpath...");
@@ -105,10 +98,16 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         integrations.sort(Comparator.comparingInt(TypeScriptIntegration::getOrder));
 
         // Preprocess model using integrations.
+        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
+        Model baseModel = context.getModel();
         for (TypeScriptIntegration integration : integrations) {
             baseModel = integration.preprocessModel(context, settings);
         }
         model = baseModel;
+        nonTraits = context.getModelWithoutTraitShapes();
+        service = settings.getService(model);
+        fileManifest = context.getFileManifest();
+        LOGGER.info(() -> "Generating TypeScript client for service " + service.getId());
 
         // Decorate the symbol provider using integrations.
         SymbolProvider resolvedProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -98,14 +98,15 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         integrations.sort(Comparator.comparingInt(TypeScriptIntegration::getOrder));
 
         // Preprocess model using integrations.
+        TypeScriptSettings typescriptSettings = TypeScriptSettings.from(context.getModel(), context.getSettings());
         for (TypeScriptIntegration integration : integrations) {
-            Model modifiedModel = integration.preprocessModel(context,
-                    TypeScriptSettings.from(context.getModel(), context.getSettings()));
+            Model modifiedModel = integration.preprocessModel(context, typescriptSettings);
             if (modifiedModel != context.getModel()) {
                 context = context.toBuilder().model(modifiedModel).build();
+                typescriptSettings = TypeScriptSettings.from(modifiedModel, context.getSettings());
             }
         }
-        settings = TypeScriptSettings.from(context.getModel(), context.getSettings());
+        settings = typescriptSettings;
         model = context.getModel();
         nonTraits = context.getModelWithoutTraitShapes();
         service = settings.getService(model);


### PR DESCRIPTION
*Description of changes:*
`TypescriptIntegration` supports `preprocessModel()` customization. However, it's never integrated with `CodegenVisitor`. This change fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
