### PR TITLE
chore: use TreeSet for structure members

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.typescript.codegen;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
@@ -48,7 +49,7 @@ final class StructuredMemberWriter {
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
         this.model = model;
         this.symbolProvider = symbolProvider;
-        this.members = members;
+        this.members = new TreeSet<>(members);
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {


### PR DESCRIPTION
This PR would be made ready for review once we explore option to retain ordering of members.

*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1683

*Description of changes:*
use TreeSet to sort structure members in their natural order.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
