### PR TITLE
Rename prepublishOnly to downlevel-dts

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "prepublishOnly": "yarn build && downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "remove-definitions": "rimraf ./types",
     "remove-dist": "rimraf ./dist",
     "remove-documentation": "rimraf ./docs",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2537

*Description of changes:*
Rename prepublishOnly to downlevel-dts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
