### PR TITLE
Deserialize 3XX response as exceptions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -836,7 +836,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Redirect error deserialization to the dispatcher if we receive an error range
             // status code that's not the modeled code (400 or higher). This allows for
             // returning other 2XX or 3XX codes that don't match the defined value.
-            writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 400) {", "}", trait.getCode(),
+            writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
                     () -> writer.write("return $L(output, context);", errorMethodName));
 
             // Start deserializing the response.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -834,8 +834,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "  context: $L\n"
                        + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
             // Redirect error deserialization to the dispatcher if we receive an error range
-            // status code that's not the modeled code (400 or higher). This allows for
-            // returning other 2XX or 3XX codes that don't match the defined value.
+            // status code that's not the modeled code (300 or higher). This allows for
+            // returning other 2XX codes that don't match the defined value.
             writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
                     () -> writer.write("return $L(output, context);", errorMethodName));
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -321,7 +321,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                        + "  context: __SerdeContext\n"
                        + "): Promise<$T> => {", "}", methodName, responseType, outputType, () -> {
             // Redirect error deserialization to the dispatcher
-            writer.openBlock("if (output.statusCode >= 400) {", "}", () -> {
+            writer.openBlock("if (output.statusCode >= 300) {", "}", () -> {
                 writer.write("return $L(output, context);", errorMethodName);
             });
 


### PR DESCRIPTION
Currently JS SDK treats 3XX response as successful but it isn't. JS SDK should
throw redirection responses as errors. Go SDK has the same behavior in [smithy-go](https://github.com/awslabs/smithy-go/blob/eef57dbcf0a0b771beb062916b8ace909ca7c9aa/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpBindingProtocolGenerator.java#L308).

*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1385

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
