### PR TITLE
Pin fast-xml-parser dependency to 3.19.0

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -74,7 +74,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     // Conditionally added when interacting with specific protocol test bodyMediaType values.
     AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", "3.6.1", false),
-    XML_PARSER("dependencies", "fast-xml-parser", "3.17.4", false);
+    XML_PARSER("dependencies", "fast-xml-parser", "3.19.0", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";


### PR DESCRIPTION
*Issue #, if available:*
The fast-xml-parser was pinned to v3.17.4 as the project switched to modified MIT License in >=3.17.5 in https://github.com/NaturalIntelligence/fast-xml-parser/commit/5d4e95188c4d3bf57ee1b2f5489c017ca3be627c

The license is now updated to MIT in [3.19.0](https://github.com/NaturalIntelligence/fast-xml-parser/blob/bbfecf97821c62685555c21a09e4071690899fef/package.json#L70)

*Description of changes:*
Pin fast-xml-parser dependency to 3.19.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
