### PR TITLE
fix: allow arbitrary path indexing on input, output tokens

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -121,7 +121,7 @@ final class PaginationGenerator implements Runnable {
         });
     }
 
-    public static String destructurePath(String path) {
+     private String destructurePath(String path) {
         String[] splitIndex = path.split("\\.");
         return "['" + String.join("']['", splitIndex) + "']";
     }
@@ -130,8 +130,9 @@ final class PaginationGenerator implements Runnable {
         String serviceTypeName = serviceSymbol.getName();
         String inputTypeName = inputSymbol.getName();
         String outputTypeName = outputSymbol.getName();
-        String inputTokenName = paginatedInfo.getInputTokenMember().getMemberName();
-        String outputTokenName = paginatedInfo.getOutputTokenMember().getMemberName();
+
+        String inputTokenName = paginatedInfo.getPaginatedTrait().getInputToken().get();
+        String outputTokenName = paginatedInfo.getPaginatedTrait().getOutputToken().get();
 
         writer.openBlock(
                 "export async function* $LPaginate(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",


### PR DESCRIPTION
*Issue #, if available:*
Allow one level indexing of input tokens

```
                "smithy.api#paginated": {
                    "inputToken": "EngineDefaults.Marker",
                    "outputToken": "EngineDefaults.Marker",
                    "items": "EngineDefaults.Parameters",
                    "pageSize": "MaxRecords"
                }
```


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
