### PR TITLE
Fix recursive structure validation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -211,12 +211,15 @@ final class StructureGenerator implements Runnable {
                 return;
             }
 
-            structuredMemberWriter.writeMemberValidators(writer);
-
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
             writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
                     objectParam, symbol.getName(),
                     () -> {
+                        // TODO: move this somewhere so it only gets run once.
+                        // Putting it at the top of the namespace can result in runtime errors when
+                        // you have mutually recursive structures because the validator of one will
+                        // be defined before the validator of the other exists at all.
+                        structuredMemberWriter.writeMemberValidators(writer);
                         structuredMemberWriter.writeValidate(writer, objectParam);
                     }
             );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -207,20 +207,19 @@ final class StructureGenerator implements Runnable {
                 }
             );
 
-            // TODO: re-enable this once we've solved recursive validation
-//            if (!includeValidation) {
-//                return;
-//            }
-//
-//            structuredMemberWriter.writeMemberValidators(writer);
-//
-//            writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
-//            writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
-//                    objectParam, symbol.getName(),
-//                    () -> {
-//                        structuredMemberWriter.writeValidate(writer, objectParam);
-//                    }
-//            );
+            if (!includeValidation) {
+                return;
+            }
+
+            structuredMemberWriter.writeMemberValidators(writer);
+
+            writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+            writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
+                    objectParam, symbol.getName(),
+                    () -> {
+                        structuredMemberWriter.writeValidate(writer, objectParam);
+                    }
+            );
         });
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -179,8 +179,7 @@ final class UnionGenerator implements Runnable {
             writeVisitorFunction();
             writeFilterSensitiveLog();
             if (includeValidation) {
-                // TODO: re-enable this once we've solved recursive validation
-                //writeValidate();
+                writeValidate();
             }
         });
     }

--- a/smithy-typescript-integ-tests/codegen/model/validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/model/validation.smithy
@@ -19,7 +19,16 @@ structure TestInput {
     enumList: ListOfEnums,
     enumMap: MapOfEnums,
     lengthTests: LengthTests,
-    nestedTests: NestedUnionOne
+    nestedTests: NestedUnionOne,
+    recursiveTests: RecursiveStructureOne,
+}
+
+structure RecursiveStructureOne {
+    member: RecursiveStructureTwo
+}
+
+structure RecursiveStructureTwo {
+    member: RecursiveStructureOne
 }
 
 structure LengthTests {


### PR DESCRIPTION
This builds on #334 so for now only look at the last commit. This is in draft mode because I don't have a solution just yet.

Basically the problem is that recursive structures fail to validate at runtime. You get an error like this:

```
 FAIL  src/nested.spec.ts
  ● Test suite failed to run

    TypeError: Cannot read property 'validate' of undefined

      274 |     member: new __CompositeStructureValidator<RecursiveStructureTwo>(
      275 |       new __NoOpValidator(),
    > 276 |       RecursiveStructureTwo.validate,
          |                             ^
      277 |     ),
      278 |   };
      279 |   export const validate = (obj: RecursiveStructureOne): __ValidationFailure[] => {

      at codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen/models/models_0.ts:276:29
      at Object.<anonymous> (codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen/models/models_0.ts:284:2)
      at Object.<anonymous> (codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen/models/index.ts:1:1)
```

The relevant generated TS code looks like:

```typescript
export interface RecursiveStructureOne {
  member?: RecursiveStructureTwo;
}

export namespace RecursiveStructureOne {
  /**
   * @internal
   */
  export const filterSensitiveLog = (obj: RecursiveStructureOne): any => ({
    ...obj,
  })
  const memberValidators = {
    member: new __CompositeStructureValidator<RecursiveStructureTwo>(
      new __NoOpValidator(),
      RecursiveStructureTwo.validate,
    ),
  };
  export const validate = (obj: RecursiveStructureOne): __ValidationFailure[] => {
    return [
      ...memberValidators.member.validate(obj.member, "member"),
    ];
  }
}

export interface RecursiveStructureTwo {
  member?: RecursiveStructureOne;
}

export namespace RecursiveStructureTwo {
  /**
   * @internal
   */
  export const filterSensitiveLog = (obj: RecursiveStructureTwo): any => ({
    ...obj,
  })
  const memberValidators = {
    member: new __CompositeStructureValidator<RecursiveStructureOne>(
      new __NoOpValidator(),
      RecursiveStructureOne.validate,
    ),
  };
  export const validate = (obj: RecursiveStructureTwo): __ValidationFailure[] => {
    return [
      ...memberValidators.member.validate(obj.member, "member"),
    ];
  }
}

```

It becomes more clear when you look at the javascript:

```javascript
var RecursiveStructureOne;
(function (RecursiveStructureOne) {
    /**
     * @internal
     */
    RecursiveStructureOne.filterSensitiveLog = (obj) => ({
        ...obj,
    });
    const memberValidators = {
        member: new server_common_1.CompositeStructureValidator(new server_common_1.NoOpValidator(), RecursiveStructureTwo.validate),
    };
    RecursiveStructureOne.validate = (obj) => {
        return [
            ...memberValidators.member.validate(obj.member, "member"),
        ];
    };
})(RecursiveStructureOne = exports.RecursiveStructureOne || (exports.RecursiveStructureOne = {}));
var RecursiveStructureTwo;
(function (RecursiveStructureTwo) {
    /**
     * @internal
     */
    RecursiveStructureTwo.filterSensitiveLog = (obj) => ({
        ...obj,
    });
    const memberValidators = {
        member: new server_common_1.CompositeStructureValidator(new server_common_1.NoOpValidator(), RecursiveStructureOne.validate),
    };
    RecursiveStructureTwo.validate = (obj) => {
        return [
            ...memberValidators.member.validate(obj.member, "member"),
        ];
    };
})(RecursiveStructureTwo = exports.RecursiveStructureTwo || (exports.RecursiveStructureTwo = {}));

```

A potential solution may be to define all the validators later so we can guarantee the namespaces have been defined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
