### PR TITLE
Split server codegen out into a separate plugin

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.BiFunction;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.build.PluginContext;
@@ -46,6 +45,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -78,11 +78,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    CodegenVisitor(
-            PluginContext context,
-            BiFunction<Model, TypeScriptSettings, SymbolProvider> createSymbolProvider,
-            TypeScriptSettings.ArtifactType artifactType
-    ) {
+    CodegenVisitor(PluginContext context, ArtifactType artifactType) {
         // Load all integrations.
         ClassLoader loader = context.getPluginClassLoader().orElse(getClass().getClassLoader());
         LOGGER.info("Attempting to discover TypeScriptIntegration from the classpath...");
@@ -117,7 +113,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 settings.generateClient() ? "client" : "server", service.getId()));
 
         // Decorate the symbol provider using integrations.
-        SymbolProvider resolvedProvider = createSymbolProvider.apply(model, settings);
+        SymbolProvider resolvedProvider = artifactType.createSymbolProvider(model, settings);
         for (TypeScriptIntegration integration : integrations) {
             resolvedProvider = integration.decorateSymbolProvider(settings, model, resolvedProvider);
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -90,7 +90,6 @@ final class HttpProtocolTestGenerator implements Runnable {
     private final ServiceShape service;
     private final SymbolProvider symbolProvider;
     private final Symbol serviceSymbol;
-    private final SymbolProvider serverSymbolProvider;
     private final Set<String> additionalStubs = new TreeSet<>();
     private final ProtocolGenerator protocolGenerator;
 
@@ -105,7 +104,6 @@ final class HttpProtocolTestGenerator implements Runnable {
             Model model,
             ShapeId protocol,
             SymbolProvider symbolProvider,
-            SymbolProvider serverSymbolProvider,
             TypeScriptDelegator delegator,
             ProtocolGenerator protocolGenerator
     ) {
@@ -114,7 +112,6 @@ final class HttpProtocolTestGenerator implements Runnable {
         this.protocol = protocol;
         this.service = settings.getService(model);
         this.symbolProvider = symbolProvider;
-        this.serverSymbolProvider = serverSymbolProvider;
         this.delegator = delegator;
         this.protocolGenerator = protocolGenerator;
         serviceSymbol = symbolProvider.toSymbol(service);
@@ -266,7 +263,7 @@ final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private void generateServerRequestTest(OperationShape operation, HttpRequestTestCase testCase) {
-        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol operationSymbol = symbolProvider.toSymbol(operation);
 
         // Lowercase all the headers we're expecting as this is what we'll get.
         Map<String, String> headers = testCase.getHeaders().entrySet().stream()
@@ -279,7 +276,7 @@ final class HttpProtocolTestGenerator implements Runnable {
         String testName = testCase.getId() + ":ServerRequest";
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
-            Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
+            Symbol serviceSymbol = symbolProvider.toSymbol(service);
             Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
 
             // Create a mock function to set in place of the server operation function so we can capture
@@ -480,8 +477,8 @@ final class HttpProtocolTestGenerator implements Runnable {
     }
 
     public void generateServerResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
-        Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
-        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        Symbol operationSymbol = symbolProvider.toSymbol(operation);
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         String testName = testCase.getId() + ":ServerResponse";
         writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
@@ -527,10 +524,10 @@ final class HttpProtocolTestGenerator implements Runnable {
             StructureShape error,
             HttpResponseTestCase testCase
     ) {
-        Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
-        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        Symbol operationSymbol = symbolProvider.toSymbol(operation);
         Symbol outputType = operationSymbol.expectProperty("outputType", Symbol.class);
-        Symbol errorSymbol = serverSymbolProvider.toSymbol(error);
+        Symbol errorSymbol = symbolProvider.toSymbol(error);
         ErrorTrait errorTrait = error.expectTrait(ErrorTrait.class);
 
         testCase.getDocumentation().ifPresent(writer::writeDocs);
@@ -565,8 +562,8 @@ final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private void writeServerResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
-        Symbol serviceSymbol = serverSymbolProvider.toSymbol(service);
-        Symbol operationSymbol = serverSymbolProvider.toSymbol(operation);
+        Symbol serviceSymbol = symbolProvider.toSymbol(service);
+        Symbol operationSymbol = symbolProvider.toSymbol(operation);
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
         Symbol serializerSymbol = operationSymbol.expectProperty("serializerType", Symbol.class);
         Symbol serviceOperationsSymbol = serviceSymbol.expectProperty("operations", Symbol.class);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -33,20 +33,10 @@ public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        new CodegenVisitor(
-                context,
-                TypeScriptCodegenPlugin::createSymbolProvider,
-                ArtifactType.CLIENT
-        ).execute();
+        new CodegenVisitor(context, ArtifactType.CLIENT).execute();
     }
 
-    /**
-     * Creates a TypeScript symbol provider.
-     *
-     * @param model Model to generate symbols for.
-     * @param settings Settings used by the plugin.
-     * @return Returns the created provider.
-     */
+    @Deprecated
     public static SymbolProvider createSymbolProvider(Model model, TypeScriptSettings settings) {
         return new SymbolVisitor(model, settings);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,21 +22,21 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
 
 /**
- * Plugin to trigger TypeScript code generation.
+ * Plugin to trigger TypeScript SSDK code generation.
  */
-public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
+public class TypeScriptServerCodegenPlugin implements SmithyBuildPlugin {
 
     @Override
     public String getName() {
-        return "typescript-codegen";
+        return "typescript-ssdk-codegen";
     }
 
     @Override
     public void execute(PluginContext context) {
         new CodegenVisitor(
                 context,
-                TypeScriptCodegenPlugin::createSymbolProvider,
-                ArtifactType.CLIENT
+                TypeScriptServerCodegenPlugin::createSymbolProvider,
+                ArtifactType.SSDK
         ).execute();
     }
 
@@ -48,6 +48,6 @@ public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
      * @return Returns the created provider.
      */
     public static SymbolProvider createSymbolProvider(Model model, TypeScriptSettings settings) {
-        return new SymbolVisitor(model, settings);
+        return new ServerSymbolVisitor(model, new SymbolVisitor(model, settings));
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
@@ -17,8 +17,6 @@ package software.amazon.smithy.typescript.codegen;
 
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
-import software.amazon.smithy.codegen.core.SymbolProvider;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
 
 /**
@@ -33,21 +31,6 @@ public class TypeScriptServerCodegenPlugin implements SmithyBuildPlugin {
 
     @Override
     public void execute(PluginContext context) {
-        new CodegenVisitor(
-                context,
-                TypeScriptServerCodegenPlugin::createSymbolProvider,
-                ArtifactType.SSDK
-        ).execute();
-    }
-
-    /**
-     * Creates a TypeScript symbol provider.
-     *
-     * @param model Model to generate symbols for.
-     * @param settings Settings used by the plugin.
-     * @return Returns the created provider.
-     */
-    public static SymbolProvider createSymbolProvider(Model model, TypeScriptSettings settings) {
-        return new ServerSymbolVisitor(model, new SymbolVisitor(model, settings));
+        new CodegenVisitor(context, ArtifactType.SSDK).execute();
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -47,8 +47,6 @@ public final class TypeScriptSettings {
     private static final String SERVICE = "service";
     private static final String PROTOCOL = "protocol";
     private static final String PRIVATE = "private";
-    private static final String GENERATE_CLIENT = "generateClient";
-    private static final String GENERATE_SERVER_SDK = "generateServerSdk";
 
     private String packageName;
     private String packageDescription = "";
@@ -58,8 +56,7 @@ public final class TypeScriptSettings {
     private ObjectNode pluginSettings = Node.objectNode();
     private ShapeId protocol;
     private boolean isPrivate;
-    private boolean generateClient;
-    private boolean generateServerSdk;
+    private ArtifactType artifactType = ArtifactType.CLIENT;
 
     /**
      * Create a settings object from a configuration object node.
@@ -72,7 +69,7 @@ public final class TypeScriptSettings {
         TypeScriptSettings settings = new TypeScriptSettings();
         config.warnIfAdditionalProperties(Arrays.asList(
                 PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION,
-                SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, GENERATE_CLIENT, GENERATE_SERVER_SDK));
+                SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE));
 
         // Get the service from the settings or infer one from the given model.
         settings.setService(config.getStringMember(SERVICE)
@@ -86,9 +83,6 @@ public final class TypeScriptSettings {
         settings.packageJson = config.getObjectMember(PACKAGE_JSON).orElse(Node.objectNode());
         config.getStringMember(PROTOCOL).map(StringNode::getValue).map(ShapeId::from).ifPresent(settings::setProtocol);
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
-        settings.setGenerateClient(config.getBooleanMember(GENERATE_CLIENT).map(BooleanNode::getValue).orElse(true));
-        settings.setGenerateServerSdk(
-                config.getBooleanMember(GENERATE_SERVER_SDK).map(BooleanNode::getValue).orElse(false));
 
         settings.setPluginSettings(config);
         return settings;
@@ -222,29 +216,34 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * Returns if the generated package will include a client.
+     * Returns if the generated package will be a client.
      *
      * @return If the package will include a client.
      */
     public boolean generateClient() {
-        return generateClient;
-    }
-
-    public void setGenerateClient(boolean generateClient) {
-        this.generateClient = generateClient;
+        return artifactType.equals(ArtifactType.CLIENT);
     }
 
     /**
-     * Returns if the generated package will include a server sdk.
+     * Returns if the generated package will be a server sdk.
      *
      * @return If the package will include a server sdk.
      */
     public boolean generateServerSdk() {
-        return generateServerSdk;
+        return artifactType.equals(ArtifactType.SSDK);
     }
 
-    public void setGenerateServerSdk(boolean generateServerSdk) {
-        this.generateServerSdk = generateServerSdk;
+    /**
+     * Returns the type of artifact being generated, such as a client or ssdk.
+     *
+     * @return The artifact type.
+     */
+    public ArtifactType getArtifactType() {
+        return artifactType;
+    }
+
+    public void setArtifactType(ArtifactType artifactType) {
+        this.artifactType = artifactType;
     }
 
     /**
@@ -312,5 +311,13 @@ public final class TypeScriptSettings {
      */
     public void setProtocol(ShapeId protocol) {
         this.protocol = Objects.requireNonNull(protocol);
+    }
+
+    /**
+     * An enum indicating the type of artifact the code generator will produce.
+     */
+    public enum ArtifactType {
+        CLIENT,
+        SSDK
     }
 }

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -1,1 +1,2 @@
 software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin
+software.amazon.smithy.typescript.codegen.TypeScriptServerCodegenPlugin


### PR DESCRIPTION
This splits up the server code generation to be gated behind a separate plugin. This lets us generate separate packages for each while still being able to generate both a client and ssdk in a single projection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
