### PR TITLE
Correctly generate test cases for list documents

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -847,7 +847,10 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 Shape wrapperShape = this.workingShape;
                 node.getElements().forEach(element -> {
                     // Swap the working shape to the member of the collection.
-                    this.workingShape = model.expectShape(((CollectionShape) wrapperShape).getMember().getTarget());
+                    // This isn't necessary if the shape is a document.
+                    if (wrapperShape instanceof CollectionShape) {
+                        this.workingShape = model.expectShape(((CollectionShape) wrapperShape).getMember().getTarget());
+                    }
                     writer.call(() -> element.accept(this)).write("\n");
                 });
                 this.workingShape = wrapperShape;
@@ -1039,7 +1042,10 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 Shape wrapperShape = this.workingShape;
                 node.getElements().forEach(element -> {
                     // Swap the working shape to the member of the collection.
-                    this.workingShape = model.expectShape(((CollectionShape) wrapperShape).getMember().getTarget());
+                    // This isn't necessary if the shape is a document.
+                    if (wrapperShape instanceof CollectionShape) {
+                        this.workingShape = model.expectShape(((CollectionShape) wrapperShape).getMember().getTarget());
+                    }
                     writer.call(() -> element.accept(this)).write("\n");
                 });
                 this.workingShape = wrapperShape;


### PR DESCRIPTION
This fixes an issue that is exposed by the new protocol tests added in Smithy 1.9.0 where array nodes were always assumed to be a collection, when in fact they can also be documents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
