### PR TITLE
Validation generation for SSDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ wrapper/
 
 # Visual Studio Code
 .vscode/*
+
+# Integ test Yarn stuff
+smithy-typescript-integ-tests/dist
+smithy-typescript-integ-tests/node_modules
+smithy-typescript-integ-tests/yarn.lock

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -259,7 +259,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
      */
     @Override
     public Void structureShape(StructureShape shape) {
-        writers.useShapeWriter(shape, writer -> new StructureGenerator(model, symbolProvider, writer, shape).run());
+        writers.useShapeWriter(shape, writer ->
+                new StructureGenerator(model, symbolProvider, writer, shape, settings.generateServerSdk()).run());
         return null;
     }
 
@@ -271,7 +272,8 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
      */
     @Override
     public Void unionShape(UnionShape shape) {
-        writers.useShapeWriter(shape, writer -> new UnionGenerator(model, symbolProvider, writer, shape).run());
+        writers.useShapeWriter(shape, writer ->
+                new UnionGenerator(model, symbolProvider, writer, shape, settings.generateServerSdk()).run());
         return null;
     }
 

--- a/smithy-typescript-integ-tests/codegen/build.gradle
+++ b/smithy-typescript-integ-tests/codegen/build.gradle
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import software.amazon.smithy.gradle.tasks.SmithyBuild
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'software.amazon.smithy:smithy-typescript-codegen:0.3.0'
+        classpath 'software.amazon.smithy:smithy-aws-typescript-codegen:0.3.0'
+        classpath "software.amazon.smithy:smithy-model:1.5.1"
+    }
+}
+
+plugins {
+    id 'software.amazon.smithy' version '0.5.2'
+}
+
+dependencies {
+    implementation "software.amazon.smithy:smithy-aws-traits:1.5.1"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+jar.enabled = false
+smithyBuildJar.enabled = false
+
+task generateServer(type: SmithyBuild) {}
+
+build.dependsOn generateServer

--- a/smithy-typescript-integ-tests/codegen/model/validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/model/validation.smithy
@@ -1,0 +1,80 @@
+namespace software.amazon.smithy.typescript.integ
+
+use aws.protocols#restJson1
+
+@restJson1
+service ValidationService {
+    version: "2020-01-25",
+    operations: [Test]
+}
+
+@readonly
+@http(method: "POST", uri:"/test")
+operation Test {
+    input: TestInput
+}
+
+structure TestInput {
+    enum: Enum,
+    lengthTests: LengthTests,
+    nestedTests: NestedUnionOne
+}
+
+structure LengthTests {
+    minMaxLengthString: MinMaxLengthString,
+
+    minMaxLengthList: MinMaxLengthList,
+
+    minMaxLengthMap: MinMaxLengthMap,
+
+    minMaxLengthBlob: MinMaxLengthBlob,
+
+    @length(min:13, max:27)
+    minMaxLengthOverride: MinMaxLengthString,
+}
+
+union NestedUnionOne {
+    value1: NestedUnionTwo
+}
+
+union NestedUnionTwo {
+    value2: SetOfStructures
+}
+
+set SetOfStructures {
+    member: NestedStructureOne
+}
+
+structure NestedStructureOne {
+    unions: ListOfUnions
+}
+
+list ListOfUnions {
+    member: NestedUnionThree
+}
+
+union NestedUnionThree {
+    value3: MinMaxLengthString
+}
+
+@enum([{"value" : "valueA"}, {"value": "valueB"}])
+string Enum
+
+@length(min: 2, max: 7)
+string MinMaxLengthString
+
+@length(min: 2, max: 4)
+map MinMaxLengthMap {
+    key: MinMaxLengthString,
+
+    @range(min: 1, max: 7)
+    value: Integer
+}
+
+@length(min: 2, max: 4)
+list MinMaxLengthList {
+    member: MinMaxLengthString
+}
+
+@length(min: 2, max: 4)
+blob MinMaxLengthBlob

--- a/smithy-typescript-integ-tests/codegen/smithy-build.json
+++ b/smithy-typescript-integ-tests/codegen/smithy-build.json
@@ -1,0 +1,14 @@
+{
+  "version" : "1.0",
+  "outputDirectory" : "build/output",
+  "projections" : {
+    "ts-server" : {
+      "plugins": {
+        "typescript-ssdk-codegen" : {
+          "package" : "@aws-smithy/typescript-integ-test-types",
+          "packageVersion": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/smithy-typescript-integ-tests/jest.config.js
+++ b/smithy-typescript-integ-tests/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    transform: {
+        "^.+\\.(ts|tsx)$": "ts-jest",
+    },
+    testMatch: ["**/src/**/?(*.)+(spec|test).ts"],
+    globals: {
+        "ts-jest": {
+            tsconfig: "tsconfig.json",
+        },
+    },
+};

--- a/smithy-typescript-integ-tests/package.json
+++ b/smithy-typescript-integ-tests/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@aws-smithy/typescript-integ-tests",
+  "private": true,
+  "version": "1.0.0",
+  "description": "TypeScript tests against generated Smithy types",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/types/index.d.ts",
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "pretest": "yarn generate && yarn build:generated && yarn build",
+    "generate": "cd codegen && gradle build",
+    "build:generated": "cd codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/awslabs/smithy-typescript.git",
+    "directory": "smithy-typescript-integ-tests"
+  },
+  "author": "AWS Smithy Team",
+  "license": "Apache-2.0",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.22",
+    "@types/node": "^14.14.37",
+    "jest": "^26.6.3",
+    "ts-jest": "^26.5.2",
+    "typescript": "^4.2.2",
+    "@aws-smithy/typescript-integ-test-types": "1.0.0"
+  },
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/awslabs/smithy-typescript/issues"
+  },
+  "homepage": "https://github.com/awslabs/smithy-typescript#readme",
+  "workspaces": [
+    "codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen"
+  ]
+}

--- a/smithy-typescript-integ-tests/src/length.spec.ts
+++ b/smithy-typescript-integ-tests/src/length.spec.ts
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import {LengthTests} from "@aws-smithy/typescript-integ-test-types";
+
+describe("length constraints", () => {
+    it("work for strings", () => {
+        expect(LengthTests.validate({ minMaxLengthString: "much longer than 7" })).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 7 ],
+            failureValue: 18,
+            memberName: "minMaxLengthString",
+        }]);
+        expect(LengthTests.validate({ minMaxLengthString: "a" })).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 7 ],
+            failureValue: 1,
+            memberName: "minMaxLengthString",
+        }]);
+    });
+    it("work for maps", () => {
+        expect(LengthTests.validate({ minMaxLengthMap: { "abc": 1 }})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 1,
+            memberName: "minMaxLengthMap",
+        }]);
+        expect(LengthTests.validate({ minMaxLengthMap: { "abc": 1, "bcd": 2, "cde": 3, "def": 4, "efg": 5 }})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 5,
+            memberName: "minMaxLengthMap",
+        }]);
+    });
+    it("also work on map keys", () => {
+        expect(LengthTests.validate({ minMaxLengthMap: { "a": 1, "bcd": 2, "cde": 3 }})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 7 ],
+            failureValue: 1,
+            memberName: "minMaxLengthMap",
+        }]);
+        expect(LengthTests.validate({ minMaxLengthMap: { "abcdefghijk": 5, "bcd": 2, "cde": 3 }})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 7 ],
+            failureValue: 11,
+            memberName: "minMaxLengthMap",
+        }]);
+    });
+    it("work for lists", () => {
+        expect(LengthTests.validate({ minMaxLengthList: ["abc"]})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 1,
+            memberName: "minMaxLengthList",
+        }]);
+        expect(LengthTests.validate({ minMaxLengthList: [ "abc", "bcd", "cde", "def", "efg" ]})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 5,
+            memberName: "minMaxLengthList",
+        }]);
+    });
+    it("also work on list values", () => {
+        expect(LengthTests.validate({ minMaxLengthList: ["abcdefghijk", "def"]})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 7 ],
+            failureValue: 11,
+            memberName: "minMaxLengthList",
+        }]);
+    });
+    it("work for blobs", () => {
+        expect(LengthTests.validate({ minMaxLengthBlob: Buffer.of(1) })).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 1,
+            memberName: "minMaxLengthBlob",
+        }]);
+        expect(LengthTests.validate({ minMaxLengthBlob: Buffer.of(1, 2, 3, 4, 5)})).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 2, 4 ],
+            failureValue: 5,
+            memberName: "minMaxLengthBlob",
+        }]);
+    });
+    it("can be overridden on members", () => {
+        expect(LengthTests.validate({ minMaxLengthOverride: "abcdef" })).toEqual([{
+            constraintType: "length",
+            constraintValues: [ 13, 27 ],
+            failureValue: 6,
+            memberName: "minMaxLengthOverride",
+        }]);
+    })
+});

--- a/smithy-typescript-integ-tests/src/nested.spec.ts
+++ b/smithy-typescript-integ-tests/src/nested.spec.ts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import {NestedUnionOne} from "@aws-smithy/typescript-integ-test-types";
+
+describe("ridiculously nested structures", () => {
+    it("still work", () => {
+        expect(NestedUnionOne.validate({ value1: { value2: [ { unions: [ { value3: "abcdefghijk"}] } ] } }))
+            .toEqual([]);
+    })
+});

--- a/smithy-typescript-integ-tests/tsconfig.json
+++ b/smithy-typescript-integ-tests/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "stripInternal": true,
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": ".",
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "noUnusedParameters": false,
+    "removeComments": false,
+    "incremental": true,
+    "preserveConstEnums": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2018",
+    "lib": ["es2015", "dom"],
+    "strict": true,
+    "declaration": true,
+    "importHelpers": true,
+    "noEmitHelpers": true,
+    "inlineSourceMap": true,
+    "inlineSources": true
+  },
+  "include": ["src/"]
+}

--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -15,6 +15,7 @@
 
 export * as httpbinding from "./httpbinding";
 export * from "./errors";
+export * from "./validation";
 
 import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { SmithyException } from "@aws-sdk/smithy-client";

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+export * from "./validators";
+
+interface StandardValidationFailure<ConstraintBoundsType, FailureType> {
+  memberName: string;
+  constraintType: string;
+  constraintValues: ArrayLike<ConstraintBoundsType>;
+  failureValue: FailureType;
+}
+
+export interface EnumValidationFailure extends StandardValidationFailure<string, string> {
+  constraintType: "enum";
+  constraintValues: string[];
+}
+
+export interface LengthValidationFailure extends StandardValidationFailure<number | undefined, number> {
+  constraintType: "length";
+  constraintValues: [number, number] | [undefined, number] | [number, undefined];
+}
+
+export interface PatternValidationFailure {
+  memberName: string;
+  constraintType: "pattern";
+  constraintValues: string;
+  failureValue: string;
+}
+
+export interface RangeValidationFailure extends StandardValidationFailure<number | undefined, number> {
+  constraintType: "range";
+  constraintValues: [number, number] | [undefined, number] | [number, undefined];
+}
+
+export class RequiredValidationFailure {
+  memberName: string;
+  constraintType = "required";
+
+  constructor(memberName: string) {
+    this.memberName = memberName;
+  }
+}
+
+export interface UniqueItemsValidationFailure {
+  memberName: string;
+  constraintType: "uniqueItems";
+  failureValue: Array<any>;
+}
+
+export type ValidationFailure =
+  | EnumValidationFailure
+  | LengthValidationFailure
+  | PatternValidationFailure
+  | RangeValidationFailure
+  | RequiredValidationFailure
+  | UniqueItemsValidationFailure;

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -1,0 +1,183 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { EnumValidator, LengthValidator, PatternValidator, RangeValidator, UniqueItemsValidator } from "./validators";
+
+describe("enum validation", () => {
+  const enumValidator = new EnumValidator(["apple", "banana", "orange"]);
+
+  it("does not fail when the enum value is found", () => {
+    expect(enumValidator.validate("apple", "fruit")).toBeNull();
+  });
+
+  it("fails when the enum value is not found", () => {
+    expect(enumValidator.validate("kiwi", "fruit")).toEqual({
+      constraintType: "enum",
+      constraintValues: ["apple", "banana", "orange"],
+      memberName: "fruit",
+      failureValue: "kiwi",
+    });
+  });
+});
+
+describe("length validation", () => {
+  const threeLengthThings = ["foo", { a: 1, b: 2, c: 3 }, ["a", "b", "c"], new Uint8Array([13, 37, 42])];
+
+  for (const value of threeLengthThings) {
+    describe(`for ${JSON.stringify(value)}`, () => {
+      it("should succeed with min = 1", () => {
+        expect(new LengthValidator(1).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should succeed with min = 3", () => {
+        expect(new LengthValidator(3).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should succeed with max = 100", () => {
+        expect(new LengthValidator(undefined, 100).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should succeed with max = 3", () => {
+        expect(new LengthValidator(undefined, 3).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should succeed with min = 3 and max = 3", () => {
+        expect(new LengthValidator(3, 3).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should succeed with min = 1 and max = 128", () => {
+        expect(new LengthValidator(1, 128).validate(value, "aThreeLengthThing")).toBeNull();
+      });
+      it("should fail with min = 4", () => {
+        expect(new LengthValidator(4).validate(value, "aThreeLengthThing")).toEqual({
+          constraintType: "length",
+          constraintValues: [4, undefined],
+          memberName: "aThreeLengthThing",
+          failureValue: 3,
+        });
+      });
+      it("should fail with max = 2", () => {
+        expect(new LengthValidator(undefined, 2).validate(value, "aThreeLengthThing")).toEqual({
+          constraintType: "length",
+          constraintValues: [undefined, 2],
+          memberName: "aThreeLengthThing",
+          failureValue: 3,
+        });
+      });
+      it("should fail with min = 1 and max = 2", () => {
+        expect(new LengthValidator(1, 2).validate(value, "aThreeLengthThing")).toEqual({
+          constraintType: "length",
+          constraintValues: [1, 2],
+          memberName: "aThreeLengthThing",
+          failureValue: 3,
+        });
+      });
+    });
+  }
+});
+
+describe("pattern validation", () => {
+  it("does not match the entire string", () => {
+    const validator = new PatternValidator("\\w+");
+    expect(validator.validate("hello", "aField")).toBeNull();
+    expect(validator.validate("!hello!", "aField")).toBeNull();
+  });
+  it("can be anchored", () => {
+    const validator = new PatternValidator("^\\w+$");
+    expect(validator.validate("hello", "aField")).toBeNull();
+    expect(validator.validate("!hello!", "aField")).toEqual({
+      constraintType: "pattern",
+      constraintValues: "^\\w+$",
+      failureValue: "!hello!",
+      memberName: "aField",
+    });
+  });
+  it("supports character class expressions", () => {
+    const validator = new PatternValidator("^\\p{L}+$");
+    expect(validator.validate("hello", "aField")).toBeNull();
+    expect(validator.validate("!hello!", "aField")).toEqual({
+      constraintType: "pattern",
+      constraintValues: "^\\p{L}+$",
+      failureValue: "!hello!",
+      memberName: "aField",
+    });
+  });
+});
+
+describe("range validation", () => {
+  it("supports min-only constraints", () => {
+    const validator = new RangeValidator(3);
+    expect(validator.validate(3, "aField")).toBeNull();
+    expect(validator.validate(4, "aField")).toBeNull();
+    expect(validator.validate(1, "aField")).toEqual({
+      constraintType: "range",
+      constraintValues: [3, undefined],
+      failureValue: 1,
+      memberName: "aField",
+    });
+  });
+  it("supports max-only constraints", () => {
+    const validator = new RangeValidator(undefined, 3);
+    expect(validator.validate(3, "aField")).toBeNull();
+    expect(validator.validate(1, "aField")).toBeNull();
+    expect(validator.validate(4, "aField")).toEqual({
+      constraintType: "range",
+      constraintValues: [undefined, 3],
+      failureValue: 4,
+      memberName: "aField",
+    });
+  });
+  it("supports min-max constraints", () => {
+    const validator = new RangeValidator(3, 5);
+    expect(validator.validate(3, "aField")).toBeNull();
+    expect(validator.validate(4, "aField")).toBeNull();
+    expect(validator.validate(5, "aField")).toBeNull();
+    expect(validator.validate(1, "aField")).toEqual({
+      constraintType: "range",
+      constraintValues: [3, 5],
+      failureValue: 1,
+      memberName: "aField",
+    });
+    expect(validator.validate(6, "aField")).toEqual({
+      constraintType: "range",
+      constraintValues: [3, 5],
+      failureValue: 6,
+      memberName: "aField",
+    });
+  });
+});
+
+describe("uniqueItems", () => {
+  const validator = new UniqueItemsValidator();
+  describe("supports strings", () => {
+    expect(validator.validate(["a", "b", "c"], "aField")).toBeNull();
+    expect(validator.validate(["a", "a", "c", "a", "b", "b"], "aField")).toEqual({
+      constraintType: "uniqueItems",
+      failureValue: ["a", "b"],
+      memberName: "aField",
+    });
+  });
+  describe("supports numbers", () => {
+    expect(validator.validate([1, 2, 3], "aField")).toBeNull();
+    expect(validator.validate([1, 1, 3, 1, 1, 2.5, 2.5], "aField")).toEqual({
+      constraintType: "uniqueItems",
+      failureValue: [1, 2.5],
+      memberName: "aField",
+    });
+  });
+  describe("supports booleans, I guess", () => {
+    expect(validator.validate([true, false], "aField")).toBeNull();
+    expect(validator.validate([true, false, true], "aField")).toEqual({
+      constraintType: "uniqueItems",
+      failureValue: [true],
+      memberName: "aField",
+    });
+  });
+});

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -1,0 +1,301 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import {
+  EnumValidationFailure,
+  LengthValidationFailure,
+  PatternValidationFailure,
+  RangeValidationFailure,
+  RequiredValidationFailure,
+  UniqueItemsValidationFailure,
+  ValidationFailure,
+} from ".";
+
+export class CompositeValidator<T> implements MultiConstraintValidator<T> {
+  private readonly validators: SingleConstraintValidator<T, any>[];
+
+  constructor(validators: SingleConstraintValidator<T, any>[]) {
+    this.validators = validators;
+  }
+
+  validate(input: T | undefined | null, memberName: string): ValidationFailure[] {
+    let retVal: ValidationFailure[] = [];
+    for (let v of this.validators) {
+      let failure = v.validate(input, memberName);
+      if (failure) {
+        retVal.push(failure);
+      }
+    }
+    return retVal;
+  }
+}
+
+export class CompositeStructureValidator<T> implements MultiConstraintValidator<T> {
+  private readonly referenceValidator: CompositeValidator<T>;
+  private readonly structureValidator: (input: T) => ValidationFailure[];
+
+  constructor(referenceValidator: CompositeValidator<T>, structureValidator: (input: T) => ValidationFailure[]) {
+    this.referenceValidator = referenceValidator;
+    this.structureValidator = structureValidator;
+  }
+
+  validate(input: T | undefined | null, memberName: string): ValidationFailure[] {
+    let retVal: ValidationFailure[] = [];
+    retVal.push(...this.referenceValidator.validate(input, memberName));
+    if (input !== null && input !== undefined) {
+      retVal.push(...this.structureValidator(input));
+    }
+    return retVal;
+  }
+}
+
+export class CompositeCollectionValidator<T> implements MultiConstraintValidator<Iterable<T>> {
+  private readonly referenceValidator: CompositeValidator<Iterable<T>>;
+  private readonly memberValidator: MultiConstraintValidator<T>;
+
+  constructor(referenceValidator: CompositeValidator<Iterable<T>>, memberValidator: MultiConstraintValidator<T>) {
+    this.referenceValidator = referenceValidator;
+    this.memberValidator = memberValidator;
+  }
+
+  validate(input: Iterable<T> | undefined | null, memberName: string): ValidationFailure[] {
+    let retVal: ValidationFailure[] = [];
+    retVal.push(...this.referenceValidator.validate(input, memberName));
+    if (input !== null && input !== undefined) {
+      for (let member of input) {
+        retVal.push(...this.memberValidator.validate(member, memberName));
+      }
+    }
+    return retVal;
+  }
+}
+
+export class CompositeMapValidator<T> implements MultiConstraintValidator<{ [key: string]: T }> {
+  private readonly referenceValidator: CompositeValidator<{ [key: string]: T }>;
+  private readonly keyValidator: MultiConstraintValidator<string>;
+  private readonly valueValidator: MultiConstraintValidator<T>;
+
+  constructor(
+    referenceValidator: CompositeValidator<{ [key: string]: T }>,
+    keyValidator: MultiConstraintValidator<string>,
+    valueValidator: MultiConstraintValidator<T>
+  ) {
+    this.referenceValidator = referenceValidator;
+    this.keyValidator = keyValidator;
+    this.valueValidator = valueValidator;
+  }
+
+  validate(input: { [key: string]: T } | undefined | null, memberName: string): ValidationFailure[] {
+    let retVal: ValidationFailure[] = [];
+    retVal.push(...this.referenceValidator.validate(input, memberName));
+    if (input !== null && input !== undefined) {
+      Object.keys(input).forEach((key) => {
+        const value = input[key];
+        retVal.push(...this.keyValidator.validate(key, memberName));
+        retVal.push(...this.valueValidator.validate(value, memberName));
+      });
+    }
+    return retVal;
+  }
+}
+
+export class NoOpValidator extends CompositeValidator<any> {
+  constructor() {
+    super([]);
+  }
+
+  validate(input: any, memberName: string): ValidationFailure[] {
+    return [];
+  }
+}
+
+export interface MultiConstraintValidator<T> {
+  validate(input: T, memberName: string): ValidationFailure[];
+}
+
+export interface SingleConstraintValidator<T, F> {
+  validate(input: T | undefined | null, memberName: string): F | null;
+}
+
+export class EnumValidator implements SingleConstraintValidator<string, EnumValidationFailure> {
+  private readonly allowedValues: string[];
+
+  constructor(allowedValues: readonly string[]) {
+    this.allowedValues = allowedValues.slice();
+  }
+
+  validate(input: string | undefined | null, memberName: string): EnumValidationFailure | null {
+    if (input === null || input === undefined) {
+      return null;
+    }
+
+    if (this.allowedValues.indexOf(input) < 0) {
+      return {
+        constraintType: "enum",
+        constraintValues: this.allowedValues.slice(),
+        memberName: memberName,
+        failureValue: input,
+      };
+    }
+
+    return null;
+  }
+}
+
+type LengthCheckable = { length: number } | { [key: string]: any };
+
+export class LengthValidator implements SingleConstraintValidator<LengthCheckable, LengthValidationFailure> {
+  private readonly min?: number;
+  private readonly max?: number;
+
+  constructor(min?: number, max?: number) {
+    if (min === undefined && max === undefined) {
+      throw new Error("Length constraints must have at least a min or a max.");
+    }
+    this.min = min;
+    this.max = max;
+  }
+
+  validate(input: LengthCheckable | undefined | null, memberName: string): LengthValidationFailure | null {
+    if (input === null || input === undefined) {
+      return null;
+    }
+
+    let length: number;
+    if (LengthValidator.hasLength(input)) {
+      length = input.length;
+    } else {
+      length = Object.keys(input).length;
+    }
+
+    if ((this.min !== undefined && length < this.min) || (this.max !== undefined && length > this.max)) {
+      return {
+        constraintType: "length",
+        constraintValues:
+          this.min === undefined
+            ? [undefined, this.max!]
+            : this.max === undefined
+            ? [this.min!, undefined]
+            : [this.min!, this.max!],
+        memberName: memberName,
+        failureValue: length,
+      };
+    }
+
+    return null;
+  }
+
+  private static hasLength<P extends PropertyKey>(obj: any): obj is { length: number } {
+    return obj.hasOwnProperty("length");
+  }
+}
+
+export class RangeValidator implements SingleConstraintValidator<number, RangeValidationFailure> {
+  private readonly min?: number;
+  private readonly max?: number;
+
+  constructor(min?: number, max?: number) {
+    if (min === undefined && max === undefined) {
+      throw new Error("Range constraints must have at least a min or a max.");
+    }
+    this.min = min;
+    this.max = max;
+  }
+
+  validate(input: number | undefined | null, memberName: string): RangeValidationFailure | null {
+    if (input === null || input === undefined) {
+      return null;
+    }
+
+    if ((this.min !== undefined && input < this.min) || (this.max !== undefined && input > this.max)) {
+      return {
+        constraintType: "range",
+        constraintValues:
+          this.min === undefined
+            ? [undefined, this.max!]
+            : this.max === undefined
+            ? [this.min!, undefined]
+            : [this.min!, this.max!],
+        memberName: memberName,
+        failureValue: input,
+      };
+    }
+
+    return null;
+  }
+}
+
+export class PatternValidator implements SingleConstraintValidator<string, PatternValidationFailure> {
+  private readonly inputPattern: string;
+  private readonly pattern: RegExp;
+
+  constructor(pattern: string) {
+    this.inputPattern = pattern;
+    this.pattern = new RegExp(pattern, "u");
+  }
+
+  validate(input: string | undefined | null, memberName: string): PatternValidationFailure | null {
+    if (input === null || input === undefined) {
+      return null;
+    }
+
+    if (!input.match(this.pattern)) {
+      return {
+        constraintType: "pattern",
+        constraintValues: this.inputPattern,
+        failureValue: input,
+        memberName: memberName,
+      };
+    }
+    return null;
+  }
+}
+
+export class RequiredValidator implements SingleConstraintValidator<any, RequiredValidationFailure> {
+  validate(input: any, memberName: string): RequiredValidationFailure | null {
+    if (input === null || input === undefined) {
+      return new RequiredValidationFailure(memberName);
+    }
+    return null;
+  }
+}
+
+export class UniqueItemsValidator implements SingleConstraintValidator<Array<any>, UniqueItemsValidationFailure> {
+  validate(input: Array<any> | undefined | null, memberName: string): UniqueItemsValidationFailure | null {
+    if (input === null || input === undefined) {
+      return null;
+    }
+
+    let repeats = new Set<any>();
+    let uniqueValues = new Set<any>();
+    for (let i of input) {
+      if (uniqueValues.has(i)) {
+        repeats.add(i);
+      } else {
+        uniqueValues.add(i);
+      }
+    }
+
+    if (repeats.size > 0) {
+      return {
+        constraintType: "uniqueItems",
+        memberName: memberName,
+        failureValue: [...repeats].sort(),
+      };
+    }
+
+    return null;
+  }
+}

--- a/smithy-typescript-ssdk-libs/tsconfig.json
+++ b/smithy-typescript-ssdk-libs/tsconfig.json
@@ -9,7 +9,6 @@
     "noUnusedParameters": false,
     "removeComments": false,
     "incremental": true,
-    "sourceMap": true,
     "preserveConstEnums": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,


### PR DESCRIPTION
*Description of changes:*

This can be broken up if desired, of course.

This adds:
- TypeScript implementations of validators for each constraint trait
- Generation of low-level validation methods for every modeled type when the SSDK is enabled.
-- I still don't know how to generate paths to members of sets, so I've punted on the path stuff in the design for now.
- An integ test subpackage that generates TS code from a model and then runs tests against it. It works, but is not hooked up to the main build of smithy-typescript.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
