### PR TITLE
Add generated error types for convenience

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -306,6 +306,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
         if (settings.generateServerSdk()) {
             generateServiceInterface(shape);
+            generateServerErrors(shape);
         }
 
         if (protocolGenerator != null) {
@@ -395,6 +396,19 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             ServerGenerator.generateServerInterfaces(serverSymbolProvider, shape, operations, writer);
             ServerGenerator.generateServiceHandler(serverSymbolProvider, shape, operations, writer);
         });
+    }
+
+    private void generateServerErrors(ServiceShape service) {
+        TopDownIndex.of(model)
+                .getContainedOperations(service)
+                .stream()
+                .flatMap(o -> o.getErrors().stream())
+                .distinct()
+                .map(id -> model.expectShape(id).asStructureShape().orElseThrow(IllegalArgumentException::new))
+                .sorted()
+                .forEachOrdered(error -> writers.useShapeWriter(service, serverSymbolProvider, writer -> {
+                    new ServerErrorGenerator(settings, model, error, serverSymbolProvider, writer).run();
+                }));
     }
 
     private void generateCommands(ServiceShape shape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerErrorGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerErrorGenerator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+
+/**
+ * Generates convenience error types for servers, since service developers will throw a modeled exception directly,
+ * while clients typically care only about catching them.
+ */
+final class ServerErrorGenerator implements Runnable {
+
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final StructureShape errorShape;
+    private final SymbolProvider symbolProvider;
+    private final TypeScriptWriter writer;
+
+    ServerErrorGenerator(TypeScriptSettings settings,
+                         Model model,
+                         StructureShape errorShape,
+                         SymbolProvider symbolProvider,
+                         TypeScriptWriter writer) {
+        this.settings = settings;
+        this.model = model;
+        this.errorShape = errorShape;
+        this.symbolProvider = symbolProvider;
+        this.writer = writer;
+    }
+
+
+    @Override
+    public void run() {
+        Symbol symbol = symbolProvider.toSymbol(errorShape);
+
+        // Did not add this as a symbol to the error shape since these should not be used by anyone but the user.
+        String typeName = symbol.getName() + "Error";
+
+        writer.openBlock("export class $L implements $T {", "}",
+                typeName,
+                symbol,
+                () -> {
+
+            writer.write("readonly name = $S;", errorShape.getId().getName());
+            writer.write("readonly $$fault = $S;", errorShape.expectTrait(ErrorTrait.class).getValue());
+            //TODO: remove me when we fix where $metadata goes
+            writer.write("readonly $$metadata = {};");
+            if (!errorShape.members().isEmpty()) {
+                writer.write("");
+                StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
+                        model, symbolProvider, errorShape.getAllMembers().values());
+                structuredMemberWriter.writeMembers(writer, errorShape);
+                writer.write("");
+                structuredMemberWriter.writeConstructor(writer, errorShape);
+            }
+        });
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -108,6 +108,26 @@ final class StructuredMemberWriter {
     }
 
     /**
+     * Writes a constructor function that takes in an object allowing modeled fields to be initialized.
+     */
+    void writeConstructor(TypeScriptWriter writer, Shape shape) {
+        writer.openBlock("constructor(opts: {", "}) {", () -> {
+            writeMembers(writer, shape);
+        });
+        writer.indent();
+
+        for (MemberShape member : members) {
+            if (skipMembers.contains(member.getMemberName())) {
+                continue;
+            }
+
+            writer.write("this.${1L} = opts.${1L};", getSanitizedMemberName(member));
+        }
+
+        writer.closeBlock("}");
+    }
+
+    /**
      * Writes SENSITIVE_STRING to hide the value of sensitive members.
      */
     private void writeSensitiveString(TypeScriptWriter writer) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -237,7 +237,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writeEmptyEndpoint(context);
 
             writer.openBlock("switch (input.name) {", "}", () -> {
-                for (final Shape shape : context.getModel().getShapesWithTrait(HttpErrorTrait.class)) {
+                for (final Shape shape : new TreeSet<>(context.getModel().getShapesWithTrait(HttpErrorTrait.class))) {
                     StructureShape errorShape = shape.asStructureShape().orElseThrow(IllegalArgumentException::new);
                     writer.openBlock("case $S: {", "}", errorShape.getId().getName(), () -> {
                         generateErrorSerializationImplementation(context, errorShape, responseType, bindingIndex);


### PR DESCRIPTION
*Description of changes:*

It's really annoying to throw objects that have a bunch of fixed values. This turns:

```
        const e: NoSuchResource = {
            name: "NoSuchResource",
            $fault: "client",
            resourceType: "Venue",
            $metadata: {}
        };
        throw e;
```

into

```
        throw new NoSuchResourceError({resourceType: "Venue"});
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
