### PR TITLE
Revert "fix: stop adding serde middleware repeatedly (#259)"

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -104,7 +104,6 @@ final class CommandGenerator implements Runnable {
         writer.writeShapeDocs(operation);
         writer.openBlock("export class $L extends $$Command<$T, $T, $L> {", "}", name, inputType, outputType,
                 configType, () -> {
-            writer.write("private resolved = false;");
 
             // Section for adding custom command properties.
             writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
@@ -146,15 +145,11 @@ final class CommandGenerator implements Runnable {
                 .write("options?: $T", applicationProtocol.getOptionsType())
                 .dedent();
         writer.openBlock("): Handler<$T, $T> {", "}", inputType, outputType, () -> {
-            writer.openBlock("if (!this.resolved) {", "}", () -> {
-                // Add serialization and deserialization plugin.
-                writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
+            // Add serialization and deserialization plugin.
+            writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
 
-                // Add customizations.
-                addCommandSpecificPlugins();
-
-                writer.write("this.resolved = true;");
-            });
+            // Add customizations.
+            addCommandSpecificPlugins();
 
             // Resolve the middleware stack.
             writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CommandGeneratorTest.java
@@ -18,10 +18,7 @@ public class CommandGeneratorTest {
                 "    configuration: ExampleClientResolvedConfig,\n" +
                 "    options?: __HttpHandlerOptions\n" +
                 "  ): Handler<GetFooCommandInput, GetFooCommandOutput> {\n" +
-                "    if (!this.resolved) {\n" +
-                "      this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));\n" +
-                "      this.resolved = true;\n" +
-                "    }\n" +
+                "    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));\n" +
                 "\n" +
                 "    const stack = clientStack.concat(this.middlewareStack);");
     }


### PR DESCRIPTION
This reverts commit c57cca31d2216849ef123d19b86ea0fab6eb12d4.

Solves: https://github.com/aws/aws-sdk-js-v3/issues/1935
Related to: https://github.com/aws/aws-sdk-js-v3/pull/1964

If a command instance is used by a different client instance, the
command still consumes the configuration of the previous client
interface. This issue is resolved by allowing adding middleware
to the stack without throwing error. So #259 is no longer needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
