### PR TITLE
Support for framework exceptions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -329,6 +329,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                             context.withSymbolProvider(serverSymbolProvider);
                     protocolGenerator.generateRequestDeserializers(serverContext);
                     protocolGenerator.generateResponseSerializers(serverContext);
+                    protocolGenerator.generateFrameworkErrorSerializer(serverContext);
                     writers.useShapeWriter(shape, serverSymbolProvider, w -> {
                         protocolGenerator.generateHandlerFactory(serverContext.withWriter(w));
                     });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/FrameworkErrorModel.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/FrameworkErrorModel.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import software.amazon.smithy.model.Model;
+
+public enum FrameworkErrorModel {
+
+    INSTANCE;
+
+    private final Model model = Model.assembler()
+            .addImport(FrameworkErrorModel.class.getResource("framework-errors.smithy"))
+            .assemble()
+            .unwrap();
+
+    public Model getModel() {
+        return model;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -143,7 +143,7 @@ final class ServerGenerator {
                     + "this.serdeContextBase);");
             writer.closeBlock("}");
             writer.openBlock("try {", "} catch(error: unknown) {", () -> {
-                writer.write("let output = this.service.$L(input, request);", operationSymbol.getName());
+                writer.write("let output = await this.service.$L(input, request);", operationSymbol.getName());
                 writer.write("return serializer.serialize(output, this.serdeContextBase);");
             });
             writer.indent();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -49,6 +49,11 @@ final class ServerGenerator {
         writer.addImport("ServiceHandler", null, "@aws-smithy/server-common");
         writer.addImport("Mux", null, "@aws-smithy/server-common");
         writer.addImport("OperationSerializer", null, "@aws-smithy/server-common");
+        writer.addImport("UnknownOperationException", null, "@aws-smithy/server-common");
+        writer.addImport("InternalFailureException", null, "@aws-smithy/server-common");
+        writer.addImport("SerializationException", null, "@aws-smithy/server-common");
+        writer.addImport("SmithyFrameworkException", null, "@aws-smithy/server-common");
+        writer.addImport("SerdeContext", null, "@aws-sdk/types");
         writer.addImport("NodeHttpHandler", null, "@aws-sdk/node-http-handler");
         writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
         writer.addImport("fromBase64", null, "@aws-sdk/util-base64-node");
@@ -68,6 +73,8 @@ final class ServerGenerator {
             writer.write("private mux: Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
             writer.write("private serializerFactory: <T extends $T>(operation: T) => "
                             + "OperationSerializer<$T, T, SmithyException>;", operationsType, serviceSymbol);
+            writer.write("private serializeFrameworkException: (e: SmithyFrameworkException, "
+                            + "ctx: Omit<SerdeContext, 'endpoint'>) => Promise<HttpResponse>;");
             writer.openBlock("private serdeContextBase = {", "};", () -> {
                 writer.write("base64Encoder: toBase64,");
                 writer.write("base64Decoder: fromBase64,");
@@ -87,25 +94,32 @@ final class ServerGenerator {
                 writer.write("operation in $T that ", serviceSymbol);
                 writer.writeInline("                         ")
                       .write("handles deserialization of requests and serialization of responses");
+                writer.write("@param serializeFrameworkException A function that can serialize "
+                        + "{@link SmithyFrameworkException}s");
             });
-            writer.openBlock("constructor(service: $1T, "
-                            + "mux: Mux<$3S, $2T>, "
-                            + "serializerFactory: <T extends $2T>(op: T) => "
-                            + "OperationSerializer<$1T, T, SmithyException>) {", "}",
-                    serviceSymbol, operationsType, serviceShape.getId().getName(), () -> {
-                writer.write("this.service = service;");
-                writer.write("this.mux = mux;");
-                writer.write("this.serializerFactory = serializerFactory;");
+            writer.openBlock("constructor(", ") {", () -> {
+                writer.write("service: $T,", serviceSymbol);
+                writer.write("mux: Mux<$S, $T>,", serviceShape.getId().getName(), operationsType);
+                writer.write("serializerFactory:<T extends $T>(op: T) => OperationSerializer<$T, T, SmithyException>,",
+                        operationsType, serviceSymbol);
+                writer.write("serializeFrameworkException: (e: SmithyFrameworkException, ctx: Omit<SerdeContext, "
+                        + "'endpoint'>) => Promise<HttpResponse>");
             });
+            writer.indent();
+            writer.write("this.service = service;");
+            writer.write("this.mux = mux;");
+            writer.write("this.serializerFactory = serializerFactory;");
+            writer.write("this.serializeFrameworkException = serializeFrameworkException;");
+            writer.closeBlock("}");
             writer.openBlock("async handle(request: HttpRequest): Promise<HttpResponse> {", "}", () -> {
                 writer.write("const target = this.mux.match(request);");
                 writer.openBlock("if (target === undefined) {", "}", () -> {
-                    writer.write("throw new Error(`Could not match any operation to $${request.method} "
-                            + "$${request.path} $${JSON.stringify(request.query)}`);");
+                    writer.write("return serializeFrameworkException(new UnknownOperationException(), "
+                            + "this.serdeContextBase);");
                 });
                 writer.openBlock("switch (target.operation) {", "}", () -> {
                     for (OperationShape operation : operations) {
-                        generateHandlerCase(writer, serviceSymbol, operation, symbolProvider.toSymbol(operation));
+                        generateHandlerCase(writer, operation, symbolProvider.toSymbol(operation));
                     }
                 });
             });
@@ -113,25 +127,33 @@ final class ServerGenerator {
     }
 
     private static void generateHandlerCase(TypeScriptWriter writer,
-                                            Symbol serviceSymbol,
                                             Shape operationShape,
                                             Symbol operationSymbol) {
         String opName = operationShape.getId().getName();
         writer.openBlock("case $S : {", "}", opName, () -> {
             writer.write("let serializer = this.serializerFactory($S);", opName);
-            writer.openBlock("try {", "} catch(error: unknown) {", () -> {
-                writer.openBlock("let input = await serializer.deserialize(request, {", "});", () -> {
+            writer.write("let input;");
+            writer.openBlock("try {", "} catch (error: unknown) {", () -> {
+                writer.openBlock("input = await serializer.deserialize(request, {", "});", () -> {
                     writer.write("endpoint: () => Promise.resolve(request), ...this.serdeContextBase");
                 });
+            });
+            writer.indent();
+            writer.write("return this.serializeFrameworkException(new SerializationException(), "
+                    + "this.serdeContextBase);");
+            writer.closeBlock("}");
+            writer.openBlock("try {", "} catch(error: unknown) {", () -> {
                 writer.write("let output = this.service.$L(input, request);", operationSymbol.getName());
                 writer.write("return serializer.serialize(output, this.serdeContextBase);");
             });
-            writer.openBlock("", "}", () -> {
-                writer.openBlock("if (serializer.isOperationError(error)) {", "}", () -> {
-                    writer.write("return serializer.serializeError(error, this.serdeContextBase);");
-                });
-                writer.write("throw error;");
+            writer.indent();
+            writer.openBlock("if (serializer.isOperationError(error)) {", "}", () -> {
+                writer.write("return serializer.serializeError(error, this.serdeContextBase);");
             });
+            writer.write("console.log('Received an unexpected error', error);");
+            writer.write("return this.serializeFrameworkException(new InternalFailureException(), "
+                    + "this.serdeContextBase);");
+            writer.closeBlock("}");
         });
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -144,6 +144,11 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     }
 
     @Override
+    public void generateFrameworkErrorSerializer(GenerationContext serverContext) {
+        LOGGER.warning("Framework error serialization is not currently supported for RPC protocols.");
+    }
+
+    @Override
     public void generateRequestDeserializers(GenerationContext context) {
         LOGGER.warning("Request deserialization is not currently supported for RPC protocols.");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -149,6 +149,13 @@ public interface ProtocolGenerator {
     void generateResponseSerializers(GenerationContext context);
 
     /**
+     * Generates the code used to serialize unmodeled errors for servers.
+     *
+     * @param serverContext Serialization context.
+     */
+    void generateFrameworkErrorSerializer(GenerationContext serverContext);
+
+    /**
      * Generates the code used to determine the service and operation
      * targeted by a given request.
      *

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
@@ -1,0 +1,13 @@
+namespace smithy.framework
+
+@error("server")
+@httpError(500)
+structure InternalFailure {}
+
+@error("client")
+@httpError(404)
+structure UnknownOperationException {}
+
+@error("client")
+@httpError(400)
+structure SerializationException {}


### PR DESCRIPTION
*Description of changes:*

The most controversial part of this, I expect, will be the hand-built static model for these that I use to reuse the code generators. I wonder if I should replace the context's `SymbolProvider` as well, in the event one of the error serialization implementations tries to do a symbol lookup. I didn't go to those lengths in this review because I'm unsure framework errors will ever be much more than a name, a status code and a message.

In the future, if we allow customization of the namespace of the framework exceptions for backwards compatibility with existing services, the static model will have to turn into a model factory of some sort.

You can take a look at the generation changes here: https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/commit/503b7ae1be16113be2fbcc1cf8af3d1ded01cbb9 and the TS definitions of the framework exceptions here: https://github.com/adamthom-amzn/smithy-typescript-ssdk-demo/commit/64ec3c51f7e0583eed61770d15c8479d4b1949ce

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
