### PR TITLE
fix: use typeof inputTokenName as token type instead of string

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -137,12 +137,15 @@ final class PaginationGenerator implements Runnable {
         writer.openBlock(
                 "export async function* paginate$L(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
                 "}",  operationName, paginationType, inputTypeName, outputTypeName, () -> {
-            writer.write("let token: string | undefined = config.startingToken || undefined;");
+            String destructuredInputTokenName = destructurePath(inputTokenName);
+            writer.write("// ToDo: replace with actual type instead of typeof input$L", destructuredInputTokenName);
+            writer.write("let token: typeof input$L | undefined = config.startingToken || undefined;",
+                    destructuredInputTokenName);
 
             writer.write("let hasNext = true;");
             writer.write("let page: $L;", outputTypeName);
             writer.openBlock("while (hasNext) {", "}", () -> {
-                writer.write("input$L = token;", destructurePath(inputTokenName));
+                writer.write("input$L = token;", destructuredInputTokenName);
 
                 if (paginatedInfo.getPageSizeMember().isPresent()) {
                     String pageSize = paginatedInfo.getPageSizeMember().get().getMemberName();


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1782

*Description of changes:*
use typeof inputTokenName as token type instead of string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
