### PR TITLE
Throw when host prefix input is not supplied

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -392,6 +392,9 @@ public final class HttpProtocolGeneratorUtils {
             for (SmithyPattern.Segment label : prefixLabels) {
                 MemberShape member = inputShape.getMember(label.getContent()).get();
                 String memberName = symbolProvider.toMemberName(member);
+                writer.openBlock("if (input.$L === undefined) {", "}", memberName, () -> {
+                    writer.write("throw new Error('Empty value provided for input host prefix: $L.');", memberName);
+                });
                 writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L!)",
                         label.getContent(), memberName);
             }


### PR DESCRIPTION
*Description of changes:*

The serializer should throw when the member is not supplied, otherwise the constructed hostname is invalidate, and hard for users to figure out the root cause. Members bond to hostname prefix is always required, so it makes sense to throw when they are not provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
