### PR TITLE
Generate ssdk error tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -183,6 +183,17 @@ final class HttpProtocolTestGenerator implements Runnable {
                     onlyIfProtocolMatches(testCase, () -> generateServerResponseTest(operation, testCase));
                 }
             });
+            // 3. Generate test cases for each error on each operation.
+            for (StructureShape error : operationIndex.getErrors(operation)) {
+                if (!error.hasTag("server-only")) {
+                    error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
+                        for (HttpResponseTestCase testCase : trait.getTestCasesFor(AppliesTo.SERVER)) {
+                            onlyIfProtocolMatches(testCase,
+                                    () -> generateServerErrorResponseTest(operation, error, testCase));
+                        }
+                    });
+                }
+            }
         }
     }
 
@@ -288,8 +299,7 @@ final class HttpProtocolTestGenerator implements Runnable {
             });
 
             String getHandlerName = "get" + handlerSymbol.getName();
-            writer.addImport(getHandlerName, getHandlerName,
-                    "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
+            writer.addImport(getHandlerName, null, "./server/");
 
             // Cast the service as any so TS will ignore the fact that the type being passed in is incomplete.
             writer.write("const handler = $L(testService as $T);", getHandlerName, serviceSymbol);
@@ -477,8 +487,6 @@ final class HttpProtocolTestGenerator implements Runnable {
     public void generateServerResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
         Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
         Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
-        Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
-        Symbol serviceOperationsSymbol = serviceSymbol.expectProperty("operations", Symbol.class);
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         String testName = testCase.getId() + ":ServerResponse";
         writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
@@ -497,42 +505,7 @@ final class HttpProtocolTestGenerator implements Runnable {
                     }
                 });
             });
-
-            writer.write("const service: any = new TestService()");
-
-            // There's a lot of setup here, including creating our own mux, serializers list, and ultimately
-            // our own service handler. This is largely in service of avoiding having to go through the
-            // request deserializer
-            writer.addImport("httpbinding", null, "@aws-smithy/server-common");
-            writer.openBlock("const testMux = new httpbinding.HttpBindingMux<$S, keyof $T>([", "]);",
-                service.getId().getName(), serviceSymbol, () -> {
-                    writer.openBlock("new httpbinding.UriSpec<$S, $S>('POST', [], [], {", "}),",
-                        service.getId().getName(), operation.getId().getName(), () -> {
-                            writer.write("service: $S,", service.getId().getName());
-                            writer.write("operation: $S,", operation.getId().getName());
-                        });
-                });
-
-            writer.write("const request = new HttpRequest({method: 'POST', hostname: 'example.com'});");
-
-            String serializerName = ProtocolGenerator.getGenericSerFunctionName(operationSymbol) + "Response";
-            writer.addImport(serializerName, serializerName,
-                    "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
-
-            writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
-            writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T, $1T> = (op) => {", "};",
-                    serviceOperationsSymbol, serviceSymbol, () -> {
-                writer.openBlock("return {", "};", () -> {
-                    writer.write("serialize: $L,", serializerName);
-                    writer.openBlock("deserialize: (output: any, context: any): Promise<any> => {", "},", () -> {
-                        writer.write("return Promise.resolve({});");
-                    });
-                });
-            });
-
-            writer.write("const handler = new $T(service, testMux, serFn);", handlerSymbol);
-            writer.write("let r = await handler.handle(request)").write("");
-            writeHttpResponseAssertions(testCase);
+            writeServerResponseTest(operation, testCase);
         });
     }
 
@@ -552,6 +525,76 @@ final class HttpProtocolTestGenerator implements Runnable {
                        + "}");
             writeResponseAssertions(operation, testCase);
         });
+    }
+
+    private void generateServerErrorResponseTest(
+            OperationShape operation,
+            StructureShape error,
+            HttpResponseTestCase testCase
+    ) {
+        Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
+        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol outputType = operationSymbol.expectProperty("outputType", Symbol.class);
+        Symbol errorSymbol = serverSymbolProvider.toSymbol(error);
+        ErrorTrait errorTrait = error.expectTrait(ErrorTrait.class);
+        testCase.getDocumentation().ifPresent(writer::writeDocs);
+        String testName = testCase.getId() + ":ServerErrorResponse";
+        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+            writer.openBlock("class TestService implements Partial<$T> {", "}", serviceSymbol, () -> {
+                writer.openBlock("$L(input: any, request: HttpRequest): $T {", "}",
+                    operationSymbol.getName(), outputType, () -> {
+                        writer.writeInline("const response = ");
+                        testCase.getParams().accept(new CommandInputNodeVisitor(error, true));
+                        writer.openBlock("const error: $T = {", "};", errorSymbol, () -> {
+                            writer.write("...response,");
+                            writer.write("name: $S,", error.getId().getName());
+                            writer.write("$$fault: $S,", errorTrait.isClientError() ? "client" : "server");
+                            writer.write("$$metadata: {},");
+                        });
+                        writer.write("throw error;");
+                    });
+            });
+            writeServerResponseTest(operation, testCase);
+        });
+    }
+
+    private void writeServerResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
+        Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
+        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
+        Symbol serializerSymbol = operationSymbol.expectProperty("serializerType", Symbol.class);
+        Symbol serviceOperationsSymbol = serviceSymbol.expectProperty("operations", Symbol.class);
+        writer.write("const service: any = new TestService()");
+
+        // There's a lot of setup here, including creating our own mux, serializers list, and ultimately
+        // our own service handler. This is largely in service of avoiding having to go through the
+        // request deserializer
+        writer.addImport("httpbinding", null, "@aws-smithy/server-common");
+        writer.openBlock("const testMux = new httpbinding.HttpBindingMux<$S, keyof $T>([", "]);",
+            service.getId().getName(), serviceSymbol, () -> {
+                writer.openBlock("new httpbinding.UriSpec<$S, $S>('POST', [], [], {", "}),",
+                    service.getId().getName(), operation.getId().getName(), () -> {
+                        writer.write("service: $S,", service.getId().getName());
+                        writer.write("operation: $S,", operation.getId().getName());
+                    });
+            });
+
+        writer.write("const request = new HttpRequest({method: 'POST', hostname: 'example.com'});");
+
+        writer.openBlock("class TestSerializer extends $T {", "}", serializerSymbol, () -> {
+            writer.openBlock("deserialize = (output: any, context: any): Promise<any> => {", "};", () -> {
+                writer.write("return Promise.resolve({});");
+            });
+        });
+
+        writer.addImport("SmithyException", "__SmithyException", "@aws-sdk/smithy-client");
+        writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
+        writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T, $1T, __SmithyException> = (op) =>"
+                        + " { return new TestSerializer(); };", serviceOperationsSymbol, serviceSymbol);
+
+        writer.write("const handler = new $T(service, testMux, serFn);", handlerSymbol);
+        writer.write("let r = await handler.handle(request)").write("");
+        writeHttpResponseAssertions(testCase);
     }
 
     private void generateErrorResponseTest(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -182,14 +182,18 @@ final class ServerCommandGenerator implements Runnable {
     private void writeErrorHandler() {
         writer.addImport("SerdeContext", null, "@aws-sdk/types");
         writer.openBlock("serializeError(error: $T, ctx: Omit<SerdeContext, 'endpoint'>): Promise<$T> {", "}",
-                errorsType, applicationProtocol.getResponseType(), () -> {
-            writer.openBlock("switch (error.name) {", "}", () -> {
-                for (ShapeId errorId : operation.getErrors()) {
-                    writeErrorHandlerCase(errorId);
+            errorsType, applicationProtocol.getResponseType(), () -> {
+                if (operation.getErrors().isEmpty()) {
+                    writer.write("throw error;");
+                } else {
+                    writer.openBlock("switch (error.name) {", "}", () -> {
+                        for (ShapeId errorId : operation.getErrors()) {
+                            writeErrorHandlerCase(errorId);
+                        }
+                        writer.openBlock("default: {", "}", () -> writer.write("throw error;"));
+                    });
                 }
-                writer.openBlock("default: {", "}", () -> writer.write("throw error;"));
             });
-        });
         writer.write("");
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -182,18 +182,18 @@ final class ServerCommandGenerator implements Runnable {
     private void writeErrorHandler() {
         writer.addImport("SerdeContext", null, "@aws-sdk/types");
         writer.openBlock("serializeError(error: $T, ctx: Omit<SerdeContext, 'endpoint'>): Promise<$T> {", "}",
-            errorsType, applicationProtocol.getResponseType(), () -> {
-                if (operation.getErrors().isEmpty()) {
-                    writer.write("throw error;");
-                } else {
-                    writer.openBlock("switch (error.name) {", "}", () -> {
-                        for (ShapeId errorId : operation.getErrors()) {
-                            writeErrorHandlerCase(errorId);
-                        }
-                        writer.openBlock("default: {", "}", () -> writer.write("throw error;"));
-                    });
-                }
-            });
+                errorsType, applicationProtocol.getResponseType(), () -> {
+            if (operation.getErrors().isEmpty()) {
+                writer.write("throw error;");
+            } else {
+                writer.openBlock("switch (error.name) {", "}", () -> {
+                    for (ShapeId errorId : operation.getErrors()) {
+                        writeErrorHandlerCase(errorId);
+                    }
+                    writer.openBlock("default: {", "}", () -> writer.write("throw error;"));
+                });
+            }
+        });
         writer.write("");
     }
 


### PR DESCRIPTION
This updates the http protocol test generator to include error tests. A generated test looks like:

```typescript
it("RestJsonInvalidGreetingError:ServerErrorResponse", async () => {
  class TestService implements Partial<RestJsonService> {
    GreetingWithErrors(input: any, request: HttpRequest): GreetingWithErrorsServerOutput {
      const response = {
        Message: "Hi",
      } as any;
      const error: InvalidGreeting = {
        ...response,
        name: "InvalidGreeting",
        $fault: "client",
        $metadata: {},
      };
      throw error;
    }
  }
  const service: any = new TestService();
  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService>([
    new httpbinding.UriSpec<"RestJson", "GreetingWithErrors">("POST", [], [], {
      service: "RestJson",
      operation: "GreetingWithErrors",
    }),
  ]);
  class TestSerializer extends GreetingWithErrorsSerializer {
    deserialize = (output: any, context: any): Promise<any> => {
      return Promise.resolve({});
    };
  }
  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
  const serFn: (
    op: RestJsonServiceOperations
  ) => __OperationSerializer<RestJsonService, RestJsonServiceOperations, __SmithyException> = (op) => {
    return new TestSerializer();
  };
  const handler = new RestJsonServiceHandler(service, testMux, serFn);
  let r = await handler.handle(request);

  expect(r.statusCode).toBe(400);

  expect(r.headers["content-type"]).toBeDefined();
  expect(r.headers["content-type"]).toBe("application/json");
  expect(r.headers["x-amzn-errortype"]).toBeDefined();
  expect(r.headers["x-amzn-errortype"]).toBe("InvalidGreeting");

  expect(r.body).toBeDefined();
  const utf8Encoder = __utf8Encoder;
  const bodyString = `{
                \"Message\": \"Hi\"
            }`;
  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
  expect(unequalParts).toBeUndefined();
});
```

Additionally, I tweaked the `serializeError` for operations with no modeled errors to immediately throw. Before it was creating an empty switch statement which would cause TypeScript to fail to compile since the errors union is `never`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
