### PR TITLE
Target ES2018 in TSConfig

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1560

*Description of changes:*
Target ES2018 in TSConfig as we now support Node.js >=10.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
