### PR TITLE
Generate ssdk request protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -202,7 +202,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         // Generate protocol tests IFF found in the model.
         if (protocolGenerator != null) {
             ShapeId protocol = protocolGenerator.getProtocol();
-            new HttpProtocolTestGenerator(settings, model, protocol, symbolProvider, writers).run();
+            new HttpProtocolTestGenerator(settings, model, protocol, symbolProvider, writers, protocolGenerator).run();
         }
 
         // Write each pending writer.


### PR DESCRIPTION
*Description of changes:*

This adds test generation for ssdk request deserialization. For example:

```typescript
/**
 * Mixes constant and variable query string parameters
 */
it("RestJsonConstantAndVariableQueryStringMissingOneValue:ServerRequest", async () => {
  let testFunction = jest.fn();
  testFunction.mockReturnValue({});
  const testService: Partial<RestJsonService> = {
    ConstantAndVariableQueryString: testFunction as __Operation<
      ConstantAndVariableQueryStringCommandInput,
      ConstantAndVariableQueryStringCommandOutput
    >,
  };
  const handler = getRestJsonServiceHandler(testService as RestJsonService);
  const request = new HttpRequest({
    method: "GET",
    hostname: "foo.example.com",
    path: "/ConstantAndVariableQueryString",
    query: {
      foo: "bar",
      baz: "bam",
    },
    headers: {},
    body: Readable.from([""]),
  });
  await handler.handle(request);

  expect(testFunction.mock.calls.length).toBe(1);
  let r: any = testFunction.mock.calls[0][0];

  const paramsToValidate: any = [
    {
      baz: "bam",
    },
  ][0];
  Object.keys(paramsToValidate).forEach((param) => {
    expect(r[param]).toBeDefined();
    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
  });
});
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
