### PR TITLE
docs: add documentation for destroy method

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -320,6 +320,12 @@ final class ServiceGenerator implements Runnable {
     private void generateDestroyMethod() {
         // Generates the destroy() method, and calls the destroy() method of
         // any runtime plugin that claims to have a destroy method.
+        if (applicationProtocol.isHttpProtocol()) {
+            writer.writeDocs("Destroy underlying resources, like sockets. It's usually not necessary to do this.\n"
+                    + "However in Node.js, it's best to explicitly shut down the client's agent when it is no longer "
+                    + "needed.\nOtherwise, sockets might stay open for quite a long time before the server terminates "
+                    + "them.");
+        }
         writer.openBlock("destroy(): void {", "}", () -> {
             writer.pushState(CLIENT_DESTROY_SECTION);
             for (RuntimeClientPlugin plugin : runtimePlugins) {


### PR DESCRIPTION
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2105

Since the `destroy` is inherited from the underlying Node.js API [agent.destroy()](https://nodejs.org/api/http.html#http_agent_destroy), and it doesn't actually destroy and disable the agent for the future use, we will keep the `destroy()` method name in V3 SDK. This change adds documentation to clarify the confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
