### PR TITLE
remove AWS-specfic default user agent

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -94,13 +94,6 @@ final class RuntimeConfigGenerator {
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
                 writer.write("utf8Encoder: toUtf8,");
-            },
-            "defaultUserAgent", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE);
-                writer.addImport("defaultUserAgent", "defaultUserAgent",
-                        TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName);
-                writer.addDefaultImport("packageInfo", "./package.json");
-                writer.write("defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> browserRuntimeConfigDefaults = MapUtils.of(
@@ -157,13 +150,6 @@ final class RuntimeConfigGenerator {
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
                 writer.write("utf8Encoder: toUtf8,");
-            },
-            "defaultUserAgent", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER);
-                writer.addImport("defaultUserAgent", "defaultUserAgent",
-                        TypeScriptDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.packageName);
-                writer.addDefaultImport("packageInfo", "./package.json");
-                writer.write("defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
@@ -178,11 +164,6 @@ final class RuntimeConfigGenerator {
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
                 writer.write("urlParser: parseUrl,");
-            },
-            "defaultUserAgent", writer -> {
-                writer.addDefaultImport("packageInfo", "./package.json");
-                writer.write("defaultUserAgent: "
-                    + "`aws-sdk-js-v3-react-native-$${packageInfo.name}/$${packageInfo.version}`,");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -232,9 +232,6 @@ final class ServiceGenerator implements Runnable {
             writer.writeDocs("The function that will be used to convert binary data to a UTF-8 encoded string");
             writer.write("utf8Encoder?: __Encoder;\n");
 
-            writer.writeDocs("The string that will be used to populate default value in 'User-Agent' header");
-            writer.write("defaultUserAgent?: string;\n");
-
             writer.writeDocs("The runtime environment");
             writer.write("runtime?: string;\n");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -54,9 +54,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", "1.0.0-rc.0", true),
     AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", "1.0.0-rc.0", true),
 
-    AWS_SDK_UTIL_USER_AGENT_BROWSER("dependencies", "@aws-sdk/util-user-agent-browser", "1.0.0-rc.0", true),
-    AWS_SDK_UTIL_USER_AGENT_NODE("dependencies", "@aws-sdk/util-user-agent-node", "1.0.0-rc.0", true),
-
     AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "1.0.0-rc.0", true),
     AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "1.0.0-rc.0", true),
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -92,7 +92,6 @@ public class RuntimeConfigGeneratorTest {
 
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
-        assertThat(runtimeConfigContents, containsString("import packageInfo from \"./package.json\""));
         assertThat(runtimeConfigContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
@@ -100,7 +99,6 @@ public class RuntimeConfigGeneratorTest {
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.browser.ts").get();
-        assertThat(runtimeConfigContents, containsString("import packageInfo from \"./package.json\""));
         assertThat(runtimeConfigBrowserContents,
                    containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
@@ -108,7 +106,6 @@ public class RuntimeConfigGeneratorTest {
 
         // Does the runtimeConfig.native.ts file expand the browser template properties properly?
         String runtimeConfigNativeContents = manifest.getFileString("runtimeConfig.native.ts").get();
-        assertThat(runtimeConfigContents, containsString("import packageInfo from \"./package.json\""));
         assertThat(runtimeConfigNativeContents,
                 containsString("import { ClientDefaults } from \"./ExampleClient\";"));
         assertThat(runtimeConfigNativeContents,


### PR DESCRIPTION
Current default user agent string is AWS specific. So the customization
is moved to AWS JS SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
