### PR TITLE
Fix serialization of REST-JSON requests when the endpoint has a path

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -235,6 +235,9 @@ public final class HttpProtocolTestGenerator implements Runnable {
             // Create a client with a custom request handler that intercepts requests.
             writer.openBlock("const client = new $T({", "});\n", serviceSymbol, () -> {
                     writer.write("...clientParams,");
+                    testCase.getHost().ifPresent(host -> {
+                        writer.write("endpoint: \"https://$L\",", host);
+                    });
                     writer.write("requestHandler: new RequestSerializationTestHandler(),");
             });
 


### PR DESCRIPTION
*Description of changes:*
Endpoints can have paths (notable example: API Gateway REST APIs without a
custom domain name), and serialization of REST-JSON requests was ignoring
these paths even though it's available from the endpoint provider.

Tested this locally against a APIGateway REST API with SigV4 that was broken without it.

This will also impact JS client generation for every REST-JSON service. We have a couple such changes out right now, was going to submit a regeneration PR when all of those land.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
