### PR TITLE
support additional resolve function parameters

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -290,11 +290,16 @@ final class ServiceGenerator implements Runnable {
             // (e.g., _config_0, _config_1, etc).
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 if (plugin.getResolveFunction().isPresent()) {
+                    Optional<List<String>> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
                     configVariable++;
-                    writer.write("let $L = $T($L);",
+                    writer.write("let $L = $T($L$L);",
                                  generateConfigVariable(configVariable),
                                  plugin.getResolveFunction().get(),
-                                 generateConfigVariable(configVariable - 1));
+                                 generateConfigVariable(configVariable - 1),
+                                 additionalParameters.map(
+                                        params -> params.stream().map(param -> ", " + param)
+                                                .collect(Collectors.joining())).orElseGet(() -> "")
+                                 );
                 }
             }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -290,16 +290,16 @@ final class ServiceGenerator implements Runnable {
             // (e.g., _config_0, _config_1, etc).
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 if (plugin.getResolveFunction().isPresent()) {
-                    Optional<List<String>> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
                     configVariable++;
+                    List<String> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
+                    String additionalParamsString = additionalParameters.isEmpty()
+                            ? ""
+                            : ", " + String.join(", ", additionalParameters);
                     writer.write("let $L = $T($L$L);",
                                  generateConfigVariable(configVariable),
                                  plugin.getResolveFunction().get(),
                                  generateConfigVariable(configVariable - 1),
-                                 additionalParameters.map(
-                                        params -> params.stream().map(param -> ", " + param)
-                                                .collect(Collectors.joining())).orElseGet(() -> "")
-                                 );
+                                 additionalParamsString);
                 }
             }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -451,8 +451,11 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         }
 
         /**
-         * Set additional positional input parameters to resolve function
-         * <p>this can only be set if {@link #resolveFunction} is set.
+         * Set additional positional input parameters to resolve function. Set
+         * this with no arguments to remove the current parameters.
+         *
+         * <p>If this is set, then all of {@link #resolveFunction},
+         * {@link #resolvedConfig} and {@link #inputConfig} must also be set.
          *
          * @param additionalParameters Additional parameters to be generated as resolve function input.
          * @return Returns the builder.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.ListUtils;
 
 public class RuntimeClientPluginTest {
     @Test
@@ -68,6 +69,7 @@ public class RuntimeClientPluginTest {
     public void configuresWithDefaultConventions() {
         RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
                 .withConventions("foo/baz", "1.0.0", "Foo")
+                .addAdditionalResolveFunctionParameters("this")
                 .build();
 
         assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
@@ -78,6 +80,8 @@ public class RuntimeClientPluginTest {
 
         assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
+
+        assertThat(plugin.getAdditionalResolveFunctionParameters().get(), equalTo(ListUtils.of("this")));
 
         assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -69,7 +69,7 @@ public class RuntimeClientPluginTest {
     public void configuresWithDefaultConventions() {
         RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
                 .withConventions("foo/baz", "1.0.0", "Foo")
-                .addAdditionalResolveFunctionParameters("this")
+                .additionalResolveFunctionParameters("this")
                 .build();
 
         assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
@@ -81,7 +81,7 @@ public class RuntimeClientPluginTest {
         assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
 
-        assertThat(plugin.getAdditionalResolveFunctionParameters().get(), equalTo(ListUtils.of("this")));
+        assertThat(plugin.getAdditionalResolveFunctionParameters(), equalTo(ListUtils.of("this")));
 
         assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));


### PR DESCRIPTION
Currently the generated client uses resolve functions to convert input
symbol type to a resolved symbol type. It only take 1 input parameter which
is the resolved symbol type returned from previous resolve function. In
some cases, we need to supply more parameters to the resolve functions,
like service client constructor, or specific command constructors.

For example, to solve the circular dependency issue of STSClient ->
credential providers -> STSClient, we need to supply the constructor
of STSclient so the credential provider can work without circular
dependency.

As a result, we can generate this STS customization:
```javascript
    let _config_4 = resolveHostHeaderConfig(_config_3);
    let _config_5 = resolveStsAuthConfig(_config_4, STSClient);
    let _config_6 = resolveUserAgentConfig(_config_5);
```

This change allows users to generate additional parameters to the
specific resolve function. Since the resolve function can only be
generated within client constructor, the available parameters within
the scope if steady.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
