### PR TITLE
Add validator implementations

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -15,6 +15,7 @@
 
 export * as httpbinding from "./httpbinding";
 export * from "./errors";
+export * from "./validation";
 
 import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { SmithyException } from "@aws-sdk/smithy-client";

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+export * from "./validators";
+
+interface StandardValidationFailure<ConstraintBoundsType, FailureType> {
+    memberName: string
+    constraintType: string
+    constraintValues: ArrayLike<ConstraintBoundsType>,
+    failureValue: FailureType
+}
+
+export interface EnumValidationFailure extends StandardValidationFailure<string, string> {
+    constraintType: "enum"
+    constraintValues: string[]
+}
+
+export interface LengthValidationFailure extends StandardValidationFailure<number | undefined, number> {
+    constraintType: "length",
+    constraintValues: [number, number] | [undefined, number] | [number, undefined]
+}
+
+export interface PatternValidationFailure {
+    memberName: string
+    constraintType: "pattern"
+    constraintValues: string
+    failureValue: string
+}
+
+export interface RangeValidationFailure extends StandardValidationFailure<number | undefined, number> {
+    constraintType: "range"
+    constraintValues: [number, number] | [undefined, number] | [number, undefined]
+}
+
+export class RequiredValidationFailure {
+    memberName: string;
+    constraintType = "required";
+
+    constructor(memberName: string) {
+        this.memberName = memberName;
+    }
+}
+
+export interface UniqueItemsValidationFailure {
+    memberName: string
+    constraintType: "uniqueItems"
+    failureValue: Array<any>
+}
+
+export type ValidationFailure = EnumValidationFailure | LengthValidationFailure
+                                    | PatternValidationFailure | RangeValidationFailure
+                                    | RequiredValidationFailure | UniqueItemsValidationFailure

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -1,0 +1,188 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import {EnumValidator, LengthValidator, PatternValidator, RangeValidator, UniqueItemsValidator} from "./validators";
+
+describe("enum validation", () => {
+    const enumValidator = new EnumValidator(["apple", "banana", "orange"]);
+
+    it("does not fail when the enum value is found", () => {
+        expect(enumValidator.validate("apple", "fruit")).toBeNull();
+    });
+
+    it ("fails when the enum value is not found", () => {
+        expect(enumValidator.validate("kiwi", "fruit")).toEqual({
+            constraintType: "enum",
+            constraintValues: ["apple", "banana", "orange"],
+            memberName: "fruit",
+            failureValue: "kiwi"
+        });
+    });
+});
+
+describe("length validation", () => {
+    const threeLengthThings = [
+        "foo",
+        { "a": 1, "b": 2, "c": 3},
+        ["a", "b", "c"],
+        new Uint8Array([13, 37, 42])
+    ];
+
+    for (const value of threeLengthThings) {
+        describe(`for ${JSON.stringify(value)}`, () => {
+            it ("should succeed with min = 1", () => {
+                expect(new LengthValidator(1).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should succeed with min = 3", () => {
+                expect(new LengthValidator(3).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should succeed with max = 100", () => {
+                expect(new LengthValidator(undefined, 100).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should succeed with max = 3", () => {
+                expect(new LengthValidator(undefined, 3).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should succeed with min = 3 and max = 3", () => {
+                expect(new LengthValidator(3, 3).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should succeed with min = 1 and max = 128", () => {
+                expect(new LengthValidator(1, 128).validate(value, "aThreeLengthThing")).toBeNull();
+            });
+            it ("should fail with min = 4", () => {
+                expect(new LengthValidator(4).validate(value, "aThreeLengthThing")).toEqual({
+                    constraintType: "length",
+                    constraintValues: [4, undefined],
+                    memberName: "aThreeLengthThing",
+                    failureValue: 3
+                })
+            });
+            it ("should fail with max = 2", () => {
+                expect(new LengthValidator(undefined, 2).validate(value, "aThreeLengthThing")).toEqual({
+                    constraintType: "length",
+                    constraintValues: [undefined, 2],
+                    memberName: "aThreeLengthThing",
+                    failureValue: 3
+                })
+            });
+            it ("should fail with min = 1 and max = 2", () => {
+                expect(new LengthValidator(1, 2).validate(value, "aThreeLengthThing")).toEqual({
+                    constraintType: "length",
+                    constraintValues: [1, 2],
+                    memberName: "aThreeLengthThing",
+                    failureValue: 3
+                })
+            });
+        });
+    }
+});
+
+describe("pattern validation", () => {
+    it("does not match the entire string", () => {
+        const validator = new PatternValidator("\\w+");
+        expect(validator.validate("hello", "aField")).toBeNull();
+        expect(validator.validate("!hello!", "aField")).toBeNull();
+    });
+    it("can be anchored", () => {
+        const validator = new PatternValidator("^\\w+$");
+        expect(validator.validate("hello", "aField")).toBeNull();
+        expect(validator.validate("!hello!", "aField")).toEqual({
+            constraintType: "pattern",
+            constraintValues: "^\\w+$",
+            failureValue: "!hello!",
+            memberName: "aField"
+        });
+    });
+    it("supports character class expressions", () => {
+        const validator = new PatternValidator("^\\p{L}+$");
+        expect(validator.validate("hello", "aField")).toBeNull();
+        expect(validator.validate("!hello!", "aField")).toEqual({
+            constraintType: "pattern",
+            constraintValues: "^\\p{L}+$",
+            failureValue: "!hello!",
+            memberName: "aField"
+        });
+    });
+});
+
+describe("range validation", () => {
+    it("supports min-only constraints", () => {
+        const validator = new RangeValidator(3);
+        expect(validator.validate(3, "aField")).toBeNull();
+        expect(validator.validate(4, "aField")).toBeNull();
+        expect(validator.validate(1, "aField")).toEqual({
+            constraintType: "range",
+            constraintValues: [3, undefined],
+            failureValue: 1,
+            memberName: "aField"
+        });
+    });
+    it("supports max-only constraints", () => {
+        const validator = new RangeValidator(undefined, 3);
+        expect(validator.validate(3, "aField")).toBeNull();
+        expect(validator.validate(1, "aField")).toBeNull();
+        expect(validator.validate(4, "aField")).toEqual({
+            constraintType: "range",
+            constraintValues: [undefined, 3],
+            failureValue: 4,
+            memberName: "aField"
+        });
+    });
+    it("supports min-max constraints", () => {
+        const validator = new RangeValidator(3, 5);
+        expect(validator.validate(3, "aField")).toBeNull();
+        expect(validator.validate(4, "aField")).toBeNull();
+        expect(validator.validate(5, "aField")).toBeNull();
+        expect(validator.validate(1, "aField")).toEqual({
+            constraintType: "range",
+            constraintValues: [3, 5],
+            failureValue: 1,
+            memberName: "aField"
+        });
+        expect(validator.validate(6, "aField")).toEqual({
+            constraintType: "range",
+            constraintValues: [3, 5],
+            failureValue: 6,
+            memberName: "aField"
+        });
+    });
+});
+
+describe("uniqueItems", () => {
+    const validator = new UniqueItemsValidator();
+    describe("supports strings", () => {
+        expect(validator.validate(["a", "b", "c"], "aField")).toBeNull();
+        expect(validator.validate(["a", "a", "c", "a", "b", "b"], "aField")).toEqual({
+            constraintType: "uniqueItems",
+            failureValue: ["a", "b"],
+            memberName: "aField"
+        });
+    });
+    describe("supports numbers", () => {
+        expect(validator.validate([1, 2, 3], "aField")).toBeNull();
+        expect(validator.validate([1, 1, 3, 1, 1, 2.5, 2.5], "aField")).toEqual({
+            constraintType: "uniqueItems",
+            failureValue: [1, 2.5],
+            memberName: "aField"
+        });
+    });
+    describe("supports booleans, I guess", () => {
+        expect(validator.validate([true, false], "aField")).toBeNull();
+        expect(validator.validate([true, false, true], "aField")).toEqual({
+            constraintType: "uniqueItems",
+            failureValue: [true],
+            memberName: "aField"
+        });
+    });
+});

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { EnumValidationFailure, LengthValidationFailure, PatternValidationFailure, UniqueItemsValidationFailure } from ".";
+
+export class EnumValidator {
+    private readonly allowedValues: string[];
+
+    constructor(allowedValues: readonly string[]) {
+        this.allowedValues = allowedValues.slice();
+    }
+
+    validate(input: string, memberName: string): EnumValidationFailure | null {
+        if (this.allowedValues.indexOf(input) < 0) {
+            return {
+                constraintType: 'enum',
+                constraintValues: this.allowedValues.slice(),
+                memberName: memberName,
+                failureValue: input
+            }
+        }
+
+        return null;
+    }
+
+}
+
+export class LengthValidator {
+    private readonly min?: number;
+    private readonly max?: number;
+
+    constructor(min?: number, max?: number) {
+        if (min === undefined && max === undefined) {
+            throw new Error('Length constraints must have at least a min or a max.');
+        }
+        this.min = min;
+        this.max = max;
+    }
+
+    validate(input: { length: number } | { [key: string]: any }, memberName: string): LengthValidationFailure | null {
+        let length: number;
+        if (LengthValidator.hasProperty(input, 'length')) {
+            length = input.length;
+        } else {
+            length = Object.keys(input).length;
+        }
+
+        if (this.min !== undefined && length < this.min || this.max !== undefined && length > this.max) {
+            return {
+                constraintType: 'length',
+                constraintValues: this.min === undefined ? [undefined, this.max!]
+                                    : this.max === undefined ? [this.min!, undefined]
+                                    : [this.min!, this.max!],
+                memberName: memberName,
+                failureValue: length
+            }
+        }
+
+        return null;
+    }
+
+    private static hasProperty<P extends PropertyKey>(obj: any, prop: P): obj is Record<P, unknown> {
+        return obj.hasOwnProperty(prop)
+    }
+}
+
+export class RangeValidator {
+    private readonly min?: number;
+    private readonly max?: number;
+
+    constructor(min?: number, max?: number) {
+        if (min === undefined && max === undefined) {
+            throw new Error('Range constraints must have at least a min or a max.');
+        }
+        this.min = min;
+        this.max = max;
+    }
+
+    validate(input: number, memberName: string) {
+        if (this.min !== undefined && input < this.min || this.max !== undefined && input > this.max) {
+            return {
+                constraintType: 'range',
+                constraintValues: this.min === undefined ? [undefined, this.max!]
+                    : this.max === undefined ? [this.min!, undefined]
+                        : [this.min!, this.max!],
+                memberName: memberName,
+                failureValue: input
+            }
+        }
+
+        return null;
+    }
+}
+
+export class PatternValidator {
+    private readonly inputPattern: string;
+    private readonly pattern: RegExp;
+
+    constructor(pattern: string) {
+        this.inputPattern = pattern;
+        this.pattern = new RegExp(pattern, "u");
+    }
+
+    validate(input: string, memberName: string): PatternValidationFailure | null {
+        if (!input.match(this.pattern)) {
+            return {
+                constraintType: 'pattern',
+                constraintValues: this.inputPattern,
+                failureValue: input,
+                memberName: memberName
+            }
+        }
+        return null;
+    }
+}
+
+export class UniqueItemsValidator {
+
+    validate(input: Array<any>, memberName: string): UniqueItemsValidationFailure | null {
+        let repeats = new Set<any>();
+        let uniqueValues = new Set<any>();
+        for (let i of input) {
+            if (uniqueValues.has(i)) {
+                repeats.add(i);
+            } else {
+                uniqueValues.add(i);
+            }
+        }
+
+        if (repeats.size > 0) {
+            return {
+                constraintType: 'uniqueItems',
+                memberName: memberName,
+                failureValue: [...repeats].sort()
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
These are basic, initial implementations of the constraints specified in the
Smithy documentation (minus required, which is going to be validated while
walking the members of a structure, and not on the values of a given member).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
