### PR TITLE
Get rid of needing to cast OperationSerializers.

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -328,7 +328,6 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                             context.withSymbolProvider(serverSymbolProvider);
                     protocolGenerator.generateRequestDeserializers(serverContext);
                     protocolGenerator.generateResponseSerializers(serverContext);
-                    protocolGenerator.generateMux(serverContext);
                     protocolGenerator.generateHandlerFactory(serverContext);
                 }
                 protocolGenerator.generateSharedComponents(context);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -154,11 +154,6 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     }
 
     @Override
-    public void generateMux(GenerationContext context) {
-        LOGGER.warning("Router generation is not currently supported for RPC protocols.");
-    }
-
-    @Override
     public void generateHandlerFactory(GenerationContext context) {
         LOGGER.warning("Handler factory generation is not currently supported for RPC protocols.");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -154,14 +154,6 @@ public interface ProtocolGenerator {
      *
      * @param context Generation context.
      */
-    void generateMux(GenerationContext context);
-
-    /**
-     * Generates the code used to determine the service and operation
-     * targeted by a given request.
-     *
-     * @param context Generation context.
-     */
     void generateHandlerFactory(GenerationContext context);
 
     /**


### PR DESCRIPTION
*Description of changes:*
Instead of using a Record, just do it Java-style with a factory function that can spit out the correctly-typed OperationSerializer.

You can see what the diff for the generated code is here: https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/commit/c6efa24117dd7e0066bf70a336b859f82023e381

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
