### PR TITLE
merge url-parser-node and url-parser-browser; add url-parser-native

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -53,12 +53,6 @@ final class RuntimeConfigGenerator {
                         TypeScriptDependency.AWS_SDK_HASH_NODE.packageName);
                 writer.write("sha256: Hash.bind(null, \"sha256\"),");
             },
-            "urlParser", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NODE);
-                writer.addImport("parseUrl", "parseUrl",
-                        TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
-                writer.write("urlParser: parseUrl,");
-            },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
@@ -109,12 +103,6 @@ final class RuntimeConfigGenerator {
                         TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER.packageName);
                 writer.write("sha256: Sha256,");
             },
-            "urlParser", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER);
-                writer.addImport("parseUrl", "parseUrl",
-                        TypeScriptDependency.AWS_SDK_URL_PARSER_BROWSER.packageName);
-                writer.write("urlParser: parseUrl,");
-            },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
@@ -160,15 +148,21 @@ final class RuntimeConfigGenerator {
                 writer.write("sha256: Sha256,");
             },
             "urlParser", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NODE);
+                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NATIVE);
                 writer.addImport("parseUrl", "parseUrl",
-                        TypeScriptDependency.AWS_SDK_URL_PARSER_NODE.packageName);
+                        TypeScriptDependency.AWS_SDK_URL_PARSER_NATIVE.packageName);
                 writer.write("urlParser: parseUrl,");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(
             "disableHostPrefix", writer -> {
                 writer.write("disableHostPrefix: false,");
+            },
+            "urlParser", writer -> {
+                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER);
+                writer.addImport("parseUrl", "parseUrl",
+                        TypeScriptDependency.AWS_SDK_URL_PARSER.packageName);
+                writer.write("urlParser: parseUrl,");
             }
     );
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -44,8 +44,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.0.0", true),
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "3.0.0", true),
 
-    AWS_SDK_URL_PARSER_BROWSER("dependencies", "@aws-sdk/url-parser-browser", "3.0.0", true),
-    AWS_SDK_URL_PARSER_NODE("dependencies", "@aws-sdk/url-parser-node", "3.0.0", true),
+    AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", "3.0.0", true),
+    AWS_SDK_URL_PARSER_NATIVE("dependencies", "@aws-sdk/url-parser-native", "3.0.0", true),
 
     AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", "3.0.0", true),
     AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", "3.0.0", true),


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1867, https://github.com/aws/aws-sdk-js-v3/issues/1900
Related: https://github.com/aws/aws-sdk-js-v3/issues/1903

Both `@aws-sdk/url-parser-node` and `@aws-sdk/url-parser-browser` use WHATWG `URL()`
to parse the url. In fact their code are identical. So they are deprecated and
replaced by `@aws-sdk/url-parser`.

However, `URL()` is not supported in React Native. So we need to use `parse()`
from "url" package. `@aws-sdk/url-parser-native` is used in React Native runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
