### PR TITLE
fix: parse status code bindings when payload binding exists

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2002,9 +2002,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 deserializeErrorPayload(context, operationOrError.asStructureShape().get(), payloadBinding);
             }
             if (payloadBinding != null) {
-                return ListUtils.of(payloadBinding);
-            } else {
-                return ListUtils.of();
+                documentBindings = ListUtils.of(payloadBinding);
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-js-v3/issues/2021

*Description of changes:*
When status code trait and the payload trait exists at the same time, the codegen of status code trait was omitted because the `return` statement. This change fixes the bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
