### PR TITLE
Accept boolean parameters in FunctionParameterList

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -160,6 +160,8 @@ public final class CodegenUtils {
                     }
                 } else if (value instanceof String) {
                     functionParametersList.add(String.format("%s: '%s'", key, value));
+                } else if (value instanceof Boolean) {
+                    functionParametersList.add(String.format("%s: %s", key, value));
                 } else {
                     // Future support for param type should be added in else if.
                     throw new CodegenException("Plugin function parameters not supported for type "


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/awslabs/smithy-typescript/pull/353

*Description of changes:*
Accept boolean parameters in FunctionParametersList
This change allows passing `isDiscoveryEndpointRequired` boolean to function parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
