### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ are as follows:
    }
 
    dependencies {
-       implementation("software.amazon.smithy:smithy-typescript-codegen:0.1.0")
+       implementation("software.amazon.smithy:smithy-typescript-codegen:0.3.0")
    }
    ```
 


### PR DESCRIPTION


*Issue #, if available:*
The readme was using an out dated version of the library in the setup
instructions. When I tried to generate a typescript client using the instructions in the README, I got the error
```
Execution failed for task ':smithyBuildJar'.
> Could not resolve all files for configuration ':smithyCli'.
   > Could not find software.amazon.smithy:smithy-typescript-codegen:0.1.0.
     Searched in the following locations:
```

*Description of changes:*
Updating to the version [here](https://github.com/awslabs/smithy-typescript/blob/main/build.gradle.kts#L28) seems to have fixed it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
