### PR TITLE
fix: create jest.config.js for clients

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/jest.config.js
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/jest.config.js
@@ -1,7 +1,4 @@
-const base = require("../../jest.config.base.js");
-
 module.exports = {
-    ...base,
-    // Only test cjs dist, avoid testing the package twice
-    testPathIgnorePatterns: ["/node_modules/", "/es/"]
+  preset: "ts-jest",
+  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
 };


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1618

*Description of changes:*
Creates jest.config.js for clients instead of extending global config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
