### PR TITLE
Update protocol test request body comparison

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-form-urlencoded-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-form-urlencoded-stub.ts
@@ -2,7 +2,7 @@
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentFormUrlencodedBodies = (expectedBody: string, generatedBody: string): Object => {
   const fromEntries = (components: string[][]): { [key: string]: string } => {
     const parts: { [key: string]: string } = {};
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-json-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-json-stub.ts
@@ -2,7 +2,7 @@
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentJsonBodies = (expectedBody: string, generatedBody: string): Object => {
   const expectedParts = JSON.parse(expectedBody);
   const generatedParts = JSON.parse(generatedBody);
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-octet-stream-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-octet-stream-stub.ts
@@ -2,15 +2,13 @@
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentUnknownTypeBodies = (
+const compareEquivalentOctetStreamBodies = (
   config: any,
   expectedBody: string,
-  generatedBody: string | Uint8Array
+  generatedBody: Uint8Array
 ): Object => {
   const expectedParts = {Value: expectedBody};
-  const generatedParts = {
-    Value: generatedBody instanceof Uint8Array ? config.utf8Encoder(generatedBody) : generatedBody
-  };
+  const generatedParts = {Value: config.utf8Encoder(generatedBody)};
 
   return compareParts(expectedParts, generatedParts);
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-text-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-text-stub.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a map of key names that were un-equal to value objects showing the
+ * discrepancies between the components.
+ */
+const compareEquivalentTextBodies = (expectedBody: string, generatedBody: string): Object => {
+  const expectedParts = {Value: expectedBody};
+  const generatedParts = {Value: generatedBody};
+
+  return compareParts(expectedParts, generatedParts);
+}

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -2,7 +2,7 @@
  * Returns a map of key names that were un-equal to value objects showing the
  * discrepancies between the components.
  */
-const compareEquivalentBodies = (expectedBody: string, generatedBody: string): Object => {
+const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string): Object => {
   const decodeEscapedXml = (str: string) => {
     return str
       .replace(/&amp;/g, "&")


### PR DESCRIPTION
This commit updates the request body comparison generation for
protocol tests to safely handle having multiple `bodyMediaType`
settings in the same suite of protocol tests. It also updates the
methodology for comparing blob bodies to not be a special case in
the generator, as they can have alternate media types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
