### PR TITLE
[SSDK] Fix validation generation and protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -134,4 +134,20 @@ public final class CodegenUtils {
                 + " `%2$s` defined in {@link %1$s}", containerSymbol.getName(), memberName));
         writer.write("export interface $1L extends $1LType {}", typeName);
     }
+
+    /**
+     * Ease the input streaming member restriction so that users don't need to construct a stream every time.
+     * This is used for inline type declarations (such as parameters) that need to take more permissive inputs
+     * Refer here for more rationales: https://github.com/aws/aws-sdk-js-v3/issues/843
+     */
+    static void writeInlineStreamingMemberType(
+            TypeScriptWriter writer,
+            Symbol containerSymbol,
+            MemberShape streamingMember
+    ) {
+        String memberName = streamingMember.getMemberName();
+        String optionalSuffix = streamingMember.isRequired() ? "" : "?";
+        writer.writeInline("Omit<$1T, $2S> & { $2L$3L: $1T[$2S]|string|Uint8Array|Buffer }",
+                containerSymbol, memberName, optionalSuffix);
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Streaming blob member inputs and design-time media types need special consideration during code generation, and the protocol tests were not accounting for the need for a validation customizer. Also, we weren't correctly generating `validate` for empty structures.

This does not impact SDK generation. Output of `git status` after `yarn generate-clients`:

```
On branch main
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   protocol_tests/aws-query/tests/functional/awsquery.spec.ts

```

And that diff has the expected content

```
diff --git a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
index a26a08b573..01b6921209 100644
--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -548,9 +548,7 @@ it("QueryInvalidGreetingError:Error:GreetingWithErrors", async () => {
 /**
  * Parses customized XML errors
  */
-// Manually skipping to unblock smithy-1.8.x update.
-// TODO: Consume AWSQueryError trait as a follow-up.
-it.skip("QueryCustomizedError:Error:GreetingWithErrors", async () => {
+it("QueryCustomizedError:Error:GreetingWithErrors", async () => {
   const client = new QueryProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
