### PR TITLE
Trim values in parsed xml only if result is empty

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -17,7 +17,7 @@ const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string)
     ignoreAttributes: false,
     parseNodeValue: false,
     trimValues: false,
-    tagValueProcessor: (val: any, tagName: any) => decodeEscapedXml(val)
+    tagValueProcessor: (val: any, tagName: any) => val.trim() === "" ? "" : decodeEscapedXml(val)
   };
 
   const parseXmlBody = (body: string) => {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -16,6 +16,7 @@ const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string)
     attributeNamePrefix: '',
     ignoreAttributes: false,
     parseNodeValue: false,
+    trimValues: false,
     tagValueProcessor: (val: any, tagName: any) => decodeEscapedXml(val)
   };
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1893

*Description of changes:*
Set trimValues=false while calling fast-xml-parser

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
