### PR TITLE
Add expectations for default member deser

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -124,46 +124,48 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String booleanShape(BooleanShape shape) {
-        return deserializeUnmodified();
+        context.getWriter().addImport("expectBoolean", "__expectBoolean", "@aws-sdk/smithy-client");
+        return "__expectBoolean(" + dataSource + ")";
     }
 
     @Override
     public String byteShape(ByteShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
     }
 
     @Override
     public String longShape(LongShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
     }
 
     @Override
     public String floatShape(FloatShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
     }
 
     @Override
     public String doubleShape(DoubleShape shape) {
-        return deserializeUnmodified();
+        return expectNumber();
+    }
+
+    private String expectNumber() {
+        context.getWriter().addImport("expectNumber", "__expectNumber", "@aws-sdk/smithy-client");
+        return "__expectNumber(" + dataSource + ")";
     }
 
     @Override
     public String stringShape(StringShape shape) {
-        return HttpProtocolGeneratorUtils.getStringOutputParam(context, shape, deserializeUnmodified());
-    }
-
-    private String deserializeUnmodified() {
-        return dataSource;
+        return HttpProtocolGeneratorUtils.getStringOutputParam(context, shape, dataSource);
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2470,7 +2470,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             dataSource = "Buffer.from(" + dataSource + ", 'base64').toString('ascii')";
         }
 
-        return HttpProtocolGeneratorUtils.getStringOutputParam(context, target, dataSource);
+        return HttpProtocolGeneratorUtils.getStringOutputParam(
+                context, target, dataSource, !isGuaranteedString(bindingType));
+    }
+
+    private boolean isGuaranteedString(Location bindingType) {
+        return bindingType != Location.PAYLOAD && bindingType != Location.DOCUMENT;
     }
 
     /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -68,14 +68,14 @@ public class DocumentMemberDeserVisitorTest {
                 + "(" + DATA_SOURCE + ", context)";
 
         return ListUtils.of(new Object[][]{
-                {BooleanShape.builder().id(id).build(), DATA_SOURCE},
-                {ByteShape.builder().id(id).build(), DATA_SOURCE},
-                {DoubleShape.builder().id(id).build(), DATA_SOURCE},
-                {FloatShape.builder().id(id).build(), DATA_SOURCE},
-                {IntegerShape.builder().id(id).build(), DATA_SOURCE},
-                {LongShape.builder().id(id).build(), DATA_SOURCE},
-                {ShortShape.builder().id(id).build(), DATA_SOURCE},
-                {StringShape.builder().id(id).build(), DATA_SOURCE},
+                {BooleanShape.builder().id(id).build(), "__expectBoolean(" + DATA_SOURCE + ")"},
+                {ByteShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {DoubleShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {FloatShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {IntegerShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {LongShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {ShortShape.builder().id(id).build(), "__expectNumber(" + DATA_SOURCE + ")"},
+                {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")"},
                 {
                     StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
                     "new __LazyJsonString(" + DATA_SOURCE + ")"


### PR DESCRIPTION
This adds expectations for the default member deserialization so that an error will be thrown if the type being deserialized isn't correct.

See https://github.com/aws/aws-sdk-js-v3/pull/2515 for the other half of this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
