### PR TITLE
ssdk modeled exception handling

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -410,7 +410,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
             if (settings.generateServerSdk()) {
                 writers.useShapeWriter(operation, serverSymbolProvider, commandWriter -> new ServerCommandGenerator(
-                        settings, model, operation, serverSymbolProvider, commandWriter).run());
+                        settings, model, operation, serverSymbolProvider, commandWriter,
+                        protocolGenerator, applicationProtocol).run());
             }
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -329,7 +329,9 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                             context.withSymbolProvider(serverSymbolProvider);
                     protocolGenerator.generateRequestDeserializers(serverContext);
                     protocolGenerator.generateResponseSerializers(serverContext);
-                    protocolGenerator.generateHandlerFactory(serverContext);
+                    writers.useShapeWriter(shape, serverSymbolProvider, w -> {
+                        protocolGenerator.generateHandlerFactory(serverContext.withWriter(w));
+                    });
                 }
                 protocolGenerator.generateSharedComponents(context);
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -175,7 +175,7 @@ final class ServerCommandGenerator implements Runnable {
                     }
                 }
                 writer.write("];");
-                writer.write("return error.name in names;");
+                writer.write("return names.includes(error.name);");
             }
         });
         writer.write("");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -115,12 +115,10 @@ final class ServerCommandGenerator implements Runnable {
     }
 
     private void writeErrorType() {
-        Symbol operationSymbol = symbolProvider.toSymbol(operation);
-
         if (operation.getErrors().isEmpty()) {
             writer.write("export type $L = never;", errorsType.getName());
         } else {
-            writer.writeInline("export type $LErrors = ", operationSymbol.getName());
+            writer.writeInline("export type $L = ", errorsType.getName());
             for (Iterator<ShapeId> iter = operation.getErrors().iterator(); iter.hasNext();) {
                 writer.writeInline("$T", symbolProvider.toSymbol(model.expectShape(iter.next())));
                 if (iter.hasNext()) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -57,6 +57,7 @@ final class ServerGenerator {
         writer.addImport("toUtf8", null, "@aws-sdk/util-utf8-node");
         writer.addImport("HttpRequest", null, "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", null, "@aws-sdk/protocol-http");
+        writer.addImport("SmithyException", null, "@aws-sdk/smithy-client");
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
@@ -65,8 +66,8 @@ final class ServerGenerator {
         writer.openBlock("export class $L implements ServiceHandler {", "}", handlerSymbol.getName(), () -> {
             writer.write("private service: $T;", serviceSymbol);
             writer.write("private mux: Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
-            writer.write("private serializerFactory: <T extends $T>(operation: T) => OperationSerializer<$T, T>;",
-                    operationsType, serviceSymbol);
+            writer.write("private serializerFactory: <T extends $T>(operation: T) => "
+                            + "OperationSerializer<$T, T, SmithyException>;", operationsType, serviceSymbol);
             writer.openBlock("private serdeContextBase = {", "};", () -> {
                 writer.write("base64Encoder: toBase64,");
                 writer.write("base64Decoder: fromBase64,");
@@ -89,7 +90,8 @@ final class ServerGenerator {
             });
             writer.openBlock("constructor(service: $1T, "
                             + "mux: Mux<$3S, $2T>, "
-                            + "serializerFactory: <T extends $2T>(op: T) => OperationSerializer<$1T, T>) {", "}",
+                            + "serializerFactory: <T extends $2T>(op: T) => "
+                            + "OperationSerializer<$1T, T, SmithyException>) {", "}",
                     serviceSymbol, operationsType, serviceShape.getId().getName(), () -> {
                 writer.write("this.service = service;");
                 writer.write("this.mux = mux;");
@@ -136,10 +138,7 @@ final class ServerGenerator {
         writer.openBlock("export interface $L {", "}", serviceInterfaceName, () -> {
             for (OperationShape operation : operations) {
                 Symbol symbol = symbolProvider.toSymbol(operation);
-                writer.write("$L: $L<$T, $T>", symbol.getName(),
-                        "__Operation",
-                        symbol.expectProperty("inputType", Symbol.class),
-                        symbol.expectProperty("outputType", Symbol.class));
+                writer.write("$L: $T", symbol.getName(), symbol);
             }
         });
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -81,6 +81,8 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
         //TODO: these names suck but otherwise they clash with the names in models
         builder.putProperty("inputType", intermediate.toBuilder().name(shapeName + "ServerInput").build());
         builder.putProperty("outputType", intermediate.toBuilder().name(shapeName + "ServerOutput").build());
+        builder.putProperty("errorsType", intermediate.toBuilder().name(shapeName + "Errors").build());
+        builder.putProperty("serializerType", intermediate.toBuilder().name(shapeName + "Serializer").build());
         return builder.build();
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -303,16 +303,28 @@ public interface ProtocolGenerator {
             this.protocolName = protocolName;
         }
 
-        public GenerationContext withSymbolProvider(SymbolProvider newProvider) {
+        public GenerationContext copy() {
             GenerationContext copy = new GenerationContext();
             copy.setSettings(settings);
             copy.setModel(model);
             copy.setService(service);
-            copy.setSymbolProvider(newProvider);
+            copy.setSymbolProvider(symbolProvider);
             copy.setWriter(writer);
             copy.setIntegrations(integrations);
             copy.setProtocolName(protocolName);
             return copy;
+        }
+
+        public GenerationContext withSymbolProvider(SymbolProvider newProvider) {
+            GenerationContext copyContext = copy();
+            copyContext.setSymbolProvider(newProvider);
+            return copyContext;
+        }
+
+        public GenerationContext withWriter(TypeScriptWriter newWriter) {
+            GenerationContext copyContext = copy();
+            copyContext.setWriter(newWriter);
+            return copyContext;
         }
     }
 }


### PR DESCRIPTION
This add exception handling to the SSDK. In doing so I've re-arranged a bunch of things to be a bit more split up. Notably the `getServiceHandler` function has been moved into the service's file and each `OperationSerializer` has been moved into that operation's file.

In addition to re-organizing, this depends on two new additions to the `OperationSerializer`, `isOperationError` and `serializeError`.

```typescript
export interface OperationSerializer<T, K extends keyof T, E extends SmithyException> {
    serialize(input: OperationOutput<T[K]>, ctx: Omit<SerdeContext, 'endpoint'>): Promise<HttpResponse>
    deserialize(input: HttpRequest, ctx: SerdeContext): Promise<OperationInput<T[K]>>
    isOperationError(error: any): error is E
    serializeError(error: E, ctx: Omit<SerdeContext, 'endpoint'>): Promise<HttpResponse>
}
```

`isOperationError` is used to check to see if an exception is in a union of exceptions that the operation expects. TypeScript is neat in that it allows you to specifically type a boolean so that it can know that's what I'm doing. Unfortunately TypeScript won't generate this check for me, so I have to do it myself. This is needed because js has only one catch block and the exception is always an `any` (though I'm assigning it to `unknown` for a bit of extra saftey).

`serializeError` is pretty self-explanitory: it dispatches to the correct serializer based on the `name` of the `SmithyException`. Since it's a simple union, something like an error mux isn't needed.

Here's an example of a generated `OperationSerializer`:

```typescript
export type GetVenue = __Operation<GetVenueServerInput, GetVenueServerOutput>

export type GetVenueServerInput = GetVenueInput;
export type GetVenueServerOutput = GetVenueOutput & __MetadataBearer;

export type GetVenueErrors = NoSuchResource | RequestTimeout

export class GetVenueSerializer implements OperationSerializer<BootlegService, "GetVenue", GetVenueErrors> {
  serialize = serializeGetVenueResponse;
  deserialize = deserializeGetVenueRequest;

  isOperationError(error: any): error is GetVenueErrors {
    // I wish TS could do this for me, but it does not seem to be able to.
    const names: GetVenueErrors['name'][] = ["NoSuchResource", "RequestTimeout"];
    return names.includes(error.name);
  };

  serializeError(error: GetVenueErrors, ctx: Omit<SerdeContext, 'endpoint'>): Promise<__HttpResponse> {
    switch (error.name) {
      case "NoSuchResource": {
        return serializeNoSuchResourceError(error, ctx);
      }
      case "RequestTimeout": {
        return serializeRequestTimeoutError(error, ctx);
      }
      default: {
        // Re-throw any error that we don't know about
        throw error;
      }
    }
  }

}
```

The generated service handler now looks like:

```typescript
export type BootlegServiceOperations = "GetVenue" | "ListVenues";
export interface BootlegService {
  GetVenue: GetVenue
  ListVenues: ListVenues
}
export class BootlegServiceHandler implements ServiceHandler {
  private service: BootlegService;
  private mux: Mux<"Bootleg", BootlegServiceOperations>;
  private serializerFactory: <T extends BootlegServiceOperations>(operation: T) => OperationSerializer<BootlegService, T, SmithyException>;
  private serdeContextBase = {
    base64Encoder: toBase64,
    base64Decoder: fromBase64,
    utf8Encoder: toUtf8,
    utf8Decoder: fromUtf8,
    streamCollector: streamCollector,
    requestHandler: new NodeHttpHandler(),
    disableHostPrefix: true
  };
  /**
   * Construct a BootlegService handler.
   * @param service The {@link BootlegService} implementation that supplies the business logic for BootlegService
   * @param mux The {@link Mux} that determines which service and operation are being invoked by a given {@link HttpRequest}
   * @param serializerFactory A factory for an {@link OperationSerializer} for each operation in BootlegService that
   *                          handles deserialization of requests and serialization of responses
   */
  constructor(service: BootlegService, mux: Mux<"Bootleg", BootlegServiceOperations>, serializerFactory: <T extends BootlegServiceOperations>(op: T) => OperationSerializer<BootlegService, T, SmithyException>) {
    this.service = service;
    this.mux = mux;
    this.serializerFactory = serializerFactory;
  }
  async handle(request: HttpRequest): Promise<HttpResponse> {
    const target = this.mux.match(request);
    if (target === undefined) {
      throw new Error(`Could not match any operation to ${request.method} ${request.path} ${JSON.stringify(request.query)}`);
    }
    switch (target.operation) {
      case "GetVenue" : {
        let serializer = this.serializerFactory("GetVenue");
        try {
          let input = await serializer.deserialize(request, {
            endpoint: () => Promise.resolve(request), ...this.serdeContextBase
          });
          let output = this.service.GetVenue(input, request);
          return serializer.serialize(output, this.serdeContextBase);
        } catch(error: unknown) {
          if (serializer.isOperationError(error)) {
            return serializer.serializeError(error, this.serdeContextBase);
          }
          throw error;
        }
      }
      case "ListVenues" : {
        let serializer = this.serializerFactory("ListVenues");
        try {
          let input = await serializer.deserialize(request, {
            endpoint: () => Promise.resolve(request), ...this.serdeContextBase
          });
          let output = this.service.ListVenues(input, request);
          return serializer.serialize(output, this.serdeContextBase);
        } catch(error: unknown) {
          if (serializer.isOperationError(error)) {
            return serializer.serializeError(error, this.serdeContextBase);
          }
          throw error;
        }
      }
    }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
