### PR TITLE
fix: not all services support empty starting pagination token

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -137,7 +137,7 @@ final class PaginationGenerator implements Runnable {
         writer.openBlock(
                 "export async function* $LPaginate(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
                 "}",  methodName, paginationType, inputTypeName, outputTypeName, () -> {
-            writer.write("let token: string | undefined = config.startingToken || '';");
+            writer.write("let token: string | undefined = config.startingToken || undefined;");
 
             writer.write("let hasNext = true;");
             writer.write("let page: $L;", outputTypeName);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Looks like not all services support the starting token being an empty string. Make it undefined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
