### PR TITLE
Sensitive member validation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -223,7 +223,7 @@ final class StructureGenerator implements Runnable {
                         // you have mutually recursive structures because the validator of one will
                         // be defined before the validator of the other exists at all.
                         structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");
-                        structuredMemberWriter.writeValidate(writer, objectParam);
+                        structuredMemberWriter.writeValidateMethodContents(writer, objectParam);
                     }
             );
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -275,7 +275,7 @@ final class UnionGenerator implements Runnable {
                 "obj", symbol.getName(),
                 () -> {
                     structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");
-                    structuredMemberWriter.writeValidate(writer, "obj");
+                    structuredMemberWriter.writeValidateMethodContents(writer, "obj");
                 }
         );
     }

--- a/smithy-typescript-integ-tests/codegen/validation/validation.smithy
+++ b/smithy-typescript-integ-tests/codegen/validation/validation.smithy
@@ -22,6 +22,10 @@ structure TestInput {
     lengthTests: LengthTests,
     nestedTests: NestedUnionOne,
     recursiveTests: RecursiveStructureOne,
+
+    @sensitive
+    @length(max: 5)
+    sensitiveMember: String
 }
 
 structure RecursiveStructureOne {

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -21,7 +21,7 @@ interface StandardValidationFailure<ConstraintBoundsType, FailureType> {
   path: string;
   constraintType: string;
   constraintValues: ArrayLike<ConstraintBoundsType>;
-  failureValue: FailureType;
+  failureValue: FailureType | null;
 }
 
 export interface EnumValidationFailure extends StandardValidationFailure<string, string> {
@@ -38,7 +38,7 @@ export interface PatternValidationFailure {
   path: string;
   constraintType: "pattern";
   constraintValues: string;
-  failureValue: string;
+  failureValue: string | null;
 }
 
 export interface RangeValidationFailure extends StandardValidationFailure<number | undefined, number> {
@@ -58,7 +58,7 @@ export class RequiredValidationFailure {
 export interface UniqueItemsValidationFailure {
   path: string;
   constraintType: "uniqueItems";
-  failureValue: Array<any>;
+  failureValue: Array<any> | null;
 }
 
 export type ValidationFailure =
@@ -97,7 +97,14 @@ export const generateValidationSummary = (failures: readonly ValidationFailure[]
 };
 
 export const generateValidationMessage = (failure: ValidationFailure): string => {
-  const failureValue = failure.constraintType === "required" ? "null" : failure.failureValue.toString();
+  let failureValue;
+  if (failure.constraintType === "required") {
+    failureValue = "null ";
+  } else if (failure.failureValue === null) {
+    failureValue = "";
+  } else {
+    failureValue = failure.failureValue.toString() + " ";
+  }
 
   let prefix = "Value";
   let suffix: string;
@@ -111,7 +118,9 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       break;
     }
     case "length": {
-      prefix = prefix + " with length";
+      if (failure.failureValue !== null) {
+        prefix = prefix + " with length";
+      }
       const min = failure.constraintValues[0];
       const max = failure.constraintValues[1];
       if (min === undefined) {
@@ -144,5 +153,5 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       suffix = "must have unique values";
     }
   }
-  return `${prefix} ${failureValue} at '${failure.path}' failed to satisfy constraint: Member ${suffix}`;
+  return `${prefix} ${failureValue}at '${failure.path}' failed to satisfy constraint: Member ${suffix}`;
 };

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -13,7 +13,40 @@
  *  permissions and limitations under the License.
  */
 
-import { EnumValidator, LengthValidator, PatternValidator, RangeValidator, UniqueItemsValidator } from "./validators";
+import {
+  CompositeValidator,
+  EnumValidator,
+  LengthValidator,
+  PatternValidator,
+  RangeValidator,
+  SensitiveConstraintValidator,
+  SingleConstraintValidator,
+  UniqueItemsValidator,
+} from "./validators";
+
+describe("sensitive validation", () => {
+  function sensitize<T, V>(validator: SingleConstraintValidator<T, V>, input: T): V {
+    const failure = new SensitiveConstraintValidator(
+      new CompositeValidator<T>([validator])
+    ).validate(input, "")[0];
+    return (failure as unknown) as V;
+  }
+
+  describe("strips the failure value from the resultant validation failure", () => {
+    it("with enums", () => {
+      expect(sensitize(new EnumValidator(["apple", "banana", "orange"]), "pear").failureValue).toBeNull();
+    });
+    it("with length", () => {
+      expect(sensitize(new LengthValidator(2, 4), "pears").failureValue).toBeNull();
+    });
+    it("with ranges", () => {
+      expect(sensitize(new RangeValidator(2, 4), 7).failureValue).toBeNull();
+    });
+    it("with patterns", () => {
+      expect(sensitize(new PatternValidator("^[a-c]+$"), "defg").failureValue).toBeNull();
+    });
+  });
+});
 
 describe("enum validation", () => {
   const enumValidator = new EnumValidator(["apple", "banana", "orange"]);


### PR DESCRIPTION
*Description of changes:*

Unfortunately StructuredMemberWriter was in a pretty bad place so I did a bigger refactor than I otherwise would for a change like this.

Essentially, it makes people nervous if they type a password or something else sensitive into a field and they see the value for that field echoed back to them in the message.

I originally thought about pushing the concept of sensitivity into every validator, but that was a big, messy change and it required each validator to check the sensitive trait. I settled on a second approach: wrap each sensitive member validator in a decorating validator that will set the failure value to null, and make our message generation treat null failure values as values that should be omitted. Null seems like a safe sentinel value to use here as every validator except the required validator skips null values, and failures from the required validator imply a null input (and there's no need to treat null sensitive member values with particular care).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
