### PR TITLE
Add yarn to base package.json dev deps

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -33,7 +33,8 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.2.4",
+    "yarn": "1.22.10"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
This adds yarn to the base dev dependencies so that the generated packages can run properly without having to pre-install yarn.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
