### PR TITLE
Update java group name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 allprojects {
-    group = "software.amazon.smithy"
+    group = "software.amazon.smithy.typescript"
     version = "0.3.0"
 }
 

--- a/smithy-typescript-integ-tests/codegen/build.gradle
+++ b/smithy-typescript-integ-tests/codegen/build.gradle
@@ -21,8 +21,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'software.amazon.smithy:smithy-typescript-codegen:0.3.0'
-        classpath 'software.amazon.smithy:smithy-aws-typescript-codegen:0.3.0'
+        classpath 'software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0'
+        classpath 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.3.0'
         classpath "software.amazon.smithy:smithy-model:1.7.2"
     }
 }


### PR DESCRIPTION
This updates the java group name to `software.amazon.smithy.typescript` so that publishing can be isolated from base smithy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
