### PR TITLE
Enable passing dynamic parameters to RuntimeClientPlugin functions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -17,7 +17,9 @@ package software.amazon.smithy.typescript.codegen;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.EventStreamIndex;
@@ -133,5 +135,39 @@ public final class CodegenUtils {
         writer.writeDocs(String.format("This interface extends from `%1$s` interface. There are more parameters than"
                 + " `%2$s` defined in {@link %1$s}", containerSymbol.getName(), memberName));
         writer.write("export interface $1L extends $1LType {}", typeName);
+    }
+
+    /**
+     * Returns the list of function parameter key-value pairs to be written for
+     * provided parameters map.
+     *
+     * @param paramsMap Map of paramters to generate a parameters string for.
+     * @return The list of parameters to be written.
+     */
+    static List<String> getFunctionParametersList(Map<String, Object> paramsMap) {
+        List<String> functionParametersList = new ArrayList<String>();
+
+        if (!paramsMap.isEmpty()) {
+            for (Map.Entry<String, Object> param : paramsMap.entrySet()) {
+                String key = param.getKey();
+                Object value = param.getValue();
+                if (value instanceof Symbol) {
+                    String symbolName = ((Symbol) value).getName();
+                    if (key.equals(symbolName)) {
+                        functionParametersList.add(key);
+                    } else {
+                        functionParametersList.add(String.format("%s: %s", key, symbolName));
+                    }
+                } else if (value instanceof String) {
+                    functionParametersList.add(String.format("%s: '%s'", key, value));
+                } else {
+                    // Future support for param type should be added in else if.
+                    throw new CodegenException("plugin function parameters not supported for type"
+                            + value.toString());
+                }
+            }
+        }
+
+        return functionParametersList;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -162,8 +162,8 @@ public final class CodegenUtils {
                     functionParametersList.add(String.format("%s: '%s'", key, value));
                 } else {
                     // Future support for param type should be added in else if.
-                    throw new CodegenException("plugin function parameters not supported for type"
-                            + value.toString());
+                    throw new CodegenException("Plugin function parameters not supported for type "
+                            + value.getClass());
                 }
             }
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -19,6 +19,7 @@ import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobStre
 import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeStreamingMemberType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -248,7 +249,9 @@ final class CommandGenerator implements Runnable {
         // the service's middleware stack.
         for (RuntimeClientPlugin plugin : runtimePlugins) {
             plugin.getPluginFunction().ifPresent(symbol -> {
-                List<String> additionalParameters = plugin.getAdditionalPluginFunctionParameters();
+                Map<String, Object> paramsMap = plugin.getPluginFunctionParameters(model, service, operation);
+                List<String> additionalParameters = CodegenUtils.getFunctionParametersList(paramsMap);
+
                 String additionalParamsString = additionalParameters.isEmpty()
                     ? ""
                     : ", { " + String.join(", ", additionalParameters) + "}";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -249,7 +249,8 @@ final class CommandGenerator implements Runnable {
         // the service's middleware stack.
         for (RuntimeClientPlugin plugin : runtimePlugins) {
             plugin.getPluginFunction().ifPresent(symbol -> {
-                Map<String, Object> paramsMap = plugin.getPluginFunctionParameters(model, service, operation);
+                Map<String, Object> paramsMap = plugin.getAdditionalPluginFunctionParameters(
+                        model, service, operation);
                 List<String> additionalParameters = CodegenUtils.getFunctionParametersList(paramsMap);
 
                 String additionalParamsString = additionalParameters.isEmpty()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -313,7 +314,9 @@ final class ServiceGenerator implements Runnable {
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 if (plugin.getResolveFunction().isPresent()) {
                     configVariable++;
-                    List<String> additionalParameters = plugin.getAdditionalResolveFunctionParameters();
+                    Map<String, Object> paramsMap = plugin.getResolveFunctionParameters(model, service, null);
+                    List<String> additionalParameters = CodegenUtils.getFunctionParametersList(paramsMap);
+
                     String additionalParamsString = additionalParameters.isEmpty()
                             ? ""
                             : ", " + String.join(", ", additionalParameters);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -314,7 +314,8 @@ final class ServiceGenerator implements Runnable {
             for (RuntimeClientPlugin plugin : runtimePlugins) {
                 if (plugin.getResolveFunction().isPresent()) {
                     configVariable++;
-                    Map<String, Object> paramsMap = plugin.getResolveFunctionParameters(model, service, null);
+                    Map<String, Object> paramsMap = plugin.getAdditionalResolveFunctionParameters(
+                            model, service, null);
                     List<String> additionalParameters = CodegenUtils.getFunctionParametersList(paramsMap);
 
                     String additionalParamsString = additionalParameters.isEmpty()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -15,8 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
-import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
@@ -49,9 +48,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final SymbolReference inputConfig;
     private final SymbolReference resolvedConfig;
     private final SymbolReference resolveFunction;
-    private final List<String> additionalResolveFunctionParameters;
+    private final FunctionParamsSupplier resolveFunctionParamsSupplier;
     private final SymbolReference pluginFunction;
-    private final List<String> additionalPluginFunctionParameters;
+    private final FunctionParamsSupplier pluginFunctionParamsSupplier;
     private final SymbolReference destroyFunction;
     private final BiPredicate<Model, ServiceShape> servicePredicate;
     private final OperationPredicate operationPredicate;
@@ -60,20 +59,12 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         inputConfig = builder.inputConfig;
         resolvedConfig = builder.resolvedConfig;
         resolveFunction = builder.resolveFunction;
-        additionalResolveFunctionParameters = ListUtils.copyOf(builder.additionalResolveFunctionParameters);
+        resolveFunctionParamsSupplier = builder.resolveFunctionParamsSupplier;
         pluginFunction = builder.pluginFunction;
-        additionalPluginFunctionParameters = ListUtils.copyOf(builder.additionalPluginFunctionParameters);
+        pluginFunctionParamsSupplier = builder.pluginFunctionParamsSupplier;
         destroyFunction = builder.destroyFunction;
         operationPredicate = builder.operationPredicate;
         servicePredicate = builder.servicePredicate;
-
-        if (!additionalResolveFunctionParameters.isEmpty() && resolveFunction == null) {
-            throw new IllegalStateException("Additional parameters can only be set if a resolve function is set.");
-        }
-
-        if (!additionalPluginFunctionParameters.isEmpty() && pluginFunction == null) {
-            throw new IllegalStateException("Additional parameters can only be set if a plugin function is set.");
-        }
 
         boolean allNull = (inputConfig == null) && (resolvedConfig == null) && (resolveFunction == null);
         boolean allSet = (inputConfig != null) && (resolvedConfig != null) && (resolveFunction != null);
@@ -100,6 +91,19 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * @return Returns true if middleware should be applied to the operation.
          */
         boolean test(Model model, ServiceShape service, OperationShape operation);
+    }
+
+    @FunctionalInterface
+    public interface FunctionParamsSupplier {
+        /**
+         * Returns dynamic parameters for resolve function.
+         *
+         * @param model Model the operation belongs to.
+         * @param service Service the operation belongs to.
+         * @param operation Operation to test.
+         * @return Returns true if middleware should be applied to the operation.
+         */
+        Map<String, Object> apply(Model model, ServiceShape service, OperationShape operation);
     }
 
     /**
@@ -163,7 +167,6 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      *
      * @return Returns the optionally present resolve function.
      * @see #getInputConfig()
-     * @see #getAdditionalResolveFunctionParameters()
      * @see #getResolvedConfig()
      */
     public Optional<SymbolReference> getResolveFunction() {
@@ -173,14 +176,23 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     /**
      * Gets a list of additional parameters to be supplied to the
      * resolve function. These parameters are to be supplied to resolve
-     * function as Nth(N &gt; 1) positional arguments. The list is empty if
-     * there are no additional parameters.
+     * function as second argument. The map is empty if there are
+     * no additional parameters.
      *
-     * @return Returns the optionally present list of parameters.
-     * @see #getResolveFunction()
+     * @param model Model the operation belongs to.
+     * @param service Service the operation belongs to.
+     * @param operation Operation to test against.
+     * @return Returns the optionally present map of parameters.
      */
-    public List<String> getAdditionalResolveFunctionParameters() {
-        return additionalResolveFunctionParameters;
+    public Map<String, Object> getResolveFunctionParameters(
+        Model model,
+        ServiceShape service,
+        OperationShape operation
+    ) {
+        if (resolveFunctionParamsSupplier != null) {
+            return resolveFunctionParamsSupplier.apply(model, service, operation);
+        }
+        return new HashMap<String, Object>();
     }
 
     /**
@@ -211,14 +223,23 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     /**
      * Gets a list of additional parameters to be supplied to the
      * plugin function. These parameters are to be supplied to plugin
-     * function as an options hash. The list is empty if
-     * there are no additional parameters.
+     * function as second argument. The map is empty if there are
+     * no additional parameters.
      *
-     * @return Returns the optionally present list of parameters.
-     * @see #getPluginFunction()
+     * @param model Model the operation belongs to.
+     * @param service Service the operation belongs to.
+     * @param operation Operation to test against.
+     * @return Returns the optionally present map of parameters.
      */
-    public List<String> getAdditionalPluginFunctionParameters() {
-        return additionalPluginFunctionParameters;
+    public Map<String, Object> getPluginFunctionParameters(
+        Model model,
+        ServiceShape service,
+        OperationShape operation
+    ) {
+        if (pluginFunctionParamsSupplier != null) {
+            return pluginFunctionParamsSupplier.apply(model, service, operation);
+        }
+        return new HashMap<String, Object>();
     }
 
     /**
@@ -284,7 +305,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                 .inputConfig(inputConfig)
                 .resolvedConfig(resolvedConfig)
                 .resolveFunction(resolveFunction)
+                .resolveFunctionParamsSupplier(resolveFunctionParamsSupplier)
                 .pluginFunction(pluginFunction)
+                .pluginFunctionParamsSupplier(pluginFunctionParamsSupplier)
                 .destroyFunction(destroyFunction);
 
         // Set these directly since their setters have mutual side-effects.
@@ -300,9 +323,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                + "inputConfig=" + inputConfig
                + ", resolvedConfig=" + resolvedConfig
                + ", resolveFunction=" + resolveFunction
-               + ", additionalResolveFunctionParameters=" + additionalResolveFunctionParameters
                + ", pluginFunction=" + pluginFunction
-               + ", additionalPluginFunctionParameters=" + additionalPluginFunctionParameters
                + ", destroyFunction=" + destroyFunction
                + '}';
     }
@@ -319,9 +340,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         return Objects.equals(inputConfig, that.inputConfig)
                && Objects.equals(resolvedConfig, that.resolvedConfig)
                && Objects.equals(resolveFunction, that.resolveFunction)
-               && Objects.equals(additionalResolveFunctionParameters, that.additionalResolveFunctionParameters)
+               && Objects.equals(resolveFunctionParamsSupplier, that.resolveFunctionParamsSupplier)
                && Objects.equals(pluginFunction, that.pluginFunction)
-               && Objects.equals(additionalPluginFunctionParameters, that.additionalPluginFunctionParameters)
+               && Objects.equals(pluginFunctionParamsSupplier, that.pluginFunctionParamsSupplier)
                && Objects.equals(destroyFunction, that.destroyFunction)
                && servicePredicate.equals(that.servicePredicate)
                && operationPredicate.equals(that.operationPredicate);
@@ -339,9 +360,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private SymbolReference inputConfig;
         private SymbolReference resolvedConfig;
         private SymbolReference resolveFunction;
-        private List<String> additionalResolveFunctionParameters = new ArrayList<>();
+        private FunctionParamsSupplier resolveFunctionParamsSupplier;
         private SymbolReference pluginFunction;
-        private List<String> additionalPluginFunctionParameters = new ArrayList<>();
+        private FunctionParamsSupplier pluginFunctionParamsSupplier;
         private SymbolReference destroyFunction;
         private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
         private OperationPredicate operationPredicate = (model, service, operation) -> false;
@@ -433,13 +454,16 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * {@link #inputConfig} must also be set.
          *
          * @param resolveFunction Function used to convert input to resolved.
-         * @param additionalParameters Additional parameters to be generated as resolve function input.
+         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
-        public Builder resolveFunction(SymbolReference resolveFunction, String... additionalParameters) {
+        public Builder resolveFunction(
+                SymbolReference resolveFunction,
+                FunctionParamsSupplier resolveFunctionParamsSupplier
+        ) {
             this.resolveFunction = resolveFunction;
-            this.additionalResolveFunctionParameters = ListUtils.of(additionalParameters);
+            this.resolveFunctionParamsSupplier = resolveFunctionParamsSupplier;
             return this;
         }
 
@@ -466,27 +490,33 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * {@link #inputConfig} must also be set.
          *
          * @param resolveFunction Function used to convert input to resolved.
-         * @param additionalParameters Additional parameters to be generated as resolve function input.
+         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
-        public Builder resolveFunction(Symbol resolveFunction, String... additionalParameters) {
-            return resolveFunction(SymbolReference.builder().symbol(resolveFunction).build(), additionalParameters);
+        public Builder resolveFunction(
+            Symbol resolveFunction,
+            FunctionParamsSupplier resolveFunctionParamsSupplier
+        ) {
+            return resolveFunction(
+                SymbolReference.builder().symbol(resolveFunction).build(),
+                resolveFunctionParamsSupplier
+            );
         }
 
         /**
-         * Set additional positional input parameters to resolve function. Set
-         * this with no arguments to remove the current parameters.
+         * Set function which returns input parameters to resolve function. Set
+         * function to return empty map to remove the current parameters.
          *
          * <p>If this is set, then all of {@link #resolveFunction},
          * {@link #resolvedConfig} and {@link #inputConfig} must also be set.
          *
-         * @param additionalParameters Additional parameters to be generated as resolve function input.
+         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
-        public Builder additionalResolveFunctionParameters(String... additionalParameters) {
-            this.additionalResolveFunctionParameters = ListUtils.of(additionalParameters);
+        public Builder resolveFunctionParamsSupplier(FunctionParamsSupplier resolveFunctionParamsSupplier) {
+            this.resolveFunctionParamsSupplier = resolveFunctionParamsSupplier;
             return this;
         }
 
@@ -508,13 +538,16 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * commands to use a specific middleware function.
          *
          * @param pluginFunction Plugin function symbol to invoke.
-         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @param pluginFunctionParamsSupplier Function which returns params to be passed as plugin function input.
          * @return Returns the builder.
          * @see #getPluginFunction()
          */
-        public Builder pluginFunction(SymbolReference pluginFunction, String... additionalParameters) {
+        public Builder pluginFunction(
+                SymbolReference pluginFunction,
+                FunctionParamsSupplier pluginFunctionParamsSupplier
+        ) {
             this.pluginFunction = pluginFunction;
-            this.additionalPluginFunctionParameters = ListUtils.of(additionalParameters);
+            this.pluginFunctionParamsSupplier = pluginFunctionParamsSupplier;
             return this;
         }
 
@@ -535,24 +568,30 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * use a specific middleware function.
          *
          * @param pluginFunction Plugin function symbol to invoke.
-         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @param pluginFunctionParamsSupplier Function which returns params to be passed as plugin function input.
          * @return Returns the builder.
          * @see #getPluginFunction()
          */
-        public Builder pluginFunction(Symbol pluginFunction, String... additionalParameters) {
-            return pluginFunction(SymbolReference.builder().symbol(pluginFunction).build(), additionalParameters);
+        public Builder pluginFunction(
+            Symbol pluginFunction,
+            FunctionParamsSupplier pluginFunctionParamsSupplier
+        ) {
+            return pluginFunction(
+                SymbolReference.builder().symbol(pluginFunction).build(),
+                pluginFunctionParamsSupplier
+            );
         }
 
         /**
-         * Set additional positional input parameters to plugin function. Set
-         * this with no arguments to remove the current parameters.
+         * Set function which returns input parameters to plugin function. Set
+         * function to return empty map to remove the current parameters.
          *
-         * @param additionalParameters Additional parameters to be generated as plugin function input.
+         * @param pluginFunctionParamsSupplier Function which returns params to be passed as plugin function input.
          * @return Returns the builder.
          * @see #getPluginFunction()
          */
-        public Builder additionalPluginFunctionParameters(String... additionalParameters) {
-            this.additionalPluginFunctionParameters = ListUtils.of(additionalParameters);
+        public Builder pluginFunctionParamsSupplier(FunctionParamsSupplier pluginFunctionParamsSupplier) {
+            this.pluginFunctionParamsSupplier = pluginFunctionParamsSupplier;
             return this;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -96,12 +96,12 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     @FunctionalInterface
     public interface FunctionParamsSupplier {
         /**
-         * Returns dynamic parameters for resolve function.
+         * Returns parameters to be passed to a function which can be computed dynamically.
          *
          * @param model Model the operation belongs to.
          * @param service Service the operation belongs to.
          * @param operation Operation to test.
-         * @return Returns true if middleware should be applied to the operation.
+         * @return Returns the map of parameters to be passed to a function.
          */
         Map<String, Object> apply(Model model, ServiceShape service, OperationShape operation);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -101,7 +101,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * @param model Model the operation belongs to.
          * @param service Service the operation belongs to.
          * @param operation Operation to test.
-         * @return Returns the map of parameters to be passed to a function.
+         * @return Returns the map of parameters to be passed to a function. The key is the key
+         * for a parameter, and value is the value for a parameter.
          */
         Map<String, Object> apply(Model model, ServiceShape service, OperationShape operation);
     }
@@ -182,7 +183,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      * @param model Model the operation belongs to.
      * @param service Service the operation belongs to.
      * @param operation Operation to test against.
-     * @return Returns the optionally present map of parameters.
+     * @return Returns the optionally present map of parameters. The key is the key
+     * for a parameter, and value is the value for a parameter.
      */
     public Map<String, Object> getResolveFunctionParameters(
         Model model,
@@ -229,7 +231,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      * @param model Model the operation belongs to.
      * @param service Service the operation belongs to.
      * @param operation Operation to test against.
-     * @return Returns the optionally present map of parameters.
+     * @return Returns the optionally present map of parameters. The key is the key
+     * for a parameter, and value is the value for a parameter.
      */
     public Map<String, Object> getPluginFunctionParameters(
         Model model,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -48,9 +48,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
     private final SymbolReference inputConfig;
     private final SymbolReference resolvedConfig;
     private final SymbolReference resolveFunction;
-    private final FunctionParamsSupplier resolveFunctionParamsSupplier;
+    private final FunctionParamsSupplier additionalResolveFunctionParamsSupplier;
     private final SymbolReference pluginFunction;
-    private final FunctionParamsSupplier pluginFunctionParamsSupplier;
+    private final FunctionParamsSupplier additionalPluginFunctionParamsSupplier;
     private final SymbolReference destroyFunction;
     private final BiPredicate<Model, ServiceShape> servicePredicate;
     private final OperationPredicate operationPredicate;
@@ -59,9 +59,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         inputConfig = builder.inputConfig;
         resolvedConfig = builder.resolvedConfig;
         resolveFunction = builder.resolveFunction;
-        resolveFunctionParamsSupplier = builder.resolveFunctionParamsSupplier;
+        additionalResolveFunctionParamsSupplier = builder.additionalResolveFunctionParamsSupplier;
         pluginFunction = builder.pluginFunction;
-        pluginFunctionParamsSupplier = builder.pluginFunctionParamsSupplier;
+        additionalPluginFunctionParamsSupplier = builder.additionalPluginFunctionParamsSupplier;
         destroyFunction = builder.destroyFunction;
         operationPredicate = builder.operationPredicate;
         servicePredicate = builder.servicePredicate;
@@ -191,8 +191,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         ServiceShape service,
         OperationShape operation
     ) {
-        if (resolveFunctionParamsSupplier != null) {
-            return resolveFunctionParamsSupplier.apply(model, service, operation);
+        if (additionalResolveFunctionParamsSupplier != null) {
+            return additionalResolveFunctionParamsSupplier.apply(model, service, operation);
         }
         return new HashMap<String, Object>();
     }
@@ -239,8 +239,8 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         ServiceShape service,
         OperationShape operation
     ) {
-        if (pluginFunctionParamsSupplier != null) {
-            return pluginFunctionParamsSupplier.apply(model, service, operation);
+        if (additionalPluginFunctionParamsSupplier != null) {
+            return additionalPluginFunctionParamsSupplier.apply(model, service, operation);
         }
         return new HashMap<String, Object>();
     }
@@ -308,9 +308,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                 .inputConfig(inputConfig)
                 .resolvedConfig(resolvedConfig)
                 .resolveFunction(resolveFunction)
-                .resolveFunctionParamsSupplier(resolveFunctionParamsSupplier)
+                .additionalResolveFunctionParamsSupplier(additionalResolveFunctionParamsSupplier)
                 .pluginFunction(pluginFunction)
-                .pluginFunctionParamsSupplier(pluginFunctionParamsSupplier)
+                .additionalPluginFunctionParamsSupplier(additionalPluginFunctionParamsSupplier)
                 .destroyFunction(destroyFunction);
 
         // Set these directly since their setters have mutual side-effects.
@@ -343,9 +343,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         return Objects.equals(inputConfig, that.inputConfig)
                && Objects.equals(resolvedConfig, that.resolvedConfig)
                && Objects.equals(resolveFunction, that.resolveFunction)
-               && Objects.equals(resolveFunctionParamsSupplier, that.resolveFunctionParamsSupplier)
+               && Objects.equals(additionalResolveFunctionParamsSupplier, that.additionalResolveFunctionParamsSupplier)
                && Objects.equals(pluginFunction, that.pluginFunction)
-               && Objects.equals(pluginFunctionParamsSupplier, that.pluginFunctionParamsSupplier)
+               && Objects.equals(additionalPluginFunctionParamsSupplier, that.additionalPluginFunctionParamsSupplier)
                && Objects.equals(destroyFunction, that.destroyFunction)
                && servicePredicate.equals(that.servicePredicate)
                && operationPredicate.equals(that.operationPredicate);
@@ -363,9 +363,9 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
         private SymbolReference inputConfig;
         private SymbolReference resolvedConfig;
         private SymbolReference resolveFunction;
-        private FunctionParamsSupplier resolveFunctionParamsSupplier;
+        private FunctionParamsSupplier additionalResolveFunctionParamsSupplier;
         private SymbolReference pluginFunction;
-        private FunctionParamsSupplier pluginFunctionParamsSupplier;
+        private FunctionParamsSupplier additionalPluginFunctionParamsSupplier;
         private SymbolReference destroyFunction;
         private BiPredicate<Model, ServiceShape> servicePredicate = (model, service) -> true;
         private OperationPredicate operationPredicate = (model, service, operation) -> false;
@@ -457,16 +457,17 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * {@link #inputConfig} must also be set.
          *
          * @param resolveFunction Function used to convert input to resolved.
-         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
+         * @param additionalResolveFunctionParamsSupplier Function which returns params to be passed
+         * as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
         public Builder resolveFunction(
                 SymbolReference resolveFunction,
-                FunctionParamsSupplier resolveFunctionParamsSupplier
+                FunctionParamsSupplier additionalResolveFunctionParamsSupplier
         ) {
             this.resolveFunction = resolveFunction;
-            this.resolveFunctionParamsSupplier = resolveFunctionParamsSupplier;
+            this.additionalResolveFunctionParamsSupplier = additionalResolveFunctionParamsSupplier;
             return this;
         }
 
@@ -493,17 +494,18 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * {@link #inputConfig} must also be set.
          *
          * @param resolveFunction Function used to convert input to resolved.
-         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
+         * @param additionalResolveFunctionParamsSupplier Function which returns params to be passed
+         * as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
         public Builder resolveFunction(
             Symbol resolveFunction,
-            FunctionParamsSupplier resolveFunctionParamsSupplier
+            FunctionParamsSupplier additionalResolveFunctionParamsSupplier
         ) {
             return resolveFunction(
                 SymbolReference.builder().symbol(resolveFunction).build(),
-                resolveFunctionParamsSupplier
+                additionalResolveFunctionParamsSupplier
             );
         }
 
@@ -514,12 +516,15 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * <p>If this is set, then all of {@link #resolveFunction},
          * {@link #resolvedConfig} and {@link #inputConfig} must also be set.
          *
-         * @param resolveFunctionParamsSupplier Function which returns params to be passed as resolve function input.
+         * @param additionalResolveFunctionParamsSupplier Function which returns params to be passed
+         * as resolve function input.
          * @return Returns the builder.
          * @see #getResolveFunction()
          */
-        public Builder resolveFunctionParamsSupplier(FunctionParamsSupplier resolveFunctionParamsSupplier) {
-            this.resolveFunctionParamsSupplier = resolveFunctionParamsSupplier;
+        public Builder additionalResolveFunctionParamsSupplier(
+            FunctionParamsSupplier additionalResolveFunctionParamsSupplier
+        ) {
+            this.additionalResolveFunctionParamsSupplier = additionalResolveFunctionParamsSupplier;
             return this;
         }
 
@@ -550,7 +555,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
                 FunctionParamsSupplier pluginFunctionParamsSupplier
         ) {
             this.pluginFunction = pluginFunction;
-            this.pluginFunctionParamsSupplier = pluginFunctionParamsSupplier;
+            this.additionalPluginFunctionParamsSupplier = pluginFunctionParamsSupplier;
             return this;
         }
 
@@ -571,17 +576,18 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * use a specific middleware function.
          *
          * @param pluginFunction Plugin function symbol to invoke.
-         * @param pluginFunctionParamsSupplier Function which returns params to be passed as plugin function input.
+         * @param additionalPluginFunctionParamsSupplier Function which returns params to be passed
+         * as plugin function input.
          * @return Returns the builder.
          * @see #getPluginFunction()
          */
         public Builder pluginFunction(
             Symbol pluginFunction,
-            FunctionParamsSupplier pluginFunctionParamsSupplier
+            FunctionParamsSupplier additionalPluginFunctionParamsSupplier
         ) {
             return pluginFunction(
                 SymbolReference.builder().symbol(pluginFunction).build(),
-                pluginFunctionParamsSupplier
+                additionalPluginFunctionParamsSupplier
             );
         }
 
@@ -589,12 +595,15 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
          * Set function which returns input parameters to plugin function. Set
          * function to return empty map to remove the current parameters.
          *
-         * @param pluginFunctionParamsSupplier Function which returns params to be passed as plugin function input.
+         * @param additionalPluginFunctionParamsSupplier Function which returns params to be passed
+         * as plugin function input.
          * @return Returns the builder.
          * @see #getPluginFunction()
          */
-        public Builder pluginFunctionParamsSupplier(FunctionParamsSupplier pluginFunctionParamsSupplier) {
-            this.pluginFunctionParamsSupplier = pluginFunctionParamsSupplier;
+        public Builder additionalPluginFunctionParamsSupplier(
+            FunctionParamsSupplier additionalPluginFunctionParamsSupplier
+        ) {
+            this.additionalPluginFunctionParamsSupplier = additionalPluginFunctionParamsSupplier;
             return this;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPlugin.java
@@ -186,7 +186,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      * @return Returns the optionally present map of parameters. The key is the key
      * for a parameter, and value is the value for a parameter.
      */
-    public Map<String, Object> getResolveFunctionParameters(
+    public Map<String, Object> getAdditionalResolveFunctionParameters(
         Model model,
         ServiceShape service,
         OperationShape operation
@@ -234,7 +234,7 @@ public final class RuntimeClientPlugin implements ToSmithyBuilder<RuntimeClientP
      * @return Returns the optionally present map of parameters. The key is the key
      * for a parameter, and value is the value for a parameter.
      */
-    public Map<String, Object> getPluginFunctionParameters(
+    public Map<String, Object> getAdditionalPluginFunctionParameters(
         Model model,
         ServiceShape service,
         OperationShape operation

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -92,12 +92,14 @@ public class RuntimeClientPluginTest {
         assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
 
-        assertThat(plugin.getResolveFunctionParameters(null, null, null), equalTo(resolveFunctionParams));
+        assertThat(plugin.getAdditionalResolveFunctionParameters(null, null, null),
+                equalTo(resolveFunctionParams));
 
         assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));
 
-        assertThat(plugin.getPluginFunctionParameters(null, null, null), equalTo(pluginFunctionParams));
+        assertThat(plugin.getAdditionalPluginFunctionParameters(null, null, null),
+                equalTo(pluginFunctionParams));
 
         assertThat(plugin.getInputConfig().get().getSymbol().getDependencies().get(0).getPackageName(),
                    equalTo("foo/baz"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -79,8 +79,8 @@ public class RuntimeClientPluginTest {
 
         RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
                 .withConventions("foo/baz", "1.0.0", "Foo")
-                .resolveFunctionParamsSupplier((m, s, o) -> resolveFunctionParams)
-                .pluginFunctionParamsSupplier((m, s, o) -> pluginFunctionParams)
+                .additionalResolveFunctionParamsSupplier((m, s, o) -> resolveFunctionParams)
+                .additionalPluginFunctionParamsSupplier((m, s, o) -> pluginFunctionParams)
                 .build();
 
         assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -3,6 +3,9 @@ package software.amazon.smithy.typescript.codegen.integration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -67,10 +70,17 @@ public class RuntimeClientPluginTest {
 
     @Test
     public void configuresWithDefaultConventions() {
+        Map<String, Object> resolveFunctionParams = new HashMap<String, Object>() {{
+                put("resolveFunctionParam", "resolveFunctionParam");
+        }};
+        Map<String, Object> pluginFunctionParams = new HashMap<String, Object>() {{
+                put("pluginFunctionParam", "pluginFunctionParam");
+        }};
+
         RuntimeClientPlugin plugin = RuntimeClientPlugin.builder()
                 .withConventions("foo/baz", "1.0.0", "Foo")
-                .additionalResolveFunctionParameters("resolveFunctionParam")
-                .additionalPluginFunctionParameters("pluginFunctionParam")
+                .resolveFunctionParamsSupplier((m, s, o) -> resolveFunctionParams)
+                .pluginFunctionParamsSupplier((m, s, o) -> pluginFunctionParams)
                 .build();
 
         assertThat(plugin.getInputConfig().get().getSymbol().getNamespace(), equalTo("foo/baz"));
@@ -82,12 +92,12 @@ public class RuntimeClientPluginTest {
         assertThat(plugin.getResolveFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getResolveFunction().get().getSymbol().getName(), equalTo("resolveFooConfig"));
 
-        assertThat(plugin.getAdditionalResolveFunctionParameters(), equalTo(ListUtils.of("resolveFunctionParam")));
+        assertThat(plugin.getResolveFunctionParameters(null, null, null), equalTo(resolveFunctionParams));
 
         assertThat(plugin.getPluginFunction().get().getSymbol().getNamespace(), equalTo("foo/baz"));
         assertThat(plugin.getPluginFunction().get().getSymbol().getName(), equalTo("getFooPlugin"));
 
-        assertThat(plugin.getAdditionalPluginFunctionParameters(), equalTo(ListUtils.of("pluginFunctionParam")));
+        assertThat(plugin.getPluginFunctionParameters(null, null, null), equalTo(pluginFunctionParams));
 
         assertThat(plugin.getInputConfig().get().getSymbol().getDependencies().get(0).getPackageName(),
                    equalTo("foo/baz"));


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/352

*Description of changes:*
This is a requirement for advanced use cases of Endpoint Discovery logic.
Currently, only Symbols and strings are generated for parameters. In future,
boolean and Map<String, String> support would be added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
