### PR TITLE
fix(protocol-tests): ser test handler should throw error not object

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -5,8 +5,10 @@ import { Readable } from 'stream';
 /**
  * Throws an expected exception that contains the serialized request.
  */
-class EXPECTED_REQUEST_SERIALIZATION_ERROR {
-    constructor(readonly request: HttpRequest) {}
+class EXPECTED_REQUEST_SERIALIZATION_ERROR extends Error {
+    constructor(readonly request: HttpRequest) {
+      super();
+    }
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/aws/aws-sdk-js-v3/pull/2349

With the v3 change above, SDK will create a JS error wrapper for anything not an error thrown from the SDK. This change makes the [`RequestSerializationTestHandler`](https://github.com/awslabs/smithy-typescript/blob/5ec6906aa41fc4679793546608f0f5ad97774884/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts#L18) to throw a JS error instead of an object. So the SDK won't apply the JS error wrapper to it.

/cc @trivikr 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
