### PR TITLE
fix: stop adding command middleware repeatedly

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -104,6 +104,7 @@ final class CommandGenerator implements Runnable {
         writer.writeShapeDocs(operation);
         writer.openBlock("export class $L extends $$Command<$T, $T, $L> {", "}", name, inputType, outputType,
                 configType, () -> {
+            writer.write("private resolved = false;");
 
             // Section for adding custom command properties.
             writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
@@ -145,11 +146,15 @@ final class CommandGenerator implements Runnable {
                 .write("options?: $T", applicationProtocol.getOptionsType())
                 .dedent();
         writer.openBlock("): Handler<$T, $T> {", "}", inputType, outputType, () -> {
-            // Add serialization and deserialization plugin.
-            writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
+            writer.openBlock("if (!this.resolved) {", "}", () -> {
+                // Add serialization and deserialization plugin.
+                writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
 
-            // Add customizations.
-            addCommandSpecificPlugins();
+                // Add customizations.
+                addCommandSpecificPlugins();
+
+                writer.write("this.resolved = true;");
+            });
 
             // Resolve the middleware stack.
             writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -18,7 +18,10 @@ public class CommandGeneratorTest {
                 "    configuration: ExampleClientResolvedConfig,\n" +
                 "    options?: __HttpHandlerOptions\n" +
                 "  ): Handler<GetFooCommandInput, GetFooCommandOutput> {\n" +
-                "    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));\n" +
+                "    if (!this.resolved) {\n" +
+                "      this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));\n" +
+                "      this.resolved = true;\n" +
+                "    }\n" +
                 "\n" +
                 "    const stack = clientStack.concat(this.middlewareStack);");
     }


### PR DESCRIPTION
When sending the same command multiple times, resolveMiddleware()
will be called many times. So adding serde middleware will throw
error because they are already added into stack. This change
prevents adding the serde middleware repeatedly.

Alternative is moving command middleware to the command constructor,
just like in client(that's why client doesn't have the problem). But
the command middleware also have depdency over client configs
supplied from resolveMiddleware(). So serde middleware and
customizations must live here.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1864


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
