### PR TITLE
Remove calls to deprecated model.getKnowledge

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -54,7 +54,7 @@ public final class CodegenUtils {
         // Get default SerdeContext.
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         // If event stream trait exists, add corresponding serde context type to the intersection type.
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         if (eventStreamIndex.getInputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");
@@ -77,7 +77,7 @@ public final class CodegenUtils {
         // Get default SerdeContext.
         List<String> contextInterfaceList = getDefaultOperationSerdeContextTypes(writer);
         // If event stream trait exists, add corresponding serde context type to the intersection type.
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         if (eventStreamIndex.getOutputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
             contextInterfaceList.add("__EventStreamSerdeContext");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -294,7 +294,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 settings, model, symbolProvider, nonModularName, writer, applicationProtocol).run());
 
         // Generate each operation for the service.
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
         boolean hasPaginatedOperation = false;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -78,7 +78,7 @@ final class CommandGenerator implements Runnable {
         this.applicationProtocol = applicationProtocol;
 
         symbol = symbolProvider.toSymbol(operation);
-        operationIndex = model.getKnowledge(OperationIndex.class);
+        operationIndex = OperationIndex.of(model);
         inputType = symbol.expectProperty("inputType", Symbol.class);
         outputType = symbol.expectProperty("outputType", Symbol.class);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -115,8 +115,8 @@ final class HttpProtocolTestGenerator implements Runnable {
 
     @Override
     public void run() {
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         // Use a TreeSet to have a fixed ordering of tests.
         for (OperationShape operation : new TreeSet<>(topDownIndex.getContainedOperations(service))) {
@@ -296,7 +296,7 @@ final class HttpProtocolTestGenerator implements Runnable {
             // Fast check if we have an undescribed or plain text body.
             if (mediaType == null || mediaType.equals("text/plain")) {
                 // Handle converting to the right comparison format for blob payloads.
-                HttpBindingIndex httpBindingIndex = model.getKnowledge(HttpBindingIndex.class);
+                HttpBindingIndex httpBindingIndex = HttpBindingIndex.of(model);
                 List<HttpBinding> payloadBindings = httpBindingIndex.getRequestBindings(operation, Location.PAYLOAD);
                 if (!payloadBindings.isEmpty() && hasBlobBinding(payloadBindings)) {
                     writer.write("expect(r.body).toMatchObject(Uint8Array.from($S, c => c.charCodeAt(0)));", body);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -54,7 +54,7 @@ final class IndexGenerator {
         writer.write("export * from \"./" + nonModularName + "\";");
 
         // write export statements for each command in /commands directory
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
         boolean hasPaginatedOperation = false;
         for (OperationShape operation : containedOperations) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
@@ -64,7 +64,7 @@ final class NonModularServiceGenerator implements Runnable {
 
     @Override
     public void run() {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         // Generate the client and extend from the modular client.
         writer.writeShapeDocs(service);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -117,7 +117,7 @@ final class ServiceGenerator implements Runnable {
             Function<Symbol, Optional<Symbol>> mapper,
             Consumer<TypeScriptWriter> defaultTypeGenerator
     ) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = topDownIndex.getContainedOperations(service);
 
         List<Symbol> symbols = containedOperations.stream()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -102,7 +102,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 .buildEscaper();
 
         // Get each structure that's used an error.
-        OperationIndex operationIndex = model.getKnowledge(OperationIndex.class);
+        OperationIndex operationIndex = OperationIndex.of(model);
         model.shapes(OperationShape.class).forEach(operationShape -> {
             errorShapes.addAll(operationIndex.getErrors(operationShape));
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -254,7 +254,7 @@ public final class TypeScriptSettings {
             return protocol;
         }
 
-        ServiceIndex serviceIndex = model.getKnowledge(ServiceIndex.class);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
         Set<ShapeId> resolvedProtocols = serviceIndex.getProtocols(service).keySet();
         if (resolvedProtocols.isEmpty()) {
             throw new UnresolvableProtocolException(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -102,9 +102,9 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
             Model model,
             ServiceShape service
     ) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
-        EventStreamIndex eventStreamIndex = model.getKnowledge(EventStreamIndex.class);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         for (OperationShape operation : operations) {
             if (eventStreamIndex.getInputInfo(operation).isPresent()
                     || eventStreamIndex.getOutputInfo(operation).isPresent()


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/awslabs/smithy-typescript/pull/242

*Description of changes:*
Regular expression used for search `model.getKnowledge\(([^\.]*).class\)` and replaced with `$1.of(model)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
