### PR TITLE
Don't recreate validators every time

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -211,6 +211,8 @@ final class StructureGenerator implements Runnable {
                 return;
             }
 
+            structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
+
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
             writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
                     objectParam, symbol.getName(),
@@ -219,7 +221,7 @@ final class StructureGenerator implements Runnable {
                         // Putting it at the top of the namespace can result in runtime errors when
                         // you have mutually recursive structures because the validator of one will
                         // be defined before the validator of the other exists at all.
-                        structuredMemberWriter.writeMemberValidators(writer);
+                        structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");
                         structuredMemberWriter.writeValidate(writer, objectParam);
                     }
             );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -267,12 +267,13 @@ final class UnionGenerator implements Runnable {
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
                 model, symbolProvider, shape.getAllMembers().values());
 
-        structuredMemberWriter.writeMemberValidators(writer);
+        structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
         writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
                 "obj", symbol.getName(),
                 () -> {
+                    structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");
                     structuredMemberWriter.writeValidate(writer, "obj");
                 }
         );


### PR DESCRIPTION
This is a kinda-ugly middle ground, where we don't have the clean code
of instantiating a validator every time we need it, and we don't have the ideal
performance of instantiating them when the namespace is defined.

*Description of changes:*

Here's what the recursive validators look like now:

```typescript
export interface RecursiveStructureOne {
  member?: RecursiveStructureTwo;
}

export namespace RecursiveStructureOne {
  /**
   * @internal
   */
  export const filterSensitiveLog = (obj: RecursiveStructureOne): any => ({
    ...obj,
  })
  const memberValidators : {
    member?: __CompositeStructureValidator<RecursiveStructureTwo>,
  } = {};
  export const validate = (obj: RecursiveStructureOne): __ValidationFailure[] => {
    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
      if (memberValidators[member] === undefined) {
        switch (member) {
          case "member": {
            memberValidators["member"] = new __CompositeStructureValidator<RecursiveStructureTwo>(
              new __NoOpValidator(),
              RecursiveStructureTwo.validate
            );
            break;
          }
        }
      }
      return memberValidators[member]!!;
    }
    return [
      ...getMemberValidator("member").validate(obj.member, "member"),
    ];
  }
}

export interface RecursiveStructureTwo {
  member?: RecursiveStructureOne;
}

export namespace RecursiveStructureTwo {
  /**
   * @internal
   */
  export const filterSensitiveLog = (obj: RecursiveStructureTwo): any => ({
    ...obj,
  })
  const memberValidators : {
    member?: __CompositeStructureValidator<RecursiveStructureOne>,
  } = {};
  export const validate = (obj: RecursiveStructureTwo): __ValidationFailure[] => {
    function getMemberValidator<T extends keyof typeof memberValidators>(member: T): NonNullable<typeof memberValidators[T]> {
      if (memberValidators[member] === undefined) {
        switch (member) {
          case "member": {
            memberValidators["member"] = new __CompositeStructureValidator<RecursiveStructureOne>(
              new __NoOpValidator(),
              RecursiveStructureOne.validate
            );
            break;
          }
        }
      }
      return memberValidators[member]!!;
    }
    return [
      ...getMemberValidator("member").validate(obj.member, "member"),
    ];
  }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
