### PR TITLE
Custom contexts for SSDK handlers

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -146,7 +146,8 @@ final class ServerCommandGenerator implements Runnable {
     private void writeOperationType() {
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
         writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
-        writer.write("export type $L = __Operation<$T, $T>", operationSymbol.getName(), inputType, outputType);
+        writer.write("export type $L<Context> = __Operation<$T, $T, Context>",
+                operationSymbol.getName(), inputType, outputType);
         writer.write("");
     }
 
@@ -156,7 +157,7 @@ final class ServerCommandGenerator implements Runnable {
         Symbol serverSymbol = symbolProvider.toSymbol(model.expectShape(settings.getService()));
 
         writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
-        writer.openBlock("export class $L implements __OperationSerializer<$T, $S, $T> {", "}",
+        writer.openBlock("export class $L implements __OperationSerializer<$T<any>, $S, $T> {", "}",
                 serializerName, serverSymbol, operation.getId().getName(), errorsType, () -> {
             String serializerFunction = ProtocolGenerator.getGenericSerFunctionName(operationSymbol) + "Response";
             String deserializerFunction = ProtocolGenerator.getGenericDeserFunctionName(operationSymbol) + "Request";

--- a/smithy-typescript-integ-tests/src/custom_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/custom_validation.spec.ts
@@ -45,7 +45,7 @@ describe("custom validation", () => {
           method: "POST",
           path: "/test",
           body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
-        })
+        }), {}
       )
       .then((result) => {
         expect(result.statusCode).toEqual(200);
@@ -58,7 +58,7 @@ describe("custom validation", () => {
           method: "POST",
           path: "/test",
           body: Readable.from(Buffer.from('{"enumList": ["BANG!", "POW!", "valueA"]}', "utf8")),
-        })
+        }), {}
       )
       .then((result) => {
         expect(result.statusCode).toEqual(400);

--- a/smithy-typescript-integ-tests/src/default_validation.spec.ts
+++ b/smithy-typescript-integ-tests/src/default_validation.spec.ts
@@ -29,7 +29,7 @@ describe("automatic validation", () => {
           method: "POST",
           path: "/test",
           body: Readable.from(Buffer.from('{"enum": "valueA"}', "utf8")),
-        })
+        }), {}
       )
       .then((result) => {
         expect(result.statusCode).toEqual(200);
@@ -42,7 +42,7 @@ describe("automatic validation", () => {
           method: "POST",
           path: "/test",
           body: Readable.from(Buffer.from('{"enum": "BANG!"}', "utf8")),
-        })
+        }), {}
       )
       .then((result) => {
         expect(result.statusCode).toEqual(400);
@@ -63,7 +63,7 @@ describe("automatic validation", () => {
                   method: "POST",
                   path: "/test",
                   body: Readable.from(Buffer.from('{"sensitiveMember": "abcdefg"}', "utf8")),
-              })
+              }), {}
           )
           .then((result) => {
               expect(result.statusCode).toEqual(400);

--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -21,10 +21,10 @@ import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { SmithyException } from "@aws-sdk/smithy-client";
 import { SerdeContext } from "@aws-sdk/types";
 
-export type Operation<I, O> = (input: I, request: HttpRequest) => Promise<O>;
+export type Operation<I, O, Context = {}> = (input: I, context: Context) => Promise<O>;
 
-export type OperationInput<T> = T extends Operation<infer I, any> ? I : never;
-export type OperationOutput<T> = T extends Operation<any, infer O> ? O : never;
+export type OperationInput<T> = T extends Operation<infer I, any, any> ? I : never;
+export type OperationOutput<T> = T extends Operation<any, infer O, any> ? O : never;
 
 export interface OperationSerializer<T, K extends keyof T, E extends SmithyException> {
   serialize(input: OperationOutput<T[K]>, ctx: ServerSerdeContext): Promise<HttpResponse>;
@@ -33,8 +33,8 @@ export interface OperationSerializer<T, K extends keyof T, E extends SmithyExcep
   serializeError(error: E, ctx: ServerSerdeContext): Promise<HttpResponse>;
 }
 
-export interface ServiceHandler<RequestType = HttpRequest, ResponseType = HttpResponse> {
-  handle(request: RequestType): Promise<ResponseType>;
+export interface ServiceHandler<Context = {}, RequestType = HttpRequest, ResponseType = HttpResponse> {
+  handle(request: RequestType, context: Context): Promise<ResponseType>;
 }
 
 export interface ServiceCoordinate<S extends string, O extends string> {


### PR DESCRIPTION
*Description of changes:*
Service authors will want to pass metadata from the originating event through to their business logic. This will likely come from APIGateway metadata, especially metadata related to authentication and authorization. In particular, the calling user, or metadata attached by the custom Lambda authorizer are frequently referenced in service implementations.

Instead of coming up with some idea of context, or potentially coupling ourselves to the way APIGateway thinks about context, this just lets service authors define their own context type and pass it through the system.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
