### PR TITLE
fix: pass args to send operation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -195,7 +195,7 @@ final class PaginationGenerator implements Runnable {
                 "}", serviceSymbol.getName(), inputSymbol.getName(),
                 outputSymbol.getName(), () -> {
             writer.write("// @ts-ignore");
-            writer.write("return await client.send(new $L(input, ...args));", operationSymbol.getName());
+            writer.write("return await client.send(new $L(input), ...args);", operationSymbol.getName());
         });
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1665

*Description of changes:*
Args are incorrectly passed to the clientCommand constructor instead of the send operation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
