### PR TITLE
remove extra model export line

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -129,8 +129,6 @@ final class IndexGenerator {
             writer.write("export * from \"./$L\";", modulePath.replace(".ts", ""));
         }
 
-        // write export statement for models
-        writer.write("export * from \"./models/index\";");
         // Write each custom export.
         for (TypeScriptIntegration integration : integrations) {
             integration.writeAdditionalExports(settings, model, symbolProvider, writer);


### PR DESCRIPTION
Remove extra line of model exports. The removed export is duplicated with:
https://github.com/awslabs/smithy-typescript/blob/4bb9ffb9e4efd9ff9abba06155911c087ccfbb92/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java#L60-L61


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
