### PR TITLE
Remove @aws-sdk/url-parser-native in favor of react-native-url-polyfill

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -145,12 +145,6 @@ final class RuntimeConfigGenerator {
                 writer.addImport("Sha256", "Sha256",
                         TypeScriptDependency.AWS_CRYPTO_SHA256_JS.packageName);
                 writer.write("sha256: Sha256,");
-            },
-            "urlParser", writer -> {
-                writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER_NATIVE);
-                writer.addImport("parseUrl", "parseUrl",
-                        TypeScriptDependency.AWS_SDK_URL_PARSER_NATIVE.packageName);
-                writer.write("urlParser: parseUrl,");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -44,7 +44,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "3.6.1", true),
 
     AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", "3.6.1", true),
-    AWS_SDK_URL_PARSER_NATIVE("dependencies", "@aws-sdk/url-parser-native", "3.6.1", true),
 
     AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", "3.6.1", true),
     AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", "3.6.1", true),


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2229

*Description of changes:*
Removes @aws-sdk/url-parser-native in favor of react-native-url-polyfill

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
