### PR TITLE
chore(protocol-tests): make handlerOptions optional

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -16,7 +16,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
 class RequestSerializationTestHandler implements HttpHandler {
     handle(
         request: HttpRequest,
-        options: HttpHandlerOptions
+        options?: HttpHandlerOptions
     ): Promise<{ response: HttpResponse }> {
         return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
     }
@@ -52,7 +52,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
     handle(
         request: HttpRequest,
-        options: HttpHandlerOptions
+        options?: HttpHandlerOptions
     ): Promise<{ response: HttpResponse }> {
         return Promise.resolve({
             response: {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1695

*Description of changes:*
make handlerOptions optional in RequestHandler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
