### PR TITLE
Add ability to filter tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -225,10 +225,9 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             String baseName = protocol.getName().toLowerCase(Locale.US)
                     .replace("-", "_")
                     .replace(".", "_");
-            writers.useFileWriter(String.format("tests/functional/%s.spec.ts", baseName), writer -> {
-                context.setWriter(writer);
-                protocolGenerator.generateProtocolTests(context);
-            });
+            String protocolTestFileName = String.format("tests/functional/%s.spec.ts", baseName);
+            context.setDeferredWriter(() -> writers.checkoutFileWriter(protocolTestFileName));
+            protocolGenerator.generateProtocolTests(context);
         }
 
         // Write each pending writer.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -100,7 +100,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
     private TypeScriptWriter writer;
 
-    HttpProtocolTestGenerator(
+    public HttpProtocolTestGenerator(
             GenerationContext context,
             ProtocolGenerator protocolGenerator,
             TestFilter testFilter
@@ -116,7 +116,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         this.context = context;
     }
 
-    HttpProtocolTestGenerator(
+    public HttpProtocolTestGenerator(
             GenerationContext context,
             ProtocolGenerator protocolGenerator
     ) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -96,9 +96,9 @@ public final class HttpProtocolTestGenerator implements Runnable {
     private final Set<String> additionalStubs = new TreeSet<>();
     private final ProtocolGenerator protocolGenerator;
     private final TestFilter testFilter;
+    private final GenerationContext context;
 
     private TypeScriptWriter writer;
-    private boolean writerInitialized = false;
 
     HttpProtocolTestGenerator(
             GenerationContext context,
@@ -110,10 +110,10 @@ public final class HttpProtocolTestGenerator implements Runnable {
         this.protocol = context.getSettings().getProtocol();
         this.service = settings.getService(model);
         this.symbolProvider = context.getSymbolProvider();
-        this.writer = context.getWriter();
         this.protocolGenerator = protocolGenerator;
         serviceSymbol = symbolProvider.toSymbol(service);
         this.testFilter = testFilter;
+        this.context = context;
     }
 
     HttpProtocolTestGenerator(
@@ -210,12 +210,12 @@ public final class HttpProtocolTestGenerator implements Runnable {
     }
 
     private void initializeWriterIfNeeded() {
-        if (!writerInitialized) {
+        if (writer == null) {
+            writer = context.getWriter();
             writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
             writer.addDependency(TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP);
             // Add the template to each generated test.
             writer.write(IoUtils.readUtf8Resource(getClass(), "protocol-test-stub.ts"));
-            writerInitialized = true;
         }
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -107,7 +107,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
     ) {
         this.settings = context.getSettings();
         this.model = context.getModel();
-        this.protocol = context.getSettings().getProtocol();
+        this.protocol = protocolGenerator.getProtocol();
         this.service = settings.getService(model);
         this.symbolProvider = context.getSymbolProvider();
         this.protocolGenerator = protocolGenerator;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -94,6 +94,7 @@ final class HttpProtocolTestGenerator implements Runnable {
     private final Symbol serviceSymbol;
     private final Set<String> additionalStubs = new TreeSet<>();
     private final ProtocolGenerator protocolGenerator;
+    private final TestFilter testFilter;
 
     /** Vends a TypeScript IFF it's needed. */
     private final TypeScriptDelegator delegator;
@@ -107,7 +108,8 @@ final class HttpProtocolTestGenerator implements Runnable {
             ShapeId protocol,
             SymbolProvider symbolProvider,
             TypeScriptDelegator delegator,
-            ProtocolGenerator protocolGenerator
+            ProtocolGenerator protocolGenerator,
+            TestFilter testFilter
     ) {
         this.settings = settings;
         this.model = model;
@@ -117,6 +119,19 @@ final class HttpProtocolTestGenerator implements Runnable {
         this.delegator = delegator;
         this.protocolGenerator = protocolGenerator;
         serviceSymbol = symbolProvider.toSymbol(service);
+        this.testFilter = testFilter;
+    }
+
+    HttpProtocolTestGenerator(
+            TypeScriptSettings settings,
+            Model model,
+            ShapeId protocol,
+            SymbolProvider symbolProvider,
+            TypeScriptDelegator delegator,
+            ProtocolGenerator protocolGenerator
+    ) {
+        this(settings, model, protocol, symbolProvider, delegator, protocolGenerator,
+                (service, operation, testCase, typeScriptSettings) -> false);
     }
 
     @Override
@@ -227,7 +242,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
         String testName = testCase.getId() + ":Request";
         testCase.getDocumentation().ifPresent(writer::writeDocs);
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+        openTestBlock(operation, testCase, testName, () -> {
             // Create a client with a custom request handler that intercepts requests.
             writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () -> {
                     writer.write("...clientParams,");
@@ -277,7 +292,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
         String testName = testCase.getId() + ":ServerRequest";
         testCase.getDocumentation().ifPresent(writer::writeDocs);
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+        openTestBlock(operation, testCase, testName, () -> {
             Symbol serviceSymbol = symbolProvider.toSymbol(service);
             Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
 
@@ -485,7 +500,7 @@ final class HttpProtocolTestGenerator implements Runnable {
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         String testName = testCase.getId() + ":ServerResponse";
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+        openTestBlock(operation, testCase, testName, () -> {
             Symbol outputType = operationSymbol.expectProperty("outputType", Symbol.class);
             writer.openBlock("class TestService implements Partial<$T> {", "}", serviceSymbol, () -> {
                 writer.openBlock("$L(input: any, request: HttpRequest): Promise<$T> {", "}",
@@ -508,7 +523,7 @@ final class HttpProtocolTestGenerator implements Runnable {
     private void generateResponseTest(OperationShape operation, HttpResponseTestCase testCase) {
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         String testName = testCase.getId() + ":Response";
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+        openTestBlock(operation, testCase, testName, () -> {
             writeResponseTestSetup(operation, testCase, true);
 
             // Invoke the handler and look for the expected response to then perform assertions.
@@ -536,8 +551,7 @@ final class HttpProtocolTestGenerator implements Runnable {
 
         testCase.getDocumentation().ifPresent(writer::writeDocs);
         String testName = testCase.getId() + ":ServerErrorResponse";
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
-
+        openTestBlock(operation, testCase, testName, () -> {
             // Generates a Partial implementation of the service type that only includes
             // the specific operation under test. Later we'll have to "cast" this with an "as",
             // but using the partial in the meantime will give us proper type checking on the
@@ -624,7 +638,7 @@ final class HttpProtocolTestGenerator implements Runnable {
         // we can test for any operation specific values properly.
         String testName = testCase.getId() + ":Error:" + operation.getId().getName();
         testCase.getDocumentation().ifPresent(writer::writeDocs);
-        writer.openBlock("it($S, async () => {", "});\n", testName, () -> {
+        openTestBlock(operation, testCase, testName, () -> {
             writeResponseTestSetup(operation, testCase, false);
 
             // Invoke the handler and look for the expected exception to then perform assertions.
@@ -788,6 +802,20 @@ final class HttpProtocolTestGenerator implements Runnable {
         });
     }
 
+    private void openTestBlock(
+            OperationShape operation,
+            HttpMessageTestCase testCase,
+            String testName,
+            Runnable f
+    ) {
+        // Skipped tests are still generated, just not run.
+        if (testFilter.skip(service, operation, testCase, settings)) {
+            writer.openBlock("it.skip($S, async() => {", "});", testName, f);
+        } else {
+            writer.openBlock("it($S, async () => {", "});", testName, f);
+        }
+    }
+
     /**
      * Supports writing out TS specific input types in the generated code
      * through visiting the target shape at the same time as the node. If
@@ -943,6 +971,32 @@ final class HttpProtocolTestGenerator implements Runnable {
             }
             return null;
         }
+    }
+
+    /**
+     * Functional interface for skipping tests.
+     */
+    @FunctionalInterface
+    public interface TestFilter {
+        /**
+         * A function that determines whether or not to skip a test.
+         *
+         * <p>A test might be temporarily skipped if it's a known failure that
+         * will be addressed later, or if the test in question asserts a
+         * serialized message that can have multiple valid forms.
+         *
+         * @param service The service for which tests are being generated.
+         * @param operation The operation for which tests are being generated.
+         * @param testCase The test case in question.
+         * @param settings The settings being used to generate the test service.
+         * @return True if the test should be skipped, false otherwise.
+         */
+        boolean skip(
+                ServiceShape service,
+                OperationShape operation,
+                HttpMessageTestCase testCase,
+                TypeScriptSettings settings
+        );
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -131,6 +131,16 @@ final class TypeScriptDelegator {
         writerConsumer.accept(checkoutWriter(filename));
     }
 
+    /**
+     * Gets a previously created writer or creates a new one if needed
+     * and adds a new line if the writer already exists.
+     *
+     * @param filename Name of the file to create.
+     */
+    TypeScriptWriter checkoutFileWriter(String filename) {
+        return checkoutWriter(filename);
+    }
+
     private TypeScriptWriter checkoutWriter(String filename) {
         String formattedFilename = Paths.get(filename).normalize().toString();
         boolean needsNewline = writers.containsKey(formattedFilename);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -270,6 +271,7 @@ public interface ProtocolGenerator {
         private ServiceShape service;
         private SymbolProvider symbolProvider;
         private TypeScriptWriter writer;
+        private Supplier<TypeScriptWriter> writerSupplier;
         private List<TypeScriptIntegration> integrations;
         private String protocolName;
 
@@ -306,11 +308,24 @@ public interface ProtocolGenerator {
         }
 
         public TypeScriptWriter getWriter() {
+            if (writerSupplier != null && writer == null) {
+                writer = writerSupplier.get();
+            }
             return writer;
         }
 
         public void setWriter(TypeScriptWriter writer) {
             this.writer = writer;
+            if (writer != null) {
+                this.writerSupplier = null;
+            }
+        }
+
+        public void setDeferredWriter(Supplier<TypeScriptWriter> writerSupplier) {
+            this.writerSupplier = writerSupplier;
+            if (writerSupplier != null) {
+                this.writer = null;
+            }
         }
 
         public List<TypeScriptIntegration> getIntegrations() {
@@ -336,6 +351,7 @@ public interface ProtocolGenerator {
             copy.setService(service);
             copy.setSymbolProvider(symbolProvider);
             copy.setWriter(writer);
+            copy.setDeferredWriter(writerSupplier);
             copy.setIntegrations(integrations);
             copy.setProtocolName(protocolName);
             return copy;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -184,6 +184,13 @@ public interface ProtocolGenerator {
     void generateResponseDeserializers(GenerationContext context);
 
     /**
+     * Generates protocol tests to assert the protocol works properly.
+     *
+     * @param context Generation context.
+     */
+    void generateProtocolTests(GenerationContext context);
+
+    /**
      * Generates the name of a serializer function for shapes of a service.
      *
      * @param symbol The symbol the serializer function is being generated for.


### PR DESCRIPTION
This adds the ability to filter certain test cases. Reasons for doing this might include wanting to skip tests for a feature not yet implemented or wanting to skip a test whose asserted http request is only one of several valid options.

smithy-go has [something similar](https://github.com/aws/smithy-go/blob/main/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/integration/HttpProtocolUnitTestGenerator.java#L761), but rather than having a functional interface they have a locked down builder where you must be very explicit on what you want to skip. My motivation for going with the functional interface instead was to address complexity around generating for input/output/error and to allow for more easily skipping based on things in the settings (such as client vs ssdk). I could be convinced to go their way though.

see also: https://github.com/aws/aws-sdk-js-v3/pull/2506


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
