### PR TITLE
Update serde interfaces to differentiate in/out

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -125,8 +125,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generates serialization functions for shapes in the passed set. These functions
      * should return a value that can then be serialized by the implementation of
-     * {@code serializeDocument}. The {@link DocumentShapeSerVisitor} and {@link DocumentMemberSerVisitor}
-     * are provided to reduce the effort of this implementation.
+     * {@link HttpBindingProtocolGenerator#serializeInputDocumentBody}. The {@link DocumentShapeSerVisitor} and
+     * {@link DocumentMemberSerVisitor} are provided to reduce the effort of this implementation.
      *
      * @param context The generation context.
      * @param shapes The shapes to generate serialization for.
@@ -136,7 +136,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Generates deserialization functions for shapes in the passed set. These functions
      * should return a value that can then be deserialized by the implementation of
-     * {@code deserializeDocument}. The {@link DocumentShapeDeserVisitor} and
+     * {@link HttpBindingProtocolGenerator#deserializeInputDocumentBody}. The {@link DocumentShapeDeserVisitor} and
      * {@link DocumentMemberDeserVisitor} are provided to reduce the effort of this implementation.
      *
      * @param context The generation context.
@@ -1345,10 +1345,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Writes the code needed to serialize the output payload of a request.
+     * Writes the code needed to serialize the output payload of a response.
      *
      * <p>Implementations of this method are expected to set a value to the
-     * {@code body} variable that will be serialized as the request body.
+     * {@code body} variable that will be serialized as the response body.
      * This variable will already be defined in scope.
      *
      * <p>For example:
@@ -1371,10 +1371,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Writes the code needed to serialize the error payload of a request.
+     * Writes the code needed to serialize the error payload of a response.
      *
      * <p>Implementations of this method are expected to set a value to the
-     * {@code body} variable that will be serialized as the request body.
+     * {@code body} variable that will be serialized as the response body.
      * This variable will already be defined in scope.
      *
      * <p>For example:
@@ -2073,7 +2073,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * bound member name of the {@code contents} variable after deserializing
      * the response body. This variable will already be defined in scope.
      *
-     *
      * @param context The generation context.
      * @param operation The operation whose input payload is being deserialized.
      * @param binding The payload binding to deserialize.
@@ -2088,12 +2087,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Writes the code needed to deserialize the output payload of a request.
+     * Writes the code needed to deserialize the output payload of a response.
      *
      * <p>Implementations of this method are expected to set a value to the
      * bound member name of the {@code contents} variable after deserializing
      * the response body. This variable will already be defined in scope.
-     *
      *
      * @param context The generation context.
      * @param operation The operation whose output payload is being deserialized.
@@ -2109,12 +2107,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Writes the code needed to deserialize the input payload of a request.
+     * Writes the code needed to deserialize the error payload of a response.
      *
      * <p>Implementations of this method are expected to set a value to the
      * bound member name of the {@code contents} variable after deserializing
      * the response body. This variable will already be defined in scope.
-     *
      *
      * @param context The generation context.
      * @param error The error whose payload is being deserialized.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -829,7 +829,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         List<HttpBinding> documentBindings = bindingIndex.getResponseBindings(operationOrError, Location.DOCUMENT);
         boolean shouldWriteDefaultBody = operationOrError.asOperationShape()
                 .map(operation -> shouldWriteDefaultOutputBody(context, operation))
-                .orElse(shouldWriteDefaultErrorBody(context, operationOrError.asStructureShape().get()));
+                .orElseGet(() -> shouldWriteDefaultErrorBody(context, operationOrError.asStructureShape().get()));
         return writeBody(context, operationOrError, payloadBindings, documentBindings, shouldWriteDefaultBody, false);
     }
 


### PR DESCRIPTION
This updates the interfaces for rest services to differentiate when an operation's input vs output vs error is being serialized / deserialized. This is necessary because there can be subtly different rules in each case.

Right now this is pretty ugly so I put it up as a draft. The major alternative I am considering is to instead have explicit methods for each case, e.g:

```java
protected abstract void serializeInputDocumentBody(
    GenerationContext context,
    OperationShape operation,
    List<HttpBinding> documentBindings
);

protected abstract void serializeOutputDocumentBody(
    GenerationContext context,
    OperationShape operation,
    List<HttpBinding> documentBindings
);

protected abstract void serializeErrorDocumentBody(
    GenerationContext context,
    OperationShape operation,
    StructureShape error,
    List<HttpBinding> documentBindings
);
```

Implementers could then make it generic on their end if necessary as apposed to having to split things up like is the case now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
