### PR TITLE
Remove logging of clientName and commandName from Command

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -171,12 +171,6 @@ final class CommandGenerator implements Runnable {
                         () -> writer.writeInline("(output: any) => output"));
                 });
             });
-            writer.openBlock("\nif (typeof logger.info === 'function') {", "}\n", () -> {
-                writer.openBlock("logger.info({", "});", () -> {
-                    writer.write("clientName,");
-                    writer.write("commandName,");
-                });
-            });
             writer.write("const { requestHandler } = configuration;");
             writer.openBlock("return stack.resolve(", ");", () -> {
                 writer.write("(request: FinalizeHandlerArguments<any>) => ");


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1785

*Description of changes:*
Remove logging of clientName and commandName from Command. It's now logger in loggerMiddleware.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
