### PR TITLE
Do not check for labels in empty input while writing hostPrefix

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -387,17 +387,19 @@ public final class HttpProtocolGeneratorUtils {
             writer.addImport("isValidHostname", "__isValidHostname",
                     TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP.packageName);
             writer.write("resolvedHostname = $S + resolvedHostname;", trait.getHostPrefix().toString());
-            List<SmithyPattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();
-            StructureShape inputShape = context.getModel().expectShape(operation.getInput()
-                    .get(), StructureShape.class);
-            for (SmithyPattern.Segment label : prefixLabels) {
-                MemberShape member = inputShape.getMember(label.getContent()).get();
-                String memberName = symbolProvider.toMemberName(member);
-                writer.openBlock("if (input.$L === undefined) {", "}", memberName, () -> {
-                    writer.write("throw new Error('Empty value provided for input host prefix: $L.');", memberName);
-                });
-                writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L!)",
-                        label.getContent(), memberName);
+            if (operation.getInput().isPresent()) {
+                List<SmithyPattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();
+                StructureShape inputShape = context.getModel().expectShape(operation.getInput()
+                        .get(), StructureShape.class);
+                for (SmithyPattern.Segment label : prefixLabels) {
+                    MemberShape member = inputShape.getMember(label.getContent()).get();
+                    String memberName = symbolProvider.toMemberName(member);
+                    writer.openBlock("if (input.$L === undefined) {", "}", memberName, () -> {
+                        writer.write("throw new Error('Empty value provided for input host prefix: $L.');", memberName);
+                    });
+                    writer.write("resolvedHostname = resolvedHostname.replace(\"{$L}\", input.$L!)",
+                            label.getContent(), memberName);
+                }
             }
             writer.openBlock("if (!__isValidHostname(resolvedHostname)) {", "}", () -> {
                 writer.write("throw new Error(\"ValidationError: prefixed hostname must be hostname compatible.\");");


### PR DESCRIPTION
*Issue #, if available:*
Fixes CI failures in aws-sdk-js-v3 which started with https://github.com/aws/aws-sdk-js-v3/actions/runs/590870041

*Description of changes:*
Do not check for labels in empty input while writing hostPrefix.

Verified that gradle build is successful in aws-sdk-js-v3 after the change from this PR is published to local maven.
```console
$ pwd
/home/trivikr/workspace/smithy-typescript

$ ./gradlew clean publishToMavenLoca
...
...
BUILD SUCCESSFUL in 3s
12 actionable tasks: 11 executed, 1 up-to-date
```

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/codegen

$ ./gradlew clean smithy-aws-typescript-codegen:build protocol-test-codegen:build -Plog-tests
...
...
BUILD SUCCESSFUL in 15s
13 actionable tasks: 13 executed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
