### PR TITLE
fix: Fix path for typesVersions in package.json

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -40,7 +40,7 @@
   },
   "typesVersions": {
     "<4.0": {
-      "types/*": ["types/ts3.4/*"]
+      "dist/types/*": ["dist/types/ts3.4/*"]
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/2372

*Description of changes:*
Fixes the path of the types for Typescript 3.x. It looks like they should actually be in `dist/types/ts3.4`, not `types/ts3.4`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.