### PR TITLE
Generate non-numeric floats in protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -938,6 +938,21 @@ final class HttpProtocolTestGenerator implements Runnable {
             // Handle blobs needing to be converted from strings to their input type of UInt8Array.
             if (workingShape.isBlobShape()) {
                 writer.write("Uint8Array.from($S, c => c.charCodeAt(0)),", node.getValue());
+            } else if (workingShape.isFloatShape() || workingShape.isDoubleShape()) {
+                switch (node.getValue()) {
+                    case "NaN":
+                        writer.write("NaN,");
+                        break;
+                    case "Infinity":
+                        writer.write("Infinity,");
+                        break;
+                    case "-Infinity":
+                        writer.write("-Infinity,");
+                        break;
+                    default:
+                        throw new CodegenException(String.format(
+                                "Unexpected string value for `%s`: \"%s\"", workingShape.getId(), node.getValue()));
+                }
             } else {
                 writer.write("$S,", node.getValue());
             }


### PR DESCRIPTION
This updates the protocol test generator to properly handle generating non-numeric float values. It doesn't actually update any of the protocol support.

See: https://github.com/awslabs/smithy/pull/828


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
