### PR TITLE
Use service renames

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -39,9 +39,10 @@ public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
      * Creates a TypeScript symbol provider.
      *
      * @param model Model to generate symbols for.
+     * @param settings Settings used by the plugin.
      * @return Returns the created provider.
      */
-    public static SymbolProvider createSymbolProvider(Model model) {
-        return new SymbolVisitor(model);
+    public static SymbolProvider createSymbolProvider(Model model, TypeScriptSettings settings) {
+        return new SymbolVisitor(model, settings);
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
@@ -20,7 +20,11 @@ public class EnumGeneratorTest {
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
-        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        Model model = Model.assembler()
+                .addShape(shape)
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
         TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))
@@ -41,7 +45,11 @@ public class EnumGeneratorTest {
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
-        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        Model model = Model.assembler()
+                .addShape(shape)
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
         TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
@@ -19,7 +20,12 @@ public class EnumGeneratorTest {
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
-        Symbol symbol = TypeScriptCodegenPlugin.createSymbolProvider(Model.builder().build()).toSymbol(shape);
+        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        Symbol symbol = TypeScriptCodegenPlugin.createSymbolProvider(model, settings).toSymbol(shape);
         new EnumGenerator(shape, symbol, writer).run();
 
         assertThat(writer.toString(), containsString("export enum Baz {"));
@@ -35,7 +41,12 @@ public class EnumGeneratorTest {
                 .build();
         StringShape shape = StringShape.builder().id("com.foo#Baz").addTrait(trait).build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
-        Symbol symbol = TypeScriptCodegenPlugin.createSymbolProvider(Model.builder().build()).toSymbol(shape);
+        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        Symbol symbol = TypeScriptCodegenPlugin.createSymbolProvider(model, settings).toSymbol(shape);
         new EnumGenerator(shape, symbol, writer).run();
 
         assertThat(writer.toString(), containsString("export type Baz = \"BAR\" | \"FOO\""));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
@@ -19,7 +19,7 @@ public class IndexGeneratorTest {
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))
                 .build());
-        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         MockManifest manifest = new MockManifest();
 
         IndexGenerator.writeIndex(settings, model, symbolProvider, manifest);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -68,7 +68,7 @@ public class RuntimeConfigGeneratorTest {
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))
                 .build());
-        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         TypeScriptDelegator delegator = new TypeScriptDelegator(
                 settings, model, manifest, symbolProvider, integrations);
         RuntimeConfigGenerator generator = new RuntimeConfigGenerator(

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServiceGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/ServiceGeneratorTest.java
@@ -27,7 +27,7 @@ public class ServiceGeneratorTest {
                 .withMember("packageVersion", Node.from("1.0.0"))
                 .build());
         TypeScriptWriter writer = new TypeScriptWriter("./foo");
-        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         ApplicationProtocol applicationProtocol = ApplicationProtocol.createDefaultHttpApplicationProtocol();
 
         List<TypeScriptIntegration> integrations = new ArrayList<>();

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -487,9 +487,11 @@ public class StructureGeneratorTest {
     @Test
     public void generatesNonErrorStructures() {
         StructureShape struct = createNonErrorStructure();
-        ModelAssembler assembler = Model.assembler().addShape(struct);
+        ModelAssembler assembler = Model.assembler()
+                .addShape(struct)
+                .addImport(getClass().getResource("simple-service.smithy"));
         struct.getAllMembers().values().forEach(assembler::addShape);
-        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        Model model = assembler.assemble().unwrap();
         TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))
@@ -514,11 +516,13 @@ public class StructureGeneratorTest {
     @Test
     public void generatesNonErrorStructuresThatExtendOtherInterfaces() {
         StructureShape struct = createNonErrorStructure();
-        ModelAssembler assembler = Model.assembler().addShape(struct);
+        ModelAssembler assembler = Model.assembler()
+                .addShape(struct)
+                .addImport(getClass().getResource("simple-service.smithy"));
         struct.getAllMembers().values().forEach(assembler::addShape);
         OperationShape operation = OperationShape.builder().id("com.foo#Operation").output(struct).build();
         assembler.addShape(operation);
-        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        Model model = assembler.assemble().unwrap();
         TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
                 .withMember("package", Node.from("example"))
                 .withMember("packageVersion", Node.from("1.0.0"))

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -489,10 +489,14 @@ public class StructureGeneratorTest {
         StructureShape struct = createNonErrorStructure();
         ModelAssembler assembler = Model.assembler().addShape(struct);
         struct.getAllMembers().values().forEach(assembler::addShape);
-        Model model = assembler.assemble().unwrap();
+        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
         TypeScriptWriter writer = new TypeScriptWriter("./foo");
-        new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model), writer, struct).run();
+        new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model, settings), writer, struct).run();
         String output = writer.toString();
 
         assertThat(output, containsString("export interface Bar {"));
@@ -514,10 +518,14 @@ public class StructureGeneratorTest {
         struct.getAllMembers().values().forEach(assembler::addShape);
         OperationShape operation = OperationShape.builder().id("com.foo#Operation").output(struct).build();
         assembler.addShape(operation);
-        Model model = assembler.assemble().unwrap();
+        Model model = Model.assembler().addImport(getClass().getResource("simple-service.smithy")).assemble().unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
         TypeScriptWriter writer = new TypeScriptWriter("./foo");
-        new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model), writer, struct).run();
+        new StructureGenerator(model, TypeScriptCodegenPlugin.createSymbolProvider(model, settings), writer, struct).run();
         String output = writer.toString();
 
         assertThat(output, containsString("export interface Bar {"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -22,8 +23,16 @@ public class SymbolProviderTest {
     @Test
     public void createsSymbols() {
         Shape shape = StructureShape.builder().id("com.foo.baz#Hello").build();
-        Model model = Model.assembler().addShape(shape).assemble().unwrap();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .addShape(shape)
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol symbol = provider.toSymbol(shape);
 
         assertThat(symbol.getName(), equalTo("Hello"));
@@ -36,8 +45,16 @@ public class SymbolProviderTest {
     public void createsSymbolsIntoTargetNamespace() {
         Shape shape1 = StructureShape.builder().id("com.foo#Hello").build();
         Shape shape2 = StructureShape.builder().id("com.foo.baz#Hello").build();
-        Model model = Model.assembler().addShapes(shape1, shape2).assemble().unwrap();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .addShapes(shape1, shape2)
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
         MockManifest manifest = new MockManifest();
@@ -59,8 +76,16 @@ public class SymbolProviderTest {
     @Test
     public void escapesReservedWords() {
         Shape shape = StructureShape.builder().id("com.foo.baz#Pick").build();
-        Model model = Model.assembler().addShape(shape).assemble().unwrap();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .addShape(shape)
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol symbol = provider.toSymbol(shape);
 
         assertThat(symbol.getName(), equalTo("_Pick"));
@@ -74,11 +99,16 @@ public class SymbolProviderTest {
                 .addMember(member)
                 .build();
         Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
                 .addShapes(struct, member)
                 .assemble()
                 .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
 
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         Symbol structSymbol = provider.toSymbol(struct);
         Symbol memberSymbol = provider.toSymbol(member);
 
@@ -100,11 +130,16 @@ public class SymbolProviderTest {
                 .member(listMember)
                 .build();
         Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
                 .addShapes(list, listMember, record)
                 .assemble()
                 .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol listSymbol = provider.toSymbol(list);
 
         assertThat(listSymbol.getName(), equalTo("(_Record)[]"));
@@ -116,11 +151,15 @@ public class SymbolProviderTest {
                 .addImport(getClass().getResource("output-structure.smithy"))
                 .assemble()
                 .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
         Shape input = model.expectShape(ShapeId.from("smithy.example#GetFooInput"));
         Shape output = model.expectShape(ShapeId.from("smithy.example#GetFooOutput"));
         Shape error = model.expectShape(ShapeId.from("smithy.example#GetFooError"));
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol inputSymbol = provider.toSymbol(input);
         Symbol outputSymbol = provider.toSymbol(output);
         Symbol errorSymbol = provider.toSymbol(error);
@@ -148,9 +187,13 @@ public class SymbolProviderTest {
                 .addImport(getClass().getResource("output-structure.smithy"))
                 .assemble()
                 .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
         Shape command = model.expectShape(ShapeId.from("smithy.example#GetFoo"));
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol commandSymbol = provider.toSymbol(command);
 
         assertThat(commandSymbol.getName(), equalTo("GetFooCommand"));
@@ -167,11 +210,16 @@ public class SymbolProviderTest {
                 .addMember(member)
                 .build();
         Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
                 .addShapes(struct, member, jsonString)
                 .assemble()
                 .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
 
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         Symbol memberSymbol = provider.toSymbol(member);
 
         assertThat(memberSymbol.getName(), equalTo("__LazyJsonString | string"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/UnionGeneratorTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 
@@ -30,8 +31,16 @@ public class UnionGeneratorTest {
                 .addMember(memberB)
                 .addMember(memberC)
                 .build();
-        Model model = Model.assembler().addShapes(unionShape, memberA, memberB, memberC).assemble().unwrap();
-        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .addShapes(unionShape, memberA, memberB, memberC)
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
         TypeScriptWriter writer = new TypeScriptWriter("./Example");
         new UnionGenerator(model, symbolProvider, writer, unionShape).run();
         String output = writer.toString();


### PR DESCRIPTION
Updates SymbolVisitor to use service renames added in Smithy 1.7.0: https://github.com/awslabs/smithy/pull/734

Removes shape condensing in CodegenVisitor.  Since services must rename conflicting shapes, it is no longer necessary to try to condense these shapes during codegen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
