### PR TITLE
Mark everything as internal or unstable

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
@@ -18,11 +18,13 @@ package software.amazon.smithy.typescript.codegen;
 import java.util.Objects;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Represents the resolves {@link Symbol}s and references for an
  * application protocol (e.g., "http", "mqtt", etc).
  */
+@SmithyUnstableApi
 public final class ApplicationProtocol {
 
     private final String name;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -26,10 +26,12 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Utility methods needed across Java packages.
  */
+@SmithyUnstableApi
 public final class CodegenUtils {
 
     private CodegenUtils() {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -50,9 +50,11 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.waiters.WaitableTrait;
 import software.amazon.smithy.waiters.Waiter;
 
+@SmithyInternalApi
 class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
     private static final Logger LOGGER = Logger.getLogger(CodegenVisitor.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -32,10 +32,12 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates a client command using plugins.
  */
+@SmithyInternalApi
 final class CommandGenerator implements Runnable {
 
     static final String COMMAND_PROPERTIES_SECTION = "command_properties";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/EnumGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/EnumGenerator.java
@@ -20,6 +20,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumDefinition;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates an appropriate TypeScript type from a Smithy enum string.
@@ -51,6 +52,7 @@ import software.amazon.smithy.model.traits.EnumTrait;
  * }
  * }</pre>
  */
+@SmithyInternalApi
 final class EnumGenerator implements Runnable {
 
     private final Symbol symbol;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/FrameworkErrorModel.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/FrameworkErrorModel.java
@@ -16,7 +16,9 @@
 package software.amazon.smithy.typescript.codegen;
 
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
+@SmithyUnstableApi
 public enum FrameworkErrorModel {
 
     INSTANCE;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -66,6 +66,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.Pair;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates HTTP protocol test cases to be run using Jest.
@@ -79,6 +80,7 @@ import software.amazon.smithy.utils.Pair;
  *
  * TODO: try/catch and if/else are still cumbersome with TypeScriptWriter.
  */
+@SmithyInternalApi
 final class HttpProtocolTestGenerator implements Runnable {
 
     private static final Logger LOGGER = Logger.getLogger(HttpProtocolTestGenerator.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ImportDeclarations.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ImportDeclarations.java
@@ -21,10 +21,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Internal class used for aggregating imports of a file.
  */
+@SmithyInternalApi
 final class ImportDeclarations {
 
     private final Path relativize;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -28,12 +28,14 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.waiters.WaitableTrait;
 import software.amazon.smithy.waiters.Waiter;
 
 /**
  * Generates an index to export the service client and each command.
  */
+@SmithyInternalApi
 final class IndexGenerator {
 
     private IndexGenerator() {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/LanguageTarget.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/LanguageTarget.java
@@ -15,9 +15,12 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
 /**
  * Represents a possible language target that can be generated.
  */
+@SmithyUnstableApi
 public enum LanguageTarget {
     /**
      * Node-specific language target.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/NonModularServiceGenerator.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -33,6 +34,7 @@ import software.amazon.smithy.utils.StringUtils;
  * operations of a service are considered referenced, meaning they will
  * not be removed by tree-shaking.
  */
+@SmithyInternalApi
 final class NonModularServiceGenerator implements Runnable {
 
     private final TypeScriptSettings settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
@@ -22,10 +22,12 @@ import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Private class used to generates a package.json file for the project.
  */
+@SmithyInternalApi
 final class PackageJsonGenerator {
 
     private PackageJsonGenerator() {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -25,7 +25,9 @@ import software.amazon.smithy.model.knowledge.PaginatedIndex;
 import software.amazon.smithy.model.knowledge.PaginationInfo;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
+@SmithyInternalApi
 final class PaginationGenerator implements Runnable {
 
     static final String PAGINATION_INTERFACE_FILE = "pagination/Interfaces.ts";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -25,12 +25,14 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates runtime configuration files, files that are used to
  * supply different default values based on the targeted language
  * environment of the SDK (e.g., Node vs Browser).
  */
+@SmithyInternalApi
 final class RuntimeConfigGenerator {
 
     private final TypeScriptSettings settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -30,10 +30,12 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates server operation types.
  */
+@SmithyInternalApi
 final class ServerCommandGenerator implements Runnable {
 
     private final TypeScriptSettings settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerErrorGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerErrorGenerator.java
@@ -20,11 +20,13 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates convenience error types for servers, since service developers will throw a modeled exception directly,
  * while clients typically care only about catching them.
  */
+@SmithyInternalApi
 final class ServerErrorGenerator implements Runnable {
 
     private final TypeScriptSettings settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -22,7 +22,9 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
+@SmithyInternalApi
 final class ServerGenerator {
 
     private ServerGenerator() {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -28,11 +28,13 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Wraps a client SymbolProvider and generates substitute shapes for server-specific symbols.
  */
+@SmithyInternalApi
 final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements SymbolProvider {
     private static final Logger LOGGER = Logger.getLogger(ServerSymbolVisitor.class.getName());
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -32,10 +32,12 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates a service client and configuration using plugins.
  */
+@SmithyInternalApi
 final class ServiceGenerator implements Runnable {
 
     static final String CLIENT_CONFIG_SECTION = "client_config";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -24,10 +24,12 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates normal structures and error structures.
  */
+@SmithyInternalApi
 final class StructureGenerator implements Runnable {
 
     private final Model model;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -31,12 +31,14 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Generates objects, interfaces, enums, etc.
  *
  * TODO: Replace this with a builder for generating classes and interfaces.
  */
+@SmithyInternalApi
 final class StructuredMemberWriter {
 
     Model model;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -63,6 +63,7 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -71,6 +72,7 @@ import software.amazon.smithy.utils.StringUtils;
  * <p>Reserved words for TypeScript are automatically escaped so that they are
  * prefixed with "_". See "reserved-words.txt" for the list of words.
  */
+@SmithyInternalApi
 final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     static final String IMPLEMENTS_INTERFACE_PROPERTY = "implementsInterface";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -20,10 +20,12 @@ import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Plugin to trigger TypeScript code generation.
  */
+@SmithyInternalApi
 public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -29,7 +29,9 @@ import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
+@SmithyUnstableApi
 final class TypeScriptDelegator {
 
     private final TypeScriptSettings settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -21,10 +21,12 @@ import java.util.List;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * An enum of all of the built-in dependencies managed by this package.
  */
+@SmithyUnstableApi
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "3.6.1", true),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptJmesPathVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptJmesPathVisitor.java
@@ -37,7 +37,9 @@ import software.amazon.smithy.jmespath.ast.OrExpression;
 import software.amazon.smithy.jmespath.ast.ProjectionExpression;
 import software.amazon.smithy.jmespath.ast.SliceExpression;
 import software.amazon.smithy.jmespath.ast.Subexpression;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
+@SmithyInternalApi
 class TypeScriptJmesPathVisitor implements ExpressionVisitor<Void> {
 
     // Execution context is the current "head" of the execution. This is scope on which the expression

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptServerCodegenPlugin.java
@@ -18,10 +18,12 @@ package software.amazon.smithy.typescript.codegen;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Plugin to trigger TypeScript SSDK code generation.
  */
+@SmithyInternalApi
 public class TypeScriptServerCodegenPlugin implements SmithyBuildPlugin {
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -33,10 +33,12 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Settings used by {@link TypeScriptCodegenPlugin}.
  */
+@SmithyUnstableApi
 public final class TypeScriptSettings {
 
     static final String TARGET_NAMESPACE = "targetNamespace";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptUtils.java
@@ -22,11 +22,13 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
  * Utility methods for TypeScript / JavaScript.
  */
+@SmithyInternalApi
 final class TypeScriptUtils {
 
     private static final Pattern PROPERTY_NAME_REGEX = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -36,6 +36,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.utils.CodeWriter;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -52,6 +53,7 @@ import software.amazon.smithy.utils.StringUtils;
  * <p>Dependencies introduced via a TypeScriptWriter are added to the package.json
  * file if the writer is a part of the {@link TypeScriptDelegator} of the {@link CodegenVisitor}.
  */
+@SmithyUnstableApi
 public final class TypeScriptWriter extends CodeWriter {
 
     private static final Logger LOGGER = Logger.getLogger(TypeScriptWriter.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -122,6 +123,7 @@ import software.amazon.smithy.utils.StringUtils;
  * so that it is forward-compatible to change a structure with optional
  * and mutually exclusive members to a tagged union.
  */
+@SmithyInternalApi
 final class UnionGenerator implements Runnable {
 
     private final Model model;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnresolvableProtocolException.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnresolvableProtocolException.java
@@ -16,7 +16,9 @@
 package software.amazon.smithy.typescript.codegen;
 
 import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
+@SmithyUnstableApi
 public class UnresolvableProtocolException extends CodegenException {
     public UnresolvableProtocolException(String message) {
         super(message);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
@@ -21,12 +21,14 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.jmespath.JmespathExpression;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.waiters.Acceptor;
 import software.amazon.smithy.waiters.AcceptorState;
 import software.amazon.smithy.waiters.Matcher;
 import software.amazon.smithy.waiters.PathMatcher;
 import software.amazon.smithy.waiters.Waiter;
 
+@SmithyInternalApi
 class WaiterGenerator implements Runnable {
     static final String WAITABLE_UTIL_PACKAGE = TypeScriptDependency.AWS_SDK_UTIL_WAITERS.packageName;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -32,10 +32,12 @@ import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * Adds event streams if needed.
  */
+@SmithyInternalApi
 public final class AddEventStreamDependency implements TypeScriptIntegration {
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -45,6 +45,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to generate member values for aggregate types deserialized from documents.
@@ -63,6 +64,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *   <li>All other types: unmodified.</li>
  * </ul>
  */
+@SmithyUnstableApi
 public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     private final GenerationContext context;
     private final String dataSource;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -45,6 +45,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to generate member values for aggregate types serialized in documents.
@@ -62,6 +63,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *   <li>All other types: unmodified.</li>
  * </ul>
  */
+@SmithyUnstableApi
 public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     private final GenerationContext context;
     private final String dataSource;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to generate deserialization functions for shapes in protocol document bodies.
@@ -62,6 +63,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *   <li>All other types: no function generated. <b>May be overridden.</b></li>
  * </ul>
  */
+@SmithyUnstableApi
 public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Void> {
     private final GenerationContext context;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Visitor to generate serialization functions for shapes in protocol document bodies.
@@ -62,6 +63,7 @@ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.G
  *   <li>All other types: no function generated. <b>May be overridden.</b></li>
  * </ul>
  */
+@SmithyUnstableApi
 public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void> {
     private final GenerationContext context;
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -73,10 +73,12 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Abstract implementation useful for all protocols that use HTTP bindings.
  */
+@SmithyUnstableApi
 public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator {
 
     private static final Logger LOGGER = Logger.getLogger(HttpBindingProtocolGenerator.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -41,10 +41,12 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Utility methods for generating HTTP protocols.
  */
+@SmithyUnstableApi
 public final class HttpProtocolGeneratorUtils {
 
     private static final Logger LOGGER = Logger.getLogger(HttpBindingProtocolGenerator.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -30,10 +30,12 @@ import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Abstract implementation useful for all HTTP protocols without bindings.
  */
+@SmithyUnstableApi
 public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
     public static final Logger LOGGER = Logger.getLogger(HttpRpcProtocolGenerator.class.getName());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -30,10 +30,12 @@ import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.CaseUtils;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Smithy protocol code generators.
  */
+@SmithyUnstableApi
 public interface ProtocolGenerator {
     /**
      * Sanitizes the name of the protocol so it can be used as a symbol

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -42,6 +43,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  * {@link TypeScriptIntegration} SPI and applied to the code generator at
  * build-time.
  */
+@SmithyUnstableApi
 public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientPlugin> {
 
     private final SymbolReference inputConfig;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -30,12 +30,14 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Java SPI for customizing TypeScript code generation, registering
  * new protocol code generators, renaming shapes, modifying the model,
  * adding custom code, etc.
  */
+@SmithyUnstableApi
 public interface TypeScriptIntegration {
     /**
      * Gets the sort order of the customization from -128 to 127.


### PR DESCRIPTION
This marks all the java classes as either internal or unstable so the generator can be published to maven without an expectation of the java code itself being GA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
