### PR TITLE
fix: export @aws-sdk/types as an explicit dependency

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -29,7 +29,7 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "1.0.0-rc.0", true),
-    AWS_SDK_TYPES("devDependencies", "@aws-sdk/types", "1.0.0-rc.0", true),
+    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "1.0.0-rc.0", true),
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "1.0.0-rc.0", true),
     INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", "1.0.0-rc.0", true),
     CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", "1.0.0-rc.0", true),


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1842
https://github.com/aws/aws-sdk-js-v3/pull/1902

*Description of changes:*
Packages that depend on @aws-sdk/types should explicitly call out that dependency so that downstream consumers get type support out of the box and do not have to install their own version of @aws-sdk/types . This PR should do that for all packages that depend on @aws-sdk/types in AWS sdk v3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
