### PR TITLE
Document deprecation in comments for shapes and members

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -237,7 +237,11 @@ public final class TypeScriptWriter extends CodeWriter {
         return member.getMemberTrait(model, DocumentationTrait.class)
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
-                    writeDocs(docs);
+                    if (member.getMemberTrait(model, DeprecatedTrait.class).isPresent()) {
+                        writeDocs("@deprecated\n\n" + docs);
+                    } else {
+                        writeDocs(docs);
+                    }
                     return true;
                 }).orElse(false);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -218,10 +218,9 @@ public final class TypeScriptWriter extends CodeWriter {
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
-                        writeDocs("@deprecated\n\n" + docs);
-                    } else {
-                        writeDocs(docs);
+                        docs = "@deprecated\n\n" + docs;
                     }
+                    writeDocs(docs);
                     return true;
                 }).orElse(false);
     }
@@ -238,10 +237,9 @@ public final class TypeScriptWriter extends CodeWriter {
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
                     if (member.getMemberTrait(model, DeprecatedTrait.class).isPresent()) {
-                        writeDocs("@deprecated\n\n" + docs);
-                    } else {
-                        writeDocs(docs);
+                        docs = "@deprecated\n\n" + docs;
                     }
+                    writeDocs(docs);
                     return true;
                 }).orElse(false);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -218,7 +218,7 @@ public final class TypeScriptWriter extends CodeWriter {
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
-                        writeDocs("@deprecated\n" + docs);
+                        writeDocs("@deprecated\n\n" + docs);
                     } else {
                         writeDocs(docs);
                     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -33,6 +33,7 @@ import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.CodeWriter;
 import software.amazon.smithy.utils.StringUtils;
@@ -216,7 +217,11 @@ public final class TypeScriptWriter extends CodeWriter {
         return shape.getTrait(DocumentationTrait.class)
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
-                    writeDocs(docs);
+                    if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
+                        writeDocs("@deprecated\n" + docs);
+                    } else {
+                        writeDocs(docs);
+                    }
                     return true;
                 }).orElse(false);
     }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1868

*Description of changes:*
Document deprecation in comments for shapes

**Shape: Lambda invokeAsync**

<details>
<summary>without deprecated tag</summary>

![lambda-invokeAsync-no-deprecated-tag](https://user-images.githubusercontent.com/16024985/103709802-40f62b80-4f68-11eb-9a4e-474834e18273.png)

</details>

<details>
<summary>with deprecated tag</summary>

![lambda-invokeAsync-deprecated](https://user-images.githubusercontent.com/16024985/103709860-65520800-4f68-11eb-9c02-5a873d4bb939.png)

</details>

**Shape: Lambda InvokeAsyncCommand**

<details>
<summary>without deprecated tag</summary>

![lambda-InvokeAsyncCommand-no-deprecated-tag](https://user-images.githubusercontent.com/16024985/103709893-7c90f580-4f68-11eb-887b-9f97690cec10.png)

</details>

<details>
<summary>with deprecated tag</summary>

![lambda-InvokeAsyncCommand-deprecated](https://user-images.githubusercontent.com/16024985/103709913-8a467b00-4f68-11eb-8c6d-141b6f9f88d6.png)

</details>

**Member: WorkDocs DescribeUsersResponse TotalNumberOfUsers**

<details>
<summary>without deprecated tag</summary>

![Screen Shot 2021-01-06 at 8 13 31 AM](https://user-images.githubusercontent.com/16024985/103791692-962d4e00-4ff7-11eb-9220-7d71612b5157.png)

</details>

<details>
<summary>with deprecated tag</summary>

![Screen Shot 2021-01-06 at 8 13 58 AM](https://user-images.githubusercontent.com/16024985/103791715-9f1e1f80-4ff7-11eb-9e7b-50e2bc554c71.png)

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
