### PR TITLE
Add ssdk response tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -436,16 +436,18 @@ final class HttpProtocolTestGenerator implements Runnable {
                 additionalStubs.add("protocol-test-xml-stub.ts");
                 return "compareEquivalentXmlBodies(bodyString, r.body.toString())";
             case "application/octet-stream":
+                writer.addImport("Encoder", "__Encoder", "@aws-sdk/types");
                 additionalStubs.add("protocol-test-octet-stream-stub.ts");
-                return "compareEquivalentOctetStreamBodies(client.config, bodyString, r.body)";
+                return "compareEquivalentOctetStreamBodies(client.config.utf8Encoder, bodyString, r.body)";
             case "text/plain":
                 additionalStubs.add("protocol-test-text-stub.ts");
                 return "compareEquivalentTextBodies(bodyString, r.body)";
             default:
                 LOGGER.warning("Unable to compare bodies with unknown media type `" + mediaType
                         + "`, defaulting to direct comparison.");
+                writer.addImport("Encoder", "__Encoder", "@aws-sdk/types");
                 additionalStubs.add("protocol-test-unknown-type-stub.ts");
-                return "compareEquivalentUnknownTypeBodies(client.config, bodyString, r.body)";
+                return "compareEquivalentUnknownTypeBodies(client.config.utf8Encoder, bodyString, r.body)";
         }
     }
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.7.0",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.20.0",
     "typescript": "~4.1.2"
   },
   "engines": {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-octet-stream-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-octet-stream-stub.ts
@@ -3,12 +3,12 @@
  * discrepancies between the components.
  */
 const compareEquivalentOctetStreamBodies = (
-  config: any,
+  utf8Encoder: __Encoder,
   expectedBody: string,
   generatedBody: Uint8Array
 ): Object => {
   const expectedParts = {Value: expectedBody};
-  const generatedParts = {Value: config.utf8Encoder(generatedBody)};
+  const generatedParts = {Value: utf8Encoder(generatedBody)};
 
   return compareParts(expectedParts, generatedParts);
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-unknown-type-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-unknown-type-stub.ts
@@ -3,13 +3,13 @@
  * discrepancies between the components.
  */
 const compareEquivalentUnknownTypeBodies = (
-  config: any,
+  utf8Encoder: __Encoder,
   expectedBody: string,
   generatedBody: string | Uint8Array
 ): Object => {
   const expectedParts = {Value: expectedBody};
   const generatedParts = {
-    Value: generatedBody instanceof Uint8Array ? config.utf8Encoder(generatedBody) : generatedBody
+    Value: generatedBody instanceof Uint8Array ? utf8Encoder(generatedBody) : generatedBody
   };
 
   return compareParts(expectedParts, generatedParts);


### PR DESCRIPTION
This adds protocol test generation for server responses, excluding errors. At time of writing 5 protocol tests fail due to differences in how servers and clients are expected to serialize empty bodies.

As part of that, this updates the compare octet and compare unknown protocol test test helpers to specifically take an Encoder rather than a client config.

This depends on #284 , ~~the first two commits are from that PR.~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
