### PR TITLE
fix: import SENSITIVE_STRING only when used

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -164,7 +164,6 @@ final class StructureGenerator implements Runnable {
     }
 
     private void renderStructureNamespace() {
-        writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
         Symbol symbol = symbolProvider.toSymbol(shape);
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
             String objectParam = "obj";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -88,9 +88,7 @@ final class StructuredMemberWriter {
     void writeMemberFilterSensitiveLog(TypeScriptWriter writer, MemberShape member, String memberParam) {
         Shape memberTarget = model.expectShape(member.getTarget());
         if (member.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
-            // member is Sensitive, hide the value.
-            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
-            writer.write("SENSITIVE_STRING");
+            writeSensitiveString(writer);
         } else if (memberTarget instanceof SimpleShape) {
             writer.write(memberParam);
         } else if (memberTarget.isStructureShape() || memberTarget.isUnionShape()) {
@@ -109,6 +107,14 @@ final class StructuredMemberWriter {
     }
 
     /**
+     * Writes SENSITIVE_STRING to hide the value of sensitive members.
+     */
+    private void writeSensitiveString(TypeScriptWriter writer) {
+        writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
+        writer.write("SENSITIVE_STRING");
+    }
+
+    /**
      * Recursively writes filterSensitiveLog for StructureShape.
      */
     private void writeStructureFilterSensitiveLog(
@@ -117,9 +123,7 @@ final class StructuredMemberWriter {
             String structureParam
     ) {
         if (structureTarget.hasTrait(SensitiveTrait.class)) {
-            // member is Sensitive, hide the value.
-            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
-            writer.write("SENSITIVE_STRING");
+            writeSensitiveString(writer);
         } else if (structureTarget.hasTrait(StreamingTrait.class) && structureTarget.isUnionShape()) {
             // disable logging for StreamingTrait
             writer.write("'STREAMING_CONTENT'");
@@ -138,9 +142,7 @@ final class StructuredMemberWriter {
             String collectionParam
     ) {
         if (collectionMember.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
-            // member is Sensitive, hide the value.
-            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
-            writer.write("SENSITIVE_STRING");
+            writeSensitiveString(writer);
         } else if (model.expectShape(collectionMember.getTarget()) instanceof SimpleShape) {
             writer.write(collectionParam);
         } else {
@@ -157,9 +159,7 @@ final class StructuredMemberWriter {
      */
     private void writeMapFilterSensitiveLog(TypeScriptWriter writer, MemberShape mapMember, String mapParam) {
         if (mapMember.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
-            // member is Sensitive, hide the value.
-            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
-            writer.write("SENSITIVE_STRING");
+            writeSensitiveString(writer);
         } else if (model.expectShape(mapMember.getTarget()) instanceof SimpleShape) {
             writer.write(mapParam);
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -89,6 +89,7 @@ final class StructuredMemberWriter {
         Shape memberTarget = model.expectShape(member.getTarget());
         if (member.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
             // member is Sensitive, hide the value.
+            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
             writer.write("SENSITIVE_STRING");
         } else if (memberTarget instanceof SimpleShape) {
             writer.write(memberParam);
@@ -117,6 +118,7 @@ final class StructuredMemberWriter {
     ) {
         if (structureTarget.hasTrait(SensitiveTrait.class)) {
             // member is Sensitive, hide the value.
+            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
             writer.write("SENSITIVE_STRING");
         } else if (structureTarget.hasTrait(StreamingTrait.class) && structureTarget.isUnionShape()) {
             // disable logging for StreamingTrait
@@ -137,6 +139,7 @@ final class StructuredMemberWriter {
     ) {
         if (collectionMember.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
             // member is Sensitive, hide the value.
+            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
             writer.write("SENSITIVE_STRING");
         } else if (model.expectShape(collectionMember.getTarget()) instanceof SimpleShape) {
             writer.write(collectionParam);
@@ -155,6 +158,7 @@ final class StructuredMemberWriter {
     private void writeMapFilterSensitiveLog(TypeScriptWriter writer, MemberShape mapMember, String mapParam) {
         if (mapMember.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
             // member is Sensitive, hide the value.
+            writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
             writer.write("SENSITIVE_STRING");
         } else if (model.expectShape(mapMember.getTarget()) instanceof SimpleShape) {
             writer.write(mapParam);


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1760

*Description of changes:*
import SENSITIVE_STRING only when used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
