### PR TITLE
Generate per-operation ServiceHandlers

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -142,8 +142,8 @@ final class ServerCommandGenerator implements Runnable {
         String serializerName = operationSymbol.expectProperty("serializerType", Symbol.class).getName();
         Symbol serverSymbol = symbolProvider.toSymbol(model.expectShape(settings.getService()));
 
-        writer.addImport("OperationSerializer", null, "@aws-smithy/server-common");
-        writer.openBlock("export class $L implements OperationSerializer<$T, $S, $T> {", "}",
+        writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
+        writer.openBlock("export class $L implements __OperationSerializer<$T, $S, $T> {", "}",
                 serializerName, serverSymbol, operation.getId().getName(), errorsType, () -> {
             String serializerFunction = ProtocolGenerator.getGenericSerFunctionName(operationSymbol) + "Response";
             String deserializerFunction = ProtocolGenerator.getGenericDeserFunctionName(operationSymbol) + "Request";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -46,64 +46,43 @@ final class ServerGenerator {
                                        Shape serviceShape,
                                        Set<OperationShape> operations,
                                        TypeScriptWriter writer) {
-        writer.addImport("ServiceHandler", null, "@aws-smithy/server-common");
-        writer.addImport("Mux", null, "@aws-smithy/server-common");
-        writer.addImport("OperationSerializer", null, "@aws-smithy/server-common");
-        writer.addImport("UnknownOperationException", null, "@aws-smithy/server-common");
-        writer.addImport("InternalFailureException", null, "@aws-smithy/server-common");
-        writer.addImport("SerializationException", null, "@aws-smithy/server-common");
-        writer.addImport("SmithyFrameworkException", null, "@aws-smithy/server-common");
-        writer.addImport("SerdeContext", null, "@aws-sdk/types");
-        writer.addImport("NodeHttpHandler", null, "@aws-sdk/node-http-handler");
-        writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
-        writer.addImport("fromBase64", null, "@aws-sdk/util-base64-node");
-        writer.addImport("toBase64", null, "@aws-sdk/util-base64-node");
-        writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8-node");
-        writer.addImport("toUtf8", null, "@aws-sdk/util-utf8-node");
-        writer.addImport("HttpRequest", null, "@aws-sdk/protocol-http");
-        writer.addImport("HttpResponse", null, "@aws-sdk/protocol-http");
-        writer.addImport("SmithyException", null, "@aws-sdk/smithy-client");
+        addCommonHandlerImports(writer);
+        writer.addImport("UnknownOperationException", "__UnknownOperationException", "@aws-smithy/server-common");
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
         Symbol operationsType = serviceSymbol.expectProperty("operations", Symbol.class);
 
-        writer.openBlock("export class $L implements ServiceHandler {", "}", handlerSymbol.getName(), () -> {
+        writeSerdeContextBase(writer);
+        writeHandleFunction(writer);
+
+        writer.openBlock("export class $L implements __ServiceHandler {", "}", handlerSymbol.getName(), () -> {
             writer.write("private service: $T;", serviceSymbol);
-            writer.write("private mux: Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
+            writer.write("private mux: __Mux<$S, $T>;", serviceShape.getId().getName(), operationsType);
             writer.write("private serializerFactory: <T extends $T>(operation: T) => "
-                            + "OperationSerializer<$T, T, SmithyException>;", operationsType, serviceSymbol);
-            writer.write("private serializeFrameworkException: (e: SmithyFrameworkException, "
-                            + "ctx: Omit<SerdeContext, 'endpoint'>) => Promise<HttpResponse>;");
-            writer.openBlock("private serdeContextBase = {", "};", () -> {
-                writer.write("base64Encoder: toBase64,");
-                writer.write("base64Decoder: fromBase64,");
-                writer.write("utf8Encoder: toUtf8,");
-                writer.write("utf8Decoder: fromUtf8,");
-                writer.write("streamCollector: streamCollector,");
-                writer.write("requestHandler: new NodeHttpHandler(),");
-                writer.write("disableHostPrefix: true");
-            });
+                            + "__OperationSerializer<$T, T, __SmithyException>;", operationsType, serviceSymbol);
+            writer.write("private serializeFrameworkException: (e: __SmithyFrameworkException, "
+                            + "ctx: Omit<SerdeContext, 'endpoint'>) => Promise<__HttpResponse>;");
             writer.writeDocs(() -> {
                 writer.write("Construct a $T handler.", serviceSymbol);
                 writer.write("@param service The {@link $1T} implementation that supplies the business logic for $1T",
                         serviceSymbol);
-                writer.writeInline("@param mux The {@link Mux} that determines which service and operation are being ");
-                writer.write("invoked by a given {@link HttpRequest}");
-                writer.writeInline("@param serializerFactory A factory for an {@link OperationSerializer} for each ");
+                writer.writeInline("@param mux The {@link __Mux} that determines which service and operation are ");
+                writer.write("being invoked by a given {@link __HttpRequest}");
+                writer.writeInline("@param serializerFactory A factory for an {@link __OperationSerializer} for each ");
                 writer.write("operation in $T that ", serviceSymbol);
                 writer.writeInline("                         ")
                       .write("handles deserialization of requests and serialization of responses");
                 writer.write("@param serializeFrameworkException A function that can serialize "
-                        + "{@link SmithyFrameworkException}s");
+                        + "{@link __SmithyFrameworkException}s");
             });
             writer.openBlock("constructor(", ") {", () -> {
                 writer.write("service: $T,", serviceSymbol);
-                writer.write("mux: Mux<$S, $T>,", serviceShape.getId().getName(), operationsType);
-                writer.write("serializerFactory:<T extends $T>(op: T) => OperationSerializer<$T, T, SmithyException>,",
-                        operationsType, serviceSymbol);
-                writer.write("serializeFrameworkException: (e: SmithyFrameworkException, ctx: Omit<SerdeContext, "
-                        + "'endpoint'>) => Promise<HttpResponse>");
+                writer.write("mux: __Mux<$S, $T>,", serviceShape.getId().getName(), operationsType);
+                writer.write("serializerFactory:<T extends $T>(op: T) => "
+                                + "__OperationSerializer<$T, T, __SmithyException>,", operationsType, serviceSymbol);
+                writer.write("serializeFrameworkException: (e: __SmithyFrameworkException, ctx: Omit<SerdeContext, "
+                        + "'endpoint'>) => Promise<__HttpResponse>");
             });
             writer.indent();
             writer.write("this.service = service;");
@@ -111,49 +90,159 @@ final class ServerGenerator {
             writer.write("this.serializerFactory = serializerFactory;");
             writer.write("this.serializeFrameworkException = serializeFrameworkException;");
             writer.closeBlock("}");
-            writer.openBlock("async handle(request: HttpRequest): Promise<HttpResponse> {", "}", () -> {
+            writer.openBlock("async handle(request: __HttpRequest): Promise<__HttpResponse> {", "}", () -> {
                 writer.write("const target = this.mux.match(request);");
                 writer.openBlock("if (target === undefined) {", "}", () -> {
-                    writer.write("return serializeFrameworkException(new UnknownOperationException(), "
-                            + "this.serdeContextBase);");
+                    writer.write("return this.serializeFrameworkException(new __UnknownOperationException(), "
+                            + "serdeContextBase);");
                 });
                 writer.openBlock("switch (target.operation) {", "}", () -> {
                     for (OperationShape operation : operations) {
-                        generateHandlerCase(writer, operation, symbolProvider.toSymbol(operation));
+                        String opName = operation.getId().getName();
+                        writer.openBlock("case $S : {", "}", opName, () -> {
+                            writer.write("return handle(request, this.serializerFactory($S), this.service.$L, "
+                                    + "this.serializeFrameworkException);",
+                                    opName, symbolProvider.toSymbol(operation).getName());
+                        });
                     }
                 });
             });
         });
     }
 
-    private static void generateHandlerCase(TypeScriptWriter writer,
-                                            Shape operationShape,
-                                            Symbol operationSymbol) {
-        String opName = operationShape.getId().getName();
-        writer.openBlock("case $S : {", "}", opName, () -> {
-            writer.write("let serializer = this.serializerFactory($S);", opName);
-            writer.write("let input;");
-            writer.openBlock("try {", "} catch (error: unknown) {", () -> {
-                writer.openBlock("input = await serializer.deserialize(request, {", "});", () -> {
-                    writer.write("endpoint: () => Promise.resolve(request), ...this.serdeContextBase");
+    static void generateOperationHandler(SymbolProvider symbolProvider,
+                                         Shape serviceShape,
+                                         OperationShape operation,
+                                         TypeScriptWriter writer) {
+        addCommonHandlerImports(writer);
+
+        writeSerdeContextBase(writer);
+        writeHandleFunction(writer);
+
+        String operationName = operation.getId().getName();
+        Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
+        Symbol operationSymbol = symbolProvider.toSymbol(operation);
+
+        Symbol inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
+        Symbol outputSymbol = operationSymbol.expectProperty("outputType", Symbol.class);
+        Symbol handlerSymbol = operationSymbol.expectProperty("handler", Symbol.class);
+        Symbol errorsSymbol = operationSymbol.expectProperty("errorsType", Symbol.class);
+
+        writer.openBlock("export class $L implements __ServiceHandler {", "}", handlerSymbol.getName(), () -> {
+            writer.write("private operation: __Operation<$T, $T>;", inputSymbol, outputSymbol);
+            writer.write("private mux: __Mux<$S, $S>;", serviceShape.getId().getName(), operationName);
+            writer.write("private serializer: __OperationSerializer<$T, $S, $T>;",
+                    serviceSymbol, operationName, errorsSymbol);
+            writer.write("private serializeFrameworkException: (e: __SmithyFrameworkException, "
+                    + "ctx: Omit<SerdeContext, 'endpoint'>) => Promise<__HttpResponse>;");
+            writer.writeDocs(() -> {
+                writer.write("Construct a $T handler.", operationSymbol);
+                writer.write("@param service The {@link __Operation} implementation that supplies the business "
+                                + "logic for $1T", operationSymbol);
+                writer.writeInline("@param mux The {@link __Mux} that verifies which service and operation are being ");
+                writer.write("invoked by a given {@link __HttpRequest}");
+                writer.write("@param serializer An {@link __OperationSerializer} for $T that ", operationSymbol);
+                writer.writeInline("                  ")
+                        .write("handles deserialization of requests and serialization of responses");
+                writer.write("@param serializeFrameworkException A function that can serialize "
+                        + "{@link __SmithyFrameworkException}s");
+            });
+            writer.openBlock("constructor(", ") {", () -> {
+                writer.write("operation: __Operation<$T, $T>,", inputSymbol, outputSymbol);
+                writer.write("mux: __Mux<$S, $S>,", serviceShape.getId().getName(), operationName);
+                writer.write("serializer: __OperationSerializer<$T, $S, $T>,",
+                        serviceSymbol, operationName, errorsSymbol);
+                writer.write("serializeFrameworkException: (e: __SmithyFrameworkException, ctx: Omit<SerdeContext, "
+                        + "'endpoint'>) => Promise<__HttpResponse>");
+            });
+            writer.indent();
+            writer.write("this.operation = operation;");
+            writer.write("this.mux = mux;");
+            writer.write("this.serializer = serializer;");
+            writer.write("this.serializeFrameworkException = serializeFrameworkException;");
+            writer.closeBlock("}");
+            writer.openBlock("async handle(request: __HttpRequest): Promise<__HttpResponse> {", "}", () -> {
+                writer.write("const target = this.mux.match(request);");
+                writer.openBlock("if (target === undefined) {", "}", () -> {
+                    writer.write("console.log('Received a request that did not match $L.$L. This indicates a "
+                            + "misconfiguration.');", serviceShape.getId(), operation.getId().getName());
+                    writer.write("return this.serializeFrameworkException(new __InternalFailureException(), "
+                            + "serdeContextBase);");
                 });
+                writer.write("return handle(request, this.serializer, this.operation, "
+                        + "this.serializeFrameworkException);");
             });
-            writer.indent();
-            writer.write("return this.serializeFrameworkException(new SerializationException(), "
-                    + "this.serdeContextBase);");
-            writer.closeBlock("}");
-            writer.openBlock("try {", "} catch(error: unknown) {", () -> {
-                writer.write("let output = await this.service.$L(input, request);", operationSymbol.getName());
-                writer.write("return serializer.serialize(output, this.serdeContextBase);");
+        });
+    }
+
+    private static void addCommonHandlerImports(TypeScriptWriter writer) {
+        writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
+        writer.addImport("ServiceHandler", "__ServiceHandler", "@aws-smithy/server-common");
+        writer.addImport("Mux", "__Mux", "@aws-smithy/server-common");
+        writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
+        writer.addImport("InternalFailureException", "__InternalFailureException", "@aws-smithy/server-common");
+        writer.addImport("SerializationException", "__SerializationException", "@aws-smithy/server-common");
+        writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", "@aws-smithy/server-common");
+        writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
+        writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
+        writer.addImport("SmithyException", "__SmithyException", "@aws-sdk/smithy-client");
+    }
+
+    private static void writeHandleFunction(TypeScriptWriter writer) {
+        writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
+        writer.addImport("OperationInput", "__OperationInput", "@aws-smithy/server-common");
+        writer.addImport("OperationOutput", "__OperationOutput", "@aws-smithy/server-common");
+
+        writer.openBlock("async function handle<S, O extends keyof S>(", "): Promise<__HttpResponse> {", () -> {
+            writer.write("request:__HttpRequest,");
+            writer.write("serializer: __OperationSerializer<S, O, __SmithyException>,");
+            writer.write("operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>>,");
+            writer.write("serializeFrameworkException: (e: __SmithyFrameworkException, "
+                    + "ctx: Omit<SerdeContext, 'endpoint'>) => Promise<__HttpResponse>");
+        });
+        writer.indent();
+        writer.write("let input;");
+        writer.openBlock("try {", "} catch (error: unknown) {", () -> {
+            writer.openBlock("input = await serializer.deserialize(request, {", "});", () -> {
+                writer.write("endpoint: () => Promise.resolve(request), ...serdeContextBase");
             });
-            writer.indent();
-            writer.openBlock("if (serializer.isOperationError(error)) {", "}", () -> {
-                writer.write("return serializer.serializeError(error, this.serdeContextBase);");
-            });
-            writer.write("console.log('Received an unexpected error', error);");
-            writer.write("return this.serializeFrameworkException(new InternalFailureException(), "
-                    + "this.serdeContextBase);");
-            writer.closeBlock("}");
+        });
+        writer.indent();
+        writer.write("return serializeFrameworkException(new __SerializationException(), "
+                + "serdeContextBase);");
+        writer.closeBlock("}");
+        writer.openBlock("try {", "} catch(error: unknown) {", () -> {
+            writer.write("let output = await operation(input, request);");
+            writer.write("return serializer.serialize(output, serdeContextBase);");
+        });
+        writer.indent();
+        writer.openBlock("if (serializer.isOperationError(error)) {", "}", () -> {
+            writer.write("return serializer.serializeError(error, serdeContextBase);");
+        });
+        writer.write("console.log('Received an unexpected error', error);");
+        writer.write("return serializeFrameworkException(new __InternalFailureException(), "
+                + "serdeContextBase);");
+        writer.closeBlock("}");
+        writer.closeBlock("}");
+    }
+
+    private static void writeSerdeContextBase(TypeScriptWriter writer) {
+        writer.addImport("SerdeContext", null, "@aws-sdk/types");
+        writer.addImport("NodeHttpHandler", null, "@aws-sdk/node-http-handler");
+        writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
+        writer.addImport("fromBase64", null, "@aws-sdk/util-base64-node");
+        writer.addImport("toBase64", null, "@aws-sdk/util-base64-node");
+        writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8-node");
+        writer.addImport("toUtf8", null, "@aws-sdk/util-utf8-node");
+
+        writer.openBlock("const serdeContextBase = {", "};", () -> {
+            writer.write("base64Encoder: toBase64,");
+            writer.write("base64Decoder: fromBase64,");
+            writer.write("utf8Encoder: toUtf8,");
+            writer.write("utf8Decoder: fromUtf8,");
+            writer.write("streamCollector: streamCollector,");
+            writer.write("requestHandler: new NodeHttpHandler(),");
+            writer.write("disableHostPrefix: true");
         });
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -83,6 +83,8 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
         builder.putProperty("outputType", intermediate.toBuilder().name(shapeName + "ServerOutput").build());
         builder.putProperty("errorsType", intermediate.toBuilder().name(shapeName + "Errors").build());
         builder.putProperty("serializerType", intermediate.toBuilder().name(shapeName + "Serializer").build());
+        builder.putProperty("handler",
+                intermediate.toBuilder().name(shapeName + "Handler").build());
         return builder.build();
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -159,7 +159,12 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
     }
 
     @Override
-    public void generateHandlerFactory(GenerationContext context) {
+    public void generateServiceHandlerFactory(GenerationContext context) {
+        LOGGER.warning("Handler factory generation is not currently supported for RPC protocols.");
+    }
+
+    @Override
+    public void generateOperationHandlerFactory(GenerationContext context, OperationShape operation) {
         LOGGER.warning("Handler factory generation is not currently supported for RPC protocols.");
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -156,12 +157,21 @@ public interface ProtocolGenerator {
     void generateFrameworkErrorSerializer(GenerationContext serverContext);
 
     /**
-     * Generates the code used to determine the service and operation
-     * targeted by a given request.
+     * Generates a factory for the ServiceHandler implementation for this service.
      *
      * @param context Generation context.
      */
-    void generateHandlerFactory(GenerationContext context);
+    void generateServiceHandlerFactory(GenerationContext context);
+
+    /**
+     * Generates the code used to handle a request for a specific operation in the given service. This allows the
+     * business logic for a service to be split among multiple deployment targets, for example, one Lambda function
+     * per operation.
+     *
+     * @param context Generation context.
+     * @param operation The operation to generate a handler factory for.
+     */
+    void generateOperationHandlerFactory(GenerationContext context, OperationShape operation);
 
     /**
      * Generates the code used to deserialize the shapes of a service


### PR DESCRIPTION
*Description of changes:*

This lets service developers choose between a single lambda function per
operation, or one lambda function that handles all operations, depending on
their preferences.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
