### PR TITLE
fix(package.json): migrate @aws-sdk/types into devDependencies for codegen

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -137,7 +137,7 @@ final class PaginationGenerator implements Runnable {
         writer.openBlock(
                 "export async function* $LPaginate(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
                 "}",  methodName, paginationType, inputTypeName, outputTypeName, () -> {
-            writer.write("let token: string | undefined = config.startingToken || '';");
+            writer.write("let token: string | undefined = config.startingToken || undefined;");
 
             writer.write("let hasNext = true;");
             writer.write("let page: $L;", outputTypeName);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -29,7 +29,7 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "1.0.0-rc.0", true),
-    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "1.0.0-rc.0", true),
+    AWS_SDK_TYPES("devDependencies", "@aws-sdk/types", "1.0.0-rc.0", true),
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "1.0.0-rc.0", true),
     INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", "1.0.0-rc.0", true),
     CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", "1.0.0-rc.0", true),


### PR DESCRIPTION
*Issue #, if available:*
Similar to: https://github.com/aws/aws-sdk-js-v3/pull/1654
Based off: https://github.com/aws/aws-sdk-js-v3/issues/1649

*Description of changes:*
Moves @aws-sdk/types into devDependencies of clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
