### PR TITLE
Support additional plugin function parameters

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -248,7 +248,7 @@ final class CommandGenerator implements Runnable {
         // the service's middleware stack.
         for (RuntimeClientPlugin plugin : runtimePlugins) {
             plugin.getPluginFunction().ifPresent(symbol -> {
-                List<String> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
+                List<String> additionalParameters = plugin.getAdditionalPluginFunctionParameters();
                 String additionalParamsString = additionalParameters.isEmpty()
                     ? ""
                     : ", { " + String.join(", ", additionalParameters) + "}";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -248,7 +248,12 @@ final class CommandGenerator implements Runnable {
         // the service's middleware stack.
         for (RuntimeClientPlugin plugin : runtimePlugins) {
             plugin.getPluginFunction().ifPresent(symbol -> {
-                writer.write("this.middlewareStack.use($T(configuration));", symbol);
+                List<String> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
+                String additionalParamsString = additionalParameters.isEmpty()
+                    ? ""
+                    : ", { " + String.join(", ", additionalParameters) + "}";
+                writer.write("this.middlewareStack.use($T(configuration$L));",
+                        symbol, additionalParamsString);
             });
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -66,7 +66,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         servicePredicate = builder.servicePredicate;
 
         if (!additionalResolveFunctionParameters.isEmpty() && resolveFunction == null) {
-            throw new IllegalStateException("Additional parameters can only be set if a resolve function is set.");
+            if (pluginFunction == null) {
+                throw new IllegalStateException("Additional parameters can only be set if a resolve function is set.");
+            }
         }
 
         boolean allNull = (inputConfig == null) && (resolvedConfig == null) && (resolveFunction == null);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -51,6 +51,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final SymbolReference resolveFunction;
     private final List<String> additionalResolveFunctionParameters;
     private final SymbolReference pluginFunction;
+    private final List<String> additionalPluginFunctionParameters;
     private final SymbolReference destroyFunction;
     private final BiPredicate<Model, ServiceShape> servicePredicate;
     private final OperationPredicate operationPredicate;
@@ -61,14 +62,17 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         resolveFunction = builder.resolveFunction;
         additionalResolveFunctionParameters = ListUtils.copyOf(builder.additionalResolveFunctionParameters);
         pluginFunction = builder.pluginFunction;
+        additionalPluginFunctionParameters = ListUtils.copyOf(builder.additionalPluginFunctionParameters);
         destroyFunction = builder.destroyFunction;
         operationPredicate = builder.operationPredicate;
         servicePredicate = builder.servicePredicate;
 
         if (!additionalResolveFunctionParameters.isEmpty() && resolveFunction == null) {
-            if (pluginFunction == null) {
-                throw new IllegalStateException("Additional parameters can only be set if a resolve function is set.");
-            }
+            throw new IllegalStateException("Additional parameters can only be set if a resolve function is set.");
+        }
+
+        if (!additionalPluginFunctionParameters.isEmpty() && pluginFunction == null) {
+            throw new IllegalStateException("Additional parameters can only be set if a plugin function is set.");
         }
 
         boolean allNull = (inputConfig == null) && (resolvedConfig == null) && (resolveFunction == null);
@@ -205,6 +209,19 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     }
 
     /**
+     * Gets a list of additional parameters to be supplied to the
+     * plugin function. These parameters are to be supplied to plugin
+     * function as an options hash. The list is empty if
+     * there are no additional parameters.
+     *
+     * @return Returns the optionally present list of parameters.
+     * @see #getPluginFunction()
+     */
+    public List<String> getAdditionalPluginFunctionParameters() {
+        return additionalPluginFunctionParameters;
+    }
+
+    /**
      * Gets the optionally present symbol reference that points to the
      * function that is used to clean up any resources when a client is
      * destroyed.
@@ -285,6 +302,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                + ", resolveFunction=" + resolveFunction
                + ", additionalResolveFunctionParameters=" + additionalResolveFunctionParameters
                + ", pluginFunction=" + pluginFunction
+               + ", additionalPluginFunctionParameters=" + additionalPluginFunctionParameters
                + ", destroyFunction=" + destroyFunction
                + '}';
     }
@@ -303,6 +321,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                && Objects.equals(resolveFunction, that.resolveFunction)
                && Objects.equals(additionalResolveFunctionParameters, that.additionalResolveFunctionParameters)
                && Objects.equals(pluginFunction, that.pluginFunction)
+               && Objects.equals(additionalPluginFunctionParameters, that.additionalPluginFunctionParameters)
                && Objects.equals(destroyFunction, that.destroyFunction)
                && servicePredicate.equals(that.servicePredicate)
                && operationPredicate.equals(that.operationPredicate);
@@ -322,6 +341,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private SymbolReference resolveFunction;
         private List<String> additionalResolveFunctionParameters = new ArrayList<>();
         private SymbolReference pluginFunction;
+        private List<String> additionalPluginFunctionParameters = new ArrayList<>();
         private SymbolReference destroyFunction;
         private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
         private OperationPredicate operationPredicate = (model, service, operation) -> false;
@@ -484,6 +504,21 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         }
 
         /**
+         * Sets a function symbol reference used to configure clients and
+         * commands to use a specific middleware function.
+         *
+         * @param pluginFunction Plugin function symbol to invoke.
+         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @return Returns the builder.
+         * @see #getPluginFunction()
+         */
+        public Builder pluginFunction(SymbolReference pluginFunction, String... additionalParameters) {
+            this.pluginFunction = pluginFunction;
+            this.additionalPluginFunctionParameters = ListUtils.of(additionalParameters);
+            return this;
+        }
+
+        /**
          * Sets a function symbol used to configure clients and commands to
          * use a specific middleware function.
          *
@@ -493,6 +528,32 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          */
         public Builder pluginFunction(Symbol pluginFunction) {
             return pluginFunction(SymbolReference.builder().symbol(pluginFunction).build());
+        }
+
+        /**
+         * Sets a function symbol used to configure clients and commands to
+         * use a specific middleware function.
+         *
+         * @param pluginFunction Plugin function symbol to invoke.
+         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @return Returns the builder.
+         * @see #getPluginFunction()
+         */
+        public Builder pluginFunction(Symbol pluginFunction, String... additionalParameters) {
+            return pluginFunction(SymbolReference.builder().symbol(pluginFunction).build(), additionalParameters);
+        }
+
+        /**
+         * Set additional positional input parameters to plugin function. Set
+         * this with no arguments to remove the current parameters.
+         *
+         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @return Returns the builder.
+         * @see #getPluginFunction()
+         */
+        public Builder additionalPluginFunctionParameters(String... additionalParameters) {
+            this.additionalPluginFunctionParameters = ListUtils.of(additionalParameters);
+            return this;
         }
 
         /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -69,7 +69,8 @@ public class RuntimeClientPluginTest {
     public void configuresWithDefaultConventions() {
         RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
                 .withConventions("foo/baz", "1.0.0", "Foo")
-                .additionalResolveFunctionParameters("this")
+                .additionalResolveFunctionParameters("resolveFunctionParam")
+                .additionalPluginFunctionParameters("pluginFunctionParam")
                 .build();
 
         assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
@@ -81,10 +82,12 @@ public class RuntimeClientPluginTest {
         assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
 
-        assertThat(plugin.getAdditionalResolveFunctionParameters(), equalTo(ListUtils.of("this")));
+        assertThat(plugin.getAdditionalResolveFunctionParameters(), equalTo(ListUtils.of("resolveFunctionParam")));
 
         assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));
+
+        assertThat(plugin.getAdditionalPluginFunctionParameters(), equalTo(ListUtils.of("pluginFunctionParam")));
 
         assertThat(plugin.getInputConfig().get().getSymbol().getDependencies().get(0).getPackageName(),
                    equalTo("foo/baz"));


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/2211
Similar to: https://github.com/awslabs/smithy-typescript/pull/302

*Description of changes:*
Currently the generated command calls additional runtime plugins, but
it only takes 1 parameter. To support endpoint discovery, we have to
pass more parameters which are specific to commands as follows:

```js
    this.middlewareStack.use(
      getEndpointDiscoveryOptionalPlugin(configuration, {
        clientStack,
        options,
      })
    );
```

In the above example, the clientStack and options passed to the plugin
are used for calling endpoint discovery command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
