### PR TITLE
Check for only structure shapes for circular dependency

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -197,24 +197,22 @@ final class StructuredMemberWriter {
             // always call filterSensitiveLog for UnionShape
             return true;
         } else if (memberTarget.isStructureShape()) {
-            parents.add(symbolProvider.toMemberName(member));
-            Collection<MemberShape> structureMemberList = ((StructureShape) memberTarget).getAllMembers().values();
-            for (MemberShape structureMember: structureMemberList) {
-                if (!parents.contains(symbolProvider.toMemberName(structureMember))
-                        && isMemberOverwriteRequired(structureMember, parents)) {
-                    return true;
+            if (!parents.contains(symbolProvider.toMemberName(member))) {
+                parents.add(symbolProvider.toMemberName(member));
+                Collection<MemberShape> structureMemberList = ((StructureShape) memberTarget).getAllMembers().values();
+                for (MemberShape structureMember: structureMemberList) {
+                    if (!parents.contains(symbolProvider.toMemberName(structureMember))
+                            && isMemberOverwriteRequired(structureMember, parents)) {
+                        return true;
+                    }
                 }
             }
         } else if (memberTarget instanceof CollectionShape) {
             MemberShape collectionMember = ((CollectionShape) memberTarget).getMember();
-            if (!parents.contains(symbolProvider.toMemberName(collectionMember))) {
-                return isMemberOverwriteRequired(collectionMember, parents);
-            }
+            return isMemberOverwriteRequired(collectionMember, parents);
         } else if (memberTarget instanceof MapShape) {
             MemberShape mapMember = ((MapShape) memberTarget).getValue();
-            if (!parents.contains(symbolProvider.toMemberName(mapMember))) {
-                return isMemberOverwriteRequired(mapMember, parents);
-            }
+            return isMemberOverwriteRequired(mapMember, parents);
         }
         return false;
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -193,11 +193,11 @@ final class StructuredMemberWriter {
         }
 
         Shape memberTarget = model.expectShape(member.getTarget());
-        parents.add(symbolProvider.toMemberName(member));
         if (memberTarget.isUnionShape()) {
             // always call filterSensitiveLog for UnionShape
             return true;
         } else if (memberTarget.isStructureShape()) {
+            parents.add(symbolProvider.toMemberName(member));
             Collection<MemberShape> structureMemberList = ((StructureShape) memberTarget).getAllMembers().values();
             for (MemberShape structureMember: structureMemberList) {
                 if (!parents.contains(symbolProvider.toMemberName(structureMember))


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The Set `parents` was added to avoid StackOverflow Error occurring due to circular dependencies in recursion in PR https://github.com/awslabs/smithy-typescript/pull/181
To check for recursions, the value needs to be populated only for Structure shapes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
