### PR TITLE
Input validation in SSDKs

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -98,10 +98,21 @@ final class ServerCommandGenerator implements Runnable {
             } else {
                 writeStreamingMemberType(writer, symbolProvider.toSymbol(input), typeName, blobStreamingMembers.get(0));
             }
+            renderNamespace(typeName, input);
         } else {
             // If the input is non-existent, then use an empty object.
             writer.write("export interface $L {}", typeName);
         }
+    }
+
+    private void renderNamespace(String typeName, StructureShape input) {
+        Symbol symbol = symbolProvider.toSymbol(input);
+        writer.openBlock("export namespace $L {", "}", typeName, () -> {
+            writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+            writer.writeDocs("@internal");
+            writer.write("export const validate: (obj: $L) => __ValidationFailure[] = $T.validate;",
+                    symbol.getName(), symbol);
+        });
     }
 
     private void writeOutputType(String typeName, Optional<StructureShape> outputShape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import static software.amazon.smithy.typescript.codegen.TypeScriptDependency.SERVER_COMMON;
+
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider;
 import software.amazon.smithy.codegen.core.ReservedWords;
@@ -97,7 +99,7 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
         String moduleName = moduleNameDelegator.formatModuleName(shape, serviceName);
 
         Symbol intermediate = createGeneratedSymbolBuilder(shape, serviceName, moduleName).build();
-        Symbol.Builder builder = intermediate.toBuilder();
+        Symbol.Builder builder = intermediate.toBuilder().addDependency(SERVER_COMMON);
         builder.putProperty("operations",
                 intermediate.toBuilder().name(serviceName + "Operations").build());
         builder.putProperty("handler",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -214,7 +214,8 @@ final class StructureGenerator implements Runnable {
             structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
-            writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
+            writer.writeDocs("@internal");
+            writer.openBlock("export const validate = ($L: $L, path: string = \"\"): __ValidationFailure[] => {", "}",
                     objectParam, symbol.getName(),
                     () -> {
                         // TODO: move this somewhere so it only gets run once.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -464,7 +464,7 @@ final class StructuredMemberWriter {
     void writeValidate(TypeScriptWriter writer, String param) {
         writer.openBlock("return [", "];", () -> {
             for (MemberShape member : members) {
-                writer.write("...getMemberValidator($1S).validate($2L.$1L, $3S),",
+                writer.write("...getMemberValidator($1S).validate($2L.$1L, `$${path}/$3L`),",
                         getSanitizedMemberName(member), param, member.getMemberName());
             }
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -78,7 +78,10 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     // Conditionally added when XML parser needs to be used.
     XML_PARSER("dependencies", "fast-xml-parser", "3.19.0", false),
-    HTML_ENTITIES("dependencies", "entities", "2.2.0", false);
+    HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
+
+    // Server dependency for SSDKs
+    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "^1.0.0-alpha.0", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,52 +30,52 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
-    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", "3.15.0", true),
-    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", "3.15.0", true),
-    AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", "3.15.0", true),
-    INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", "3.15.0", true),
-    CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", "3.15.0", true),
+    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/client-documentation-generator", SdkVersion.LIVE, true),
+    AWS_SDK_TYPES("dependencies", "@aws-sdk/types", SdkVersion.LIVE, true),
+    AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", SdkVersion.LIVE, true),
+    INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", SdkVersion.LIVE, true),
+    CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", SdkVersion.LIVE, true),
     TYPES_NODE("devDependencies", "@types/node", "^12.7.5", true),
 
-    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", "3.15.0", true),
-    MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", "3.15.0", true),
-    MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", "3.15.0", true),
-    MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", "3.15.0", true),
+    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", SdkVersion.LIVE, true),
+    MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", SdkVersion.LIVE, true),
+    MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", SdkVersion.LIVE, true),
+    MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", SdkVersion.LIVE, true),
 
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "^1.1.0", true),
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "^1.1.0", true),
-    AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", "3.15.0", true),
+    AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", SdkVersion.LIVE, true),
 
-    AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", "3.15.0", true),
+    AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", SdkVersion.LIVE, true),
 
-    AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", "3.13.1", true),
-    AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", "3.13.1", true),
+    AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", SdkVersion.LIVE, true),
+    AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", SdkVersion.LIVE, true),
 
-    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", "3.13.1", true),
-    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", "3.13.1", true),
+    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", SdkVersion.LIVE, true),
+    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", SdkVersion.LIVE, true),
 
-    AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", "3.13.1", true),
-    AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", "3.13.1", true),
+    AWS_SDK_UTIL_UTF8_BROWSER("dependencies", "@aws-sdk/util-utf8-browser", SdkVersion.LIVE, true),
+    AWS_SDK_UTIL_UTF8_NODE("dependencies", "@aws-sdk/util-utf8-node", SdkVersion.LIVE, true),
 
-    AWS_SDK_UTIL_WAITERS("dependencies", "@aws-sdk/util-waiter",  "3.15.0", false),
+    AWS_SDK_UTIL_WAITERS("dependencies", "@aws-sdk/util-waiter",  SdkVersion.LIVE, false),
 
     // Conditionally added when using an HTTP application protocol.
-    AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", "3.15.0", false),
-    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", "3.15.0", false),
-    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", "3.15.0", false),
+    AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", SdkVersion.LIVE, false),
+    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", SdkVersion.LIVE, false),
+    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", SdkVersion.LIVE, false),
 
     // Conditionally added if a event stream shape is found anywhere in the model
     AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
-            "3.15.0", false),
-    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", "3.15.0", false),
-    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", "3.15.0", false),
+            SdkVersion.LIVE, false),
+    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", SdkVersion.LIVE, false),
+    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", SdkVersion.LIVE, false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^5.2.2", false),
     TYPES_BIG_JS("devDependencies", "@types/big.js", "^4.0.5", false),
 
     // Conditionally added when interacting with specific protocol test bodyMediaType values.
-    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", "3.15.0", false),
+    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", SdkVersion.LIVE, false),
 
     // Conditionally added when XML parser needs to be used.
     XML_PARSER("dependencies", "fast-xml-parser", "3.19.0", false),
@@ -147,5 +148,14 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
                 .name(name)
                 .addDependency(dependency)
                 .build();
+    }
+
+    /**
+     * Holds package-wide constants, such as the current version of the AWS SDK for JS v3.
+     */
+    private static final class SdkVersion {
+        static final String LIVE = "3.18.0";
+
+        private SdkVersion() {}
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -270,7 +270,8 @@ final class UnionGenerator implements Runnable {
         structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
-        writer.openBlock("export const validate = ($L: $L): __ValidationFailure[] => {", "}",
+        writer.writeDocs("@internal");
+        writer.openBlock("export const validate = ($L: $L, path: string = \"\"): __ValidationFailure[] => {", "}",
                 "obj", symbol.getName(),
                 () -> {
                     structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");

--- a/smithy-typescript-integ-tests/.eslintrc.js
+++ b/smithy-typescript-integ-tests/.eslintrc.js
@@ -1,0 +1,30 @@
+module.exports = {
+  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parserOptions: {
+    ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+    sourceType: "module", // Allows for the use of imports
+  },
+  extends: [
+    // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    "plugin:@typescript-eslint/recommended",
+  ],
+  plugins: ["@typescript-eslint", "simple-import-sort"],
+  rules: {
+    /** Turn off strict enforcement */
+    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "prefer-rest-params": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+
+    /** Warnings */
+    "@typescript-eslint/no-namespace": "warn",
+
+    /** Errors */
+    "simple-import-sort/imports": "error",
+  },
+};

--- a/smithy-typescript-integ-tests/codegen/build.gradle
+++ b/smithy-typescript-integ-tests/codegen/build.gradle
@@ -23,7 +23,8 @@ buildscript {
     dependencies {
         classpath 'software.amazon.smithy.typescript:smithy-typescript-codegen:0.3.0'
         classpath 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.3.0'
-        classpath "software.amazon.smithy:smithy-model:1.7.2"
+        classpath "software.amazon.smithy:smithy-model:1.8.0"
+        classpath "software.amazon.smithy:smithy-validation-model:1.8.0"
     }
 }
 
@@ -32,7 +33,7 @@ plugins {
 }
 
 dependencies {
-    implementation "software.amazon.smithy:smithy-aws-traits:1.7.2"
+    implementation "software.amazon.smithy:smithy-aws-traits:1.8.0"
 }
 
 repositories {

--- a/smithy-typescript-integ-tests/codegen/custom_validation/custom_validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/custom_validation/custom_validation.smithy
@@ -1,0 +1,38 @@
+namespace software.amazon.smithy.typescript.integ
+
+use aws.protocols#restJson1
+
+@restJson1
+service CustomValidation {
+    version: "2020-01-25",
+    operations: [Test]
+}
+
+@readonly
+@http(method: "POST", uri:"/test")
+operation Test {
+    input: TestInput,
+    errors: [CustomValidationError]
+}
+
+structure TestInput {
+    enumList: ListOfEnums
+}
+
+@enum([{"value" : "valueA"}, {"value": "valueB"}])
+string Enum
+
+@length(max: 2)
+list ListOfEnums {
+    member: Enum
+}
+
+@error("client")
+structure CustomValidationError {
+    failingPaths: StringList,
+    totalFailures: Integer
+}
+
+list StringList {
+    member: String
+}

--- a/smithy-typescript-integ-tests/codegen/smithy-build.json
+++ b/smithy-typescript-integ-tests/codegen/smithy-build.json
@@ -2,11 +2,22 @@
   "version": "1.0",
   "outputDirectory": "build/output",
   "projections": {
-    "ts-server": {
+    "validation": {
+      "imports": ["validation"],
       "plugins": {
         "typescript-ssdk-codegen": {
           "package": "@aws-smithy/typescript-integ-test-types",
           "packageVersion": "1.0.0"
+        }
+      }
+    },
+    "customValidation": {
+      "imports": ["custom_validation"],
+      "plugins": {
+        "typescript-ssdk-codegen": {
+          "package": "@aws-smithy/typescript-integ-test-custom-validation",
+          "packageVersion": "1.0.0",
+          "disableDefaultValidation": true
         }
       }
     }

--- a/smithy-typescript-integ-tests/codegen/validation/validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/validation/validation.smithy
@@ -11,7 +11,8 @@ service ValidationService {
 @readonly
 @http(method: "POST", uri:"/test")
 operation Test {
-    input: TestInput
+    input: TestInput,
+    errors: [ smithy.framework#ValidationException ]
 }
 
 structure TestInput {

--- a/smithy-typescript-integ-tests/package.json
+++ b/smithy-typescript-integ-tests/package.json
@@ -6,12 +6,19 @@
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "clean": "yarn clear-build-cache && yarn clear-build-info",
+    "clear-build-cache": "rimraf ./*/dist ./*/types, ./*/*.tgz",
+    "clear-build-info": "rimraf **/*.tsbuildinfo",
     "prepublishOnly": "yarn build",
-    "pretest": "yarn generate && yarn build:generated && yarn build",
-    "generate": "cd codegen && gradle build",
-    "build:generated": "cd codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "pretest": "yarn build",
+    "generate": "cd codegen && gradle clean build",
+    "build:validation": "cd codegen/build/smithyprojections/codegen/validation/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "build:customValidation": "cd codegen/build/smithyprojections/codegen/customValidation/typescript-ssdk-codegen && yarn install && yarn link @aws-smithy/server-common && yarn build",
+    "build:generated": "yarn build:validation && yarn build:customValidation",
     "build": "tsc -p tsconfig.json",
-    "test": "jest"
+    "test": "jest",
+    "lint": "yarn run eslint **/src/**/*.ts",
+    "format": "prettier --write **/*.{ts,js,json}"
   },
   "repository": {
     "type": "git",
@@ -27,7 +34,16 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.5.2",
     "typescript": "^4.2.2",
-    "@aws-smithy/typescript-integ-test-types": "1.0.0"
+    "@aws-smithy/typescript-integ-test-types": "1.0.0",
+    "@aws-smithy/typescript-integ-test-custom-validation": "1.0.0",
+    "prettier": "2.2.1",
+    "eslint": "7.14.0",
+    "eslint-config-prettier": "6.15.0",
+    "eslint-plugin-prettier": "3.1.4",
+    "eslint-plugin-simple-import-sort": "6.0.1",
+    "@typescript-eslint/eslint-plugin": "4.22.1",
+    "@typescript-eslint/parser": "4.22.1",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": ">= 14.0.0"
@@ -37,6 +53,7 @@
   },
   "homepage": "https://github.com/awslabs/smithy-typescript#readme",
   "workspaces": [
-    "codegen/build/smithyprojections/codegen/ts-server/typescript-ssdk-codegen"
+    "codegen/build/smithyprojections/codegen/validation/typescript-ssdk-codegen",
+    "codegen/build/smithyprojections/codegen/customValidation/typescript-ssdk-codegen"
   ]
 }

--- a/smithy-typescript-integ-tests/prettier.config.js
+++ b/smithy-typescript-integ-tests/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // Custom
+  printWidth: 120,
+};

--- a/smithy-typescript-integ-tests/src/custom_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/custom_validation.spec.ts
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { ValidationContext, ValidationFailure } from "@aws-smithy/server-common";
+import {
+  CustomValidationError,
+  CustomValidationErrorError,
+  getTestHandler,
+} from "@aws-smithy/typescript-integ-test-custom-validation";
+import { Readable } from "stream";
+
+const testHandler = getTestHandler(
+  async () => {
+    return { $metadata: {} };
+  },
+  (context: ValidationContext<"Test">, failures: ValidationFailure[]): CustomValidationError | undefined => {
+    if (!failures) {
+      return undefined;
+    }
+    return new CustomValidationErrorError({
+      failingPaths: Array.from(new Set(failures.map((f) => f.path))),
+      totalFailures: failures.length,
+    });
+  }
+);
+
+describe("custom validation", () => {
+  it("does not fail valid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(200);
+      });
+  });
+  it("fails invalid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enumList": ["BANG!", "POW!", "valueA"]}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(400);
+        expect(result.headers["x-amzn-errortype"]).toEqual("CustomValidationError");
+        const parsedBody = JSON.parse(result.body);
+        expect(parsedBody.failingPaths).toEqual(["/enumList", "/enumList/0", "/enumList/1"]);
+        expect(parsedBody.totalFailures).toEqual(3);
+      });
+  });
+});

--- a/smithy-typescript-integ-tests/src/default_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/default_validation.spec.ts
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { getTestHandler } from "@aws-smithy/typescript-integ-test-types";
+import { Readable } from "stream";
+
+const testHandler = getTestHandler(async () => {
+  return { $metadata: {} };
+});
+
+describe("automatic validation", () => {
+  it("does not fail valid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(200);
+      });
+  });
+  it("fails invalid requests", () => {
+    return testHandler
+      .handle(
+        new HttpRequest({
+          method: "POST",
+          path: "/test",
+          body: Readable.from(Buffer.from('{"enum": "BANG!"}', "utf8")),
+        })
+      )
+      .then((result) => {
+        expect(result.statusCode).toEqual(400);
+        expect(result.headers["x-amzn-errortype"]).toEqual("ValidationException");
+        const parsedBody = JSON.parse(result.body);
+        expect(parsedBody.message).toContain("1 validation error detected");
+        expect(parsedBody.fieldList).toHaveLength(1);
+        expect(parsedBody.fieldList[0].path).toEqual("/enum");
+        expect(parsedBody.fieldList[0].message).toEqual(
+          "Value BANG! at '/enum' failed to satisfy constraint: Member must satisfy enum value set: valueA,valueB"
+        );
+      });
+  });
+});

--- a/smithy-typescript-integ-tests/src/enum.spec.ts
+++ b/smithy-typescript-integ-tests/src/enum.spec.ts
@@ -13,11 +13,11 @@
  *  permissions and limitations under the License.
  */
 
-import { TestInput, Enum } from "@aws-smithy/typescript-integ-test-types";
+import { Enum, TestInput } from "@aws-smithy/typescript-integ-test-types";
 
 describe("enum constraints", () => {
   const validEnum: Enum = "valueA";
-  const invalidEnum: string = "invalidEnum";
+  const invalidEnum = "invalidEnum";
   const expectedFailureBase = {
     constraintType: "enum",
     constraintValues: ["valueA", "valueB"],
@@ -27,7 +27,7 @@ describe("enum constraints", () => {
     expect(TestInput.validate({ enum: validEnum })).toEqual([]);
     expect(TestInput.validate({ enum: invalidEnum })).toEqual([
       {
-        memberName: "enum",
+        path: "/enum",
         ...expectedFailureBase,
       },
     ]);
@@ -36,13 +36,13 @@ describe("enum constraints", () => {
     expect(TestInput.validate({ enumList: [validEnum] })).toEqual([]);
     expect(TestInput.validate({ enumList: [invalidEnum] })).toEqual([
       {
-        memberName: "enumList",
+        path: "/enumList/0",
         ...expectedFailureBase,
       },
     ]);
     expect(TestInput.validate({ enumList: [validEnum, invalidEnum] })).toEqual([
       {
-        memberName: "enumList",
+        path: "/enumList/1",
         ...expectedFailureBase,
       },
     ]);
@@ -51,7 +51,7 @@ describe("enum constraints", () => {
     expect(TestInput.validate({ enumMap: { valid: validEnum } })).toEqual([]);
     expect(TestInput.validate({ enumMap: { invalid: invalidEnum } })).toEqual([
       {
-        memberName: "enumMap",
+        path: "/enumMap/invalid",
         ...expectedFailureBase,
       },
     ]);
@@ -61,7 +61,7 @@ describe("enum constraints", () => {
       })
     ).toEqual([
       {
-        memberName: "enumMap",
+        path: "/enumMap/invalid",
         ...expectedFailureBase,
       },
     ]);

--- a/smithy-typescript-integ-tests/src/length.spec.ts
+++ b/smithy-typescript-integ-tests/src/length.spec.ts
@@ -17,14 +17,12 @@ import { LengthTests } from "@aws-smithy/typescript-integ-test-types";
 
 describe("length constraints", () => {
   it("work for strings", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthString: "much longer than 7" })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthString: "much longer than 7" })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
         failureValue: 18,
-        memberName: "minMaxLengthString",
+        path: "/minMaxLengthString",
       },
     ]);
     expect(LengthTests.validate({ minMaxLengthString: "a" })).toEqual([
@@ -32,7 +30,7 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 7],
         failureValue: 1,
-        memberName: "minMaxLengthString",
+        path: "/minMaxLengthString",
       },
     ]);
   });
@@ -42,7 +40,7 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 1,
-        memberName: "minMaxLengthMap",
+        path: "/minMaxLengthMap",
       },
     ]);
     expect(
@@ -54,19 +52,17 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 5,
-        memberName: "minMaxLengthMap",
+        path: "/minMaxLengthMap",
       },
     ]);
   });
   it("also work on map keys", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthMap: { a: 1, bcd: 2, cde: 3 } })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthMap: { a: 1, bcd: 2, cde: 3 } })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
         failureValue: 1,
-        memberName: "minMaxLengthMap",
+        path: "/minMaxLengthMap",
       },
     ]);
     expect(
@@ -78,7 +74,7 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 7],
         failureValue: 11,
-        memberName: "minMaxLengthMap",
+        path: "/minMaxLengthMap",
       },
     ]);
   });
@@ -88,7 +84,7 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 1,
-        memberName: "minMaxLengthList",
+        path: "/minMaxLengthList",
       },
     ]);
     expect(
@@ -100,19 +96,17 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 5,
-        memberName: "minMaxLengthList",
+        path: "/minMaxLengthList",
       },
     ]);
   });
   it("also work on list values", () => {
-    expect(
-      LengthTests.validate({ minMaxLengthList: ["abcdefghijk", "def"] })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthList: ["abcdefghijk", "def"] })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 7],
         failureValue: 11,
-        memberName: "minMaxLengthList",
+        path: "/minMaxLengthList/0",
       },
     ]);
   });
@@ -122,17 +116,15 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 1,
-        memberName: "minMaxLengthBlob",
+        path: "/minMaxLengthBlob",
       },
     ]);
-    expect(
-      LengthTests.validate({ minMaxLengthBlob: Buffer.of(1, 2, 3, 4, 5) })
-    ).toEqual([
+    expect(LengthTests.validate({ minMaxLengthBlob: Buffer.of(1, 2, 3, 4, 5) })).toEqual([
       {
         constraintType: "length",
         constraintValues: [2, 4],
         failureValue: 5,
-        memberName: "minMaxLengthBlob",
+        path: "/minMaxLengthBlob",
       },
     ]);
   });
@@ -142,7 +134,7 @@ describe("length constraints", () => {
         constraintType: "length",
         constraintValues: [13, 27],
         failureValue: 6,
-        memberName: "minMaxLengthOverride",
+        path: "/minMaxLengthOverride",
       },
     ]);
   });

--- a/smithy-typescript-integ-tests/src/nested.spec.ts
+++ b/smithy-typescript-integ-tests/src/nested.spec.ts
@@ -23,4 +23,18 @@ describe("ridiculously nested structures", () => {
       })
     ).toEqual([]);
   });
+  it("will also fail", () => {
+    expect(
+      NestedUnionOne.validate({
+        value1: { value2: [{ unions: [{ value3: "a" }] }] },
+      })
+    ).toEqual([
+      {
+        constraintType: "length",
+        constraintValues: [2, 7],
+        failureValue: 1,
+        path: "/value1/value2/0/unions/0/value3",
+      },
+    ]);
+  });
 });

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -8,7 +8,7 @@
     "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "build": "tsc -p tsconfig.json",
-    "postbuild": "downlevel-dts dist/types dist/types/ts3.4",
+    "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },
   "repository": {
@@ -30,7 +30,8 @@
     "downlevel-dts": "^0.7.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.2.2",
+    "rimraf": "^3.0.2"
   },
   "files": [
     "dist/cjs/**/*.js",

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -26,7 +26,7 @@ describe("enum validation", () => {
     expect(enumValidator.validate("kiwi", "fruit")).toEqual({
       constraintType: "enum",
       constraintValues: ["apple", "banana", "orange"],
-      memberName: "fruit",
+      path: "fruit",
       failureValue: "kiwi",
     });
   });
@@ -59,7 +59,7 @@ describe("length validation", () => {
         expect(new LengthValidator(4).validate(value, "aThreeLengthThing")).toEqual({
           constraintType: "length",
           constraintValues: [4, undefined],
-          memberName: "aThreeLengthThing",
+          path: "aThreeLengthThing",
           failureValue: 3,
         });
       });
@@ -67,7 +67,7 @@ describe("length validation", () => {
         expect(new LengthValidator(undefined, 2).validate(value, "aThreeLengthThing")).toEqual({
           constraintType: "length",
           constraintValues: [undefined, 2],
-          memberName: "aThreeLengthThing",
+          path: "aThreeLengthThing",
           failureValue: 3,
         });
       });
@@ -75,7 +75,7 @@ describe("length validation", () => {
         expect(new LengthValidator(1, 2).validate(value, "aThreeLengthThing")).toEqual({
           constraintType: "length",
           constraintValues: [1, 2],
-          memberName: "aThreeLengthThing",
+          path: "aThreeLengthThing",
           failureValue: 3,
         });
       });
@@ -96,7 +96,7 @@ describe("pattern validation", () => {
       constraintType: "pattern",
       constraintValues: "^\\w+$",
       failureValue: "!hello!",
-      memberName: "aField",
+      path: "aField",
     });
   });
   it("supports character class expressions", () => {
@@ -106,7 +106,7 @@ describe("pattern validation", () => {
       constraintType: "pattern",
       constraintValues: "^\\p{L}+$",
       failureValue: "!hello!",
-      memberName: "aField",
+      path: "aField",
     });
   });
 });
@@ -120,7 +120,7 @@ describe("range validation", () => {
       constraintType: "range",
       constraintValues: [3, undefined],
       failureValue: 1,
-      memberName: "aField",
+      path: "aField",
     });
   });
   it("supports max-only constraints", () => {
@@ -131,7 +131,7 @@ describe("range validation", () => {
       constraintType: "range",
       constraintValues: [undefined, 3],
       failureValue: 4,
-      memberName: "aField",
+      path: "aField",
     });
   });
   it("supports min-max constraints", () => {
@@ -143,13 +143,13 @@ describe("range validation", () => {
       constraintType: "range",
       constraintValues: [3, 5],
       failureValue: 1,
-      memberName: "aField",
+      path: "aField",
     });
     expect(validator.validate(6, "aField")).toEqual({
       constraintType: "range",
       constraintValues: [3, 5],
       failureValue: 6,
-      memberName: "aField",
+      path: "aField",
     });
   });
 });
@@ -161,7 +161,7 @@ describe("uniqueItems", () => {
     expect(validator.validate(["a", "a", "c", "a", "b", "b"], "aField")).toEqual({
       constraintType: "uniqueItems",
       failureValue: ["a", "b"],
-      memberName: "aField",
+      path: "aField",
     });
   });
   describe("supports numbers", () => {
@@ -169,7 +169,7 @@ describe("uniqueItems", () => {
     expect(validator.validate([1, 1, 3, 1, 1, 2.5, 2.5], "aField")).toEqual({
       constraintType: "uniqueItems",
       failureValue: [1, 2.5],
-      memberName: "aField",
+      path: "aField",
     });
   });
   describe("supports booleans, I guess", () => {
@@ -177,7 +177,7 @@ describe("uniqueItems", () => {
     expect(validator.validate([true, false, true], "aField")).toEqual({
       constraintType: "uniqueItems",
       failureValue: [true],
-      memberName: "aField",
+      path: "aField",
     });
   });
 });


### PR DESCRIPTION
This adds input validation to the SSDKs, meaning that constraints specified in the model will be applied to inputs after deserialization.

Unlike some other frameworks of note, validation is opt-out, and not opt-in. The service developer, in order to ignore invalid input, will need to supply code that does so explicitly.

To use default validation, service authors must add `smithy.framework#ValidationException` to every operation. It will return these exceptions automatically when inputs fall outside of bounds.  An example output:

```json
{
    "fieldList": [
        {
            "message": "Value Canopy Club@ at '/name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[\\p{L}\\p{N}][\\p{L}\\p{N} ]+[\\p{L}\\p{N}]$",
            "path": "/name"
        },
        {
            "message": "Value -750 at '/capacity' failed to satisfy constraint: Member must be greater than or equal to 1",
            "path": "/capacity"
        }
    ],
    "message": "2 validation errors at 2 paths detected. First failure: Value Canopy Club@ at '/name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[\\p{L}\\p{N}][\\p{L}\\p{N} ]+[\\p{L}\\p{N}]$"
}
```



To use custom validation, service authors must set `disableDefaultValidation` to `true` in their `smithy-build.json` and then supply a `ValidationCustomizer` to their handler. Doing so looks like this:

```typescript
const testHandler = getTestHandler(
  async () => {
    return { $metadata: {} };
  },
  (context: ValidationContext<"Test">, failures: ValidationFailure[]): CustomValidationError | undefined => {
    if (!failures) {
      return undefined;
    }
    return new CustomValidationErrorError({
      failingMembers: Array.from(new Set(failures.map((f) => f.memberName))),
      totalFailures: failures.length,
    });
  }
);
```

The second argument is the ValidationCustomizer, which is a function type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
