### PR TITLE
Introduce a server-specific symbol provider.

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -64,6 +64,26 @@ final class IndexGenerator {
         writer.write("export * as $L from \"./protocols/$L\";", protocolName, protocolName);
     }
 
+    static void writeServerIndex(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            FileManifest fileManifest
+    ) {
+        TypeScriptWriter writer = new TypeScriptWriter("");
+
+        ServiceShape service = settings.getService(model);
+        Symbol symbol = symbolProvider.toSymbol(service);
+
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+        for (OperationShape operation : containedOperations) {
+            writer.write("export * from \"./types/$L\";", symbolProvider.toSymbol(operation).getName());
+        }
+        writer.write("export * from \"./$L\"", symbol.getName());
+        fileManifest.writeFile("server/index.ts", writer.toString());
+    }
+
     private static void writeClientExports(
             TypeScriptSettings settings,
             Model model,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -15,19 +15,35 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import java.util.LinkedHashSet;
+import java.util.Iterator;
 import java.util.Set;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.utils.StringUtils;
+import software.amazon.smithy.model.shapes.Shape;
 
 final class ServerGenerator {
 
     private ServerGenerator() {}
 
-    static void generateServiceHandler(ServiceShape service,
+    static void generateOperationsType(SymbolProvider symbolProvider,
+                                       Shape serviceShape,
+                                       Set<OperationShape> operations,
+                                       TypeScriptWriter writer) {
+        Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
+        writer.writeInline("type $L = ", serviceSymbol.expectProperty("operations", Symbol.class).getName());
+        for (Iterator<OperationShape> iter = operations.iterator(); iter.hasNext();) {
+            writer.writeInline("$S", iter.next().getId().getName());
+            if (iter.hasNext()) {
+                writer.writeInline(" | ");
+            }
+        }
+        writer.write(";");
+    }
+
+    static void generateServiceHandler(SymbolProvider symbolProvider,
+                                       Shape serviceShape,
                                        Set<OperationShape> operations,
                                        TypeScriptWriter writer) {
         writer.addImport("ServiceHandler", null, "@aws-smithy/server-common");
@@ -42,17 +58,15 @@ final class ServerGenerator {
         writer.addImport("HttpRequest", null, "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", null, "@aws-sdk/protocol-http");
 
-        String serviceName = StringUtils.capitalize(service.getId().getName());
-        String operationsTypeName = serviceName + "Operations";
+        Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
+        Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
+        Symbol operationsType = serviceSymbol.expectProperty("operations", Symbol.class);
 
-        writer.addImport(serviceName + "Service", null, ".");
-        writer.write("type $L = keyof $L;", operationsTypeName, serviceName + "Service");
-
-        writer.openBlock("export class $LServiceHandler implements ServiceHandler {", "}", serviceName, () -> {
-            writer.write("private service: $LService;", serviceName);
-            writer.write("private mux: Mux<$S, $L>;", serviceName, operationsTypeName);
-            writer.write("private serializers: Record<$1L, OperationSerializer<$2LService, $1L>>;",
-                    operationsTypeName, serviceName);
+        writer.openBlock("export class $L implements ServiceHandler {", "}", handlerSymbol.getName(), () -> {
+            writer.write("private service: $T;", serviceSymbol);
+            writer.write("private mux: Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
+            writer.write("private serializers: Record<$1T, OperationSerializer<$2L, $1T>>;",
+                    operationsType, serviceSymbol.getName());
             writer.openBlock("private serdeContextBase = {", "};", () -> {
                 writer.write("base64Encoder: toBase64,");
                 writer.write("base64Decoder: fromBase64,");
@@ -63,19 +77,19 @@ final class ServerGenerator {
                 writer.write("disableHostPrefix: true");
             });
             writer.write("/**");
-            writer.write(" * Construct a $LService handler.", serviceName);
-            writer.write(" * @param service The {@link $LService} implementation that supplies", serviceName);
-            writer.write(" *                the business logic for $LService", serviceName);
+            writer.write(" * Construct a $T handler.", serviceSymbol);
+            writer.write(" * @param service The {@link $T} implementation that supplies", serviceSymbol);
+            writer.write(" *                the business logic for $T", serviceSymbol);
             writer.write(" * @param mux The {@link Mux} that determines which service and operation are being");
             writer.write(" *            invoked by a given {@link HttpRequest}");
             writer.write(" * @param serializers An {@link OperationSerializer} for each operation in");
-            writer.write(" *                    $LService that handles deserialization of requests and", serviceName);
-            writer.write(" *                    serialization of responses");
+            writer.write(" *                    $T that handles deserialization of requests", serviceSymbol);
+            writer.write(" *                    and serialization of responses");
             writer.write(" */");
-            writer.openBlock("constructor(service: $1LService, "
-                            + "mux: Mux<$1S, $2L>, "
-                            + "serializers: Record<$2L, OperationSerializer<$1LService, $2L>>) {", "}",
-                    serviceName, operationsTypeName, () -> {
+            writer.openBlock("constructor(service: $1T, "
+                            + "mux: Mux<$3S, $2T>, "
+                            + "serializers: Record<$2T, OperationSerializer<$1T, $2T>>) {", "}",
+                    serviceSymbol, operationsType, serviceShape.getId().getName(), () -> {
                 writer.write("this.service = service;");
                 writer.write("this.mux = mux;");
                 writer.write("this.serializers = serializers;");
@@ -88,22 +102,25 @@ final class ServerGenerator {
                 });
                 writer.openBlock("switch (target.operation) {", "}", () -> {
                     for (OperationShape operation : operations) {
-                        generateHandlerCase(writer, serviceName, operation);
+                        generateHandlerCase(writer, serviceSymbol, operation, symbolProvider.toSymbol(operation));
                     }
                 });
             });
         });
     }
 
-    private static void generateHandlerCase(TypeScriptWriter writer, String serviceName, OperationShape operation) {
-        String opName = operation.getId().getName();
+    private static void generateHandlerCase(TypeScriptWriter writer,
+                                            Symbol serviceSymbol,
+                                            Shape operationShape,
+                                            Symbol operationSymbol) {
+        String opName = operationShape.getId().getName();
         writer.openBlock("case $S : {", "}", opName, () -> {
-            writer.write("let serializer = this.serializers.$1L as OperationSerializer<$2LService, $1S>;",
-                    opName, serviceName);
+            writer.write("let serializer = this.serializers.$2L as OperationSerializer<$1L, $2S>;",
+                    serviceSymbol.getName(), opName);
             writer.openBlock("let input = await serializer.deserialize(request, {", "});", () -> {
                 writer.write("endpoint: () => Promise.resolve(request), ...this.serdeContextBase");
             });
-            writer.write("let output = this.service.$L(input, request);", opName);
+            writer.write("let output = this.service.$L(input, request);", operationSymbol.getName());
             writer.write("return serializer.serialize(output, this.serdeContextBase);");
         });
     }
@@ -114,41 +131,16 @@ final class ServerGenerator {
                                          TypeScriptWriter writer) {
         writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
 
-        String serviceInterfaceName = StringUtils.capitalize(service.getId().getName()) + "Service";
+        String serviceInterfaceName = symbolProvider.toSymbol(service).getName();
 
         writer.openBlock("export interface $L {", "}", serviceInterfaceName, () -> {
             for (OperationShape operation : operations) {
                 Symbol symbol = symbolProvider.toSymbol(operation);
-                writer.write("$L: $L<$T, $T>", StringUtils.capitalize(operation.getId().getName()),
+                writer.write("$L: $L<$T, $T>", symbol.getName(),
                         "__Operation",
                         symbol.expectProperty("inputType", Symbol.class),
                         symbol.expectProperty("outputType", Symbol.class));
             }
         });
-
-        writer.addImport("ParsedRequest", "__ParsedRequest", "@aws-smithy/server-common");
-        writer.addImport("PreparedResponse", "__PreparedResponse", "@aws-smithy/server-common");
-
-        Set<String> requestInterfaces = new LinkedHashSet<>();
-        Set<String> responseInterfaces = new LinkedHashSet<>();
-        for (OperationShape operation : operations) {
-            String opName = StringUtils.capitalize(operation.getId().getName());
-            String requestInterfaceName = "Parsed" + opName + "Request";
-            String responseInterfaceName = "Prepared" + opName + "Response";
-
-            writer.write("export interface $L extends $L<$L, $S> {}",
-                    requestInterfaceName, "__ParsedRequest", serviceInterfaceName, opName);
-            writer.write("export interface $L extends $L<$L, $S> {}",
-                    responseInterfaceName, "__PreparedResponse", serviceInterfaceName, opName);
-
-            requestInterfaces.add(requestInterfaceName);
-            responseInterfaces.add(responseInterfaceName);
-        }
-
-        writer.write("export type $LRequests = $L;",
-                serviceInterfaceName, String.join(" | ", requestInterfaces));
-
-        writer.write("export type $LResponses = $L;",
-                serviceInterfaceName, String.join(" | ", responseInterfaces));
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.util.logging.Logger;
+import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider;
+import software.amazon.smithy.codegen.core.ReservedWords;
+import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Wraps a client SymbolProvider and generates substitute shapes for server-specific symbols.
+ */
+final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements SymbolProvider {
+    private static final Logger LOGGER = Logger.getLogger(ServerSymbolVisitor.class.getName());
+
+    private final Model model;
+    private final SymbolProvider delegate;
+    private final ReservedWordSymbolProvider.Escaper escaper;
+    private final ModuleNameDelegator moduleNameDelegator;
+
+    ServerSymbolVisitor(Model model, SymbolProvider delegate) {
+        this.model = model;
+        this.delegate = delegate;
+
+        // Load reserved words from a new-line delimited file.
+        ReservedWords reservedWords = new ReservedWordsBuilder()
+                .loadWords(TypeScriptCodegenPlugin.class.getResource("reserved-words.txt"))
+                .build();
+
+        escaper = ReservedWordSymbolProvider.builder()
+                .nameReservedWords(reservedWords)
+                // Only escape words when the symbol has a definition file to
+                // prevent escaping intentional references to built-in types.
+                .escapePredicate((shape, symbol) -> !StringUtils.isEmpty(symbol.getDefinitionFile()))
+                .buildEscaper();
+
+        moduleNameDelegator = new ModuleNameDelegator();
+    }
+
+    @Override
+    public Symbol toSymbol(Shape shape) {
+        if (shape.getType() == ShapeType.SERVICE
+            || shape.getType() == ShapeType.OPERATION) {
+            Symbol symbol = shape.accept(this);
+            LOGGER.fine(() -> "Creating symbol from " + shape + ": " + symbol);
+            return escaper.escapeSymbol(shape, symbol);
+        }
+        return delegate.toSymbol(shape);
+    }
+
+    @Override
+    public Symbol operationShape(OperationShape shape) {
+        String shapeName = flattenShapeName(shape);
+        String moduleName = moduleNameDelegator.formatModuleName(shape, shapeName);
+
+        Symbol intermediate = createGeneratedSymbolBuilder(shape, shapeName, moduleName).build();
+        Symbol.Builder builder = intermediate.toBuilder();
+        //TODO: these names suck but otherwise they clash with the names in models
+        builder.putProperty("inputType", intermediate.toBuilder().name(shapeName + "ServerInput").build());
+        builder.putProperty("outputType", intermediate.toBuilder().name(shapeName + "ServerOutput").build());
+        return builder.build();
+    }
+
+    @Override
+    public Symbol serviceShape(ServiceShape shape) {
+        String baseName = flattenShapeName(shape);
+        String serviceName = baseName + "Service";
+        String moduleName = moduleNameDelegator.formatModuleName(shape, serviceName);
+
+        Symbol intermediate = createGeneratedSymbolBuilder(shape, serviceName, moduleName).build();
+        Symbol.Builder builder = intermediate.toBuilder();
+        builder.putProperty("operations",
+                intermediate.toBuilder().name(serviceName + "Operations").build());
+        builder.putProperty("handler",
+                intermediate.toBuilder().name(serviceName + "Handler").build());
+        return builder.build();
+    }
+
+    @Override
+    protected Symbol getDefault(Shape shape) {
+        return delegate.toSymbol(shape);
+    }
+
+    // TODO: Can probably share these statically with SymbolVisitor
+    private String flattenShapeName(ToShapeId id) {
+        return StringUtils.capitalize(id.toShapeId().getName());
+    }
+
+    private Symbol.Builder createGeneratedSymbolBuilder(Shape shape, String typeName, String namespace) {
+        return createSymbolBuilder(shape, typeName, namespace)
+                .definitionFile(toFilename(namespace));
+    }
+
+    private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, String namespace) {
+        return Symbol.builder()
+                .putProperty("shape", shape)
+                .name(typeName)
+                .namespace(namespace, "/");
+    }
+
+    private String toFilename(String namespace) {
+        return namespace + ".ts";
+    }
+
+    static final class ModuleNameDelegator {
+
+        public String formatModuleName(Shape shape, String name) {
+            if (shape.getType() == ShapeType.SERVICE) {
+                return "./server/" + name;
+            } else if (shape.getType() == ShapeType.OPERATION) {
+                return "./server/types/" + name;
+            }
+
+            throw new IllegalArgumentException("Unsupported shape type: " + shape.getType());
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -81,11 +81,12 @@ final class TypeScriptDelegator {
      * with the writer.
      *
      * @param shape Shape to create the writer for.
+     * @param provider The symbol provider to use (instead of the default one).
      * @param writerConsumer Consumer that accepts and works with the file.
      */
-    void useShapeWriter(Shape shape, Consumer<TypeScriptWriter> writerConsumer) {
+    void useShapeWriter(Shape shape, SymbolProvider provider, Consumer<TypeScriptWriter> writerConsumer) {
         // Checkout/create the appropriate writer for the shape.
-        Symbol symbol = symbolProvider.toSymbol(shape);
+        Symbol symbol = provider.toSymbol(shape);
         TypeScriptWriter writer = checkoutWriter(symbol.getDefinitionFile());
 
         // Add any needed DECLARE symbols.
@@ -97,11 +98,24 @@ final class TypeScriptDelegator {
         // Allow integrations to do things like add onSection callbacks.
         // These onSection callbacks are removed when popState is called.
         for (TypeScriptIntegration integration : integrations) {
-            integration.onShapeWriterUse(settings, model, symbolProvider, writer, shape);
+            integration.onShapeWriterUse(settings, model, provider, writer, shape);
         }
 
         writerConsumer.accept(writer);
         writer.popState();
+    }
+
+    /**
+     * Gets a previously created writer or creates a new one if needed.
+     *
+     * <p>Any imports required by the given symbol are automatically registered
+     * with the writer.
+     *
+     * @param shape Shape to create the writer for.
+     * @param writerConsumer Consumer that accepts and works with the file.
+     */
+    void useShapeWriter(Shape shape, Consumer<TypeScriptWriter> writerConsumer) {
+        useShapeWriter(shape, symbolProvider, writerConsumer);
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -310,5 +310,17 @@ public interface ProtocolGenerator {
         public void setProtocolName(String protocolName) {
             this.protocolName = protocolName;
         }
+
+        public GenerationContext withSymbolProvider(SymbolProvider newProvider) {
+            GenerationContext copy = new GenerationContext();
+            copy.setSettings(settings);
+            copy.setModel(model);
+            copy.setService(service);
+            copy.setSymbolProvider(newProvider);
+            copy.setWriter(writer);
+            copy.setIntegrations(integrations);
+            copy.setProtocolName(protocolName);
+            return copy;
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Refactors the server codegen to use a server-specific symbol provider and its symbols where possible.

You can see an example of what the new codegen looks like (in server-only mode) [here](https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/commit/21f905dfae52aa39fe0a3d920bba2baa06ce50f2).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
