### PR TITLE
fix bug when generating event stream events serializer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -850,8 +850,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             // Write event document bindings if exist.
             SymbolProvider symbolProvider = context.getSymbolProvider();
             Symbol symbol = symbolProvider.toSymbol(event);
-            // Use normal structure deserializer instead of event deserializer to deserialize document body.
-            String serFunctionName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName());
+            // Use normal structure serializer instead of event serializer to serialize document body.
+            String serFunctionName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
             writer.write("message.body = $L(input, context);", serFunctionName);
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

This will unblock the LaxRunTimeV2's new bi-directional streaming `StartConversation()` operation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
