### PR TITLE
change runtime config from constant to provider functions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -46,49 +46,49 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("NodeHttpHandler", "NodeHttpHandler",
                         TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                writer.write("requestHandler: new NodeHttpHandler(),");
+                writer.write("new NodeHttpHandler()");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_HASH_NODE);
                 writer.addImport("Hash", "Hash",
                         TypeScriptDependency.AWS_SDK_HASH_NODE.packageName);
-                writer.write("sha256: Hash.bind(null, \"sha256\"),");
+                writer.write("Hash.bind(null, \"sha256\")");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
                         TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE.packageName);
-                writer.write("bodyLengthChecker: calculateBodyLength,");
+                writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
                         TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                writer.write("streamCollector,");
+                writer.write("streamCollector");
             },
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
                 writer.addImport("fromBase64", "fromBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
-                writer.write("base64Decoder: fromBase64,");
+                writer.write("fromBase64");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE);
                 writer.addImport("toBase64", "toBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_NODE.packageName);
-                writer.write("base64Encoder: toBase64,");
+                writer.write("toBase64");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
                 writer.addImport("fromUtf8", "fromUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
-                writer.write("utf8Decoder: fromUtf8,");
+                writer.write("fromUtf8");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE);
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_NODE.packageName);
-                writer.write("utf8Encoder: toUtf8,");
+                writer.write("toUtf8");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> browserRuntimeConfigDefaults = MapUtils.of(
@@ -96,49 +96,49 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("FetchHttpHandler", "FetchHttpHandler",
                         TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
-                writer.write("requestHandler: new FetchHttpHandler(),");
+                writer.write("new FetchHttpHandler()");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
                 writer.addImport("Sha256", "Sha256",
                         TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER.packageName);
-                writer.write("sha256: Sha256,");
+                writer.write("Sha256");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
                         TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER.packageName);
-                writer.write("bodyLengthChecker: calculateBodyLength,");
+                writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
                         TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
-                writer.write("streamCollector,");
+                writer.write("streamCollector");
             },
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
                 writer.addImport("fromBase64", "fromBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
-                writer.write("base64Decoder: fromBase64,");
+                writer.write("fromBase64");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER);
                 writer.addImport("toBase64", "toBase64",
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64_BROWSER.packageName);
-                writer.write("base64Encoder: toBase64,");
+                writer.write("toBase64");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
                 writer.addImport("fromUtf8", "fromUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
-                writer.write("utf8Decoder: fromUtf8,");
+                writer.write("fromUtf8");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER);
                 writer.addImport("toUtf8", "toUtf8",
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8_BROWSER.packageName);
-                writer.write("utf8Encoder: toUtf8,");
+                writer.write("toUtf8");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
@@ -146,18 +146,18 @@ final class RuntimeConfigGenerator {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
                 writer.addImport("Sha256", "Sha256",
                         TypeScriptDependency.AWS_CRYPTO_SHA256_JS.packageName);
-                writer.write("sha256: Sha256,");
+                writer.write("Sha256");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(
             "disableHostPrefix", writer -> {
-                writer.write("disableHostPrefix: false,");
+                writer.write("false");
             },
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER);
                 writer.addImport("parseUrl", "parseUrl",
                         TypeScriptDependency.AWS_SDK_URL_PARSER.packageName);
-                writer.write("urlParser: parseUrl,");
+                writer.write("parseUrl");
             }
     );
 
@@ -180,14 +180,15 @@ final class RuntimeConfigGenerator {
         String template = TypeScriptUtils.loadResourceAsString(target.getTemplateFileName());
         String contents = template
                 .replace("${clientModuleName}", symbolProvider.toSymbol(service).getNamespace())
+                .replace("${clientConfigName}", symbolProvider.toSymbol(service).getName() + "Config")
                 .replace("${apiVersion}", service.getVersion())
                 .replace("$", "$$") // sanitize template place holders.
                 .replace("$${customizations}", "${L@customizations}");
 
         delegator.useFileWriter(target.getTargetFilename(), writer -> {
             // Inject customizations into the ~template.
-            writer.onSection("customizations", original -> {
-                writer.indent();
+            writer.indent().onSection("customizations", original -> {
+                // writer.indent();
                 // Start with defaults, use a TreeMap for keeping entries sorted.
                 Map<String, Consumer<TypeScriptWriter>> configs =
                         new TreeMap<>(getDefaultRuntimeConfigs(target));
@@ -195,9 +196,16 @@ final class RuntimeConfigGenerator {
                 for (TypeScriptIntegration integration : integrations) {
                     configs.putAll(integration.getRuntimeConfigWriters(settings, model, symbolProvider, target));
                 }
-                configs.values().forEach(value -> value.accept(writer));
-                writer.dedent();
+                int indentation = target.equals(LanguageTarget.SHARED) ? 1 : 2;
+                configs.forEach((key, value) -> {
+                    writer.indent(indentation).disableNewlines().openBlock("$1L: config.$1L ?? ", ",\n", key,
+                        () -> {
+                            value.accept(writer);
+                        });
+                    writer.dedent(indentation);
+                });
             });
+            writer.dedent();
             writer.write(contents, "");
         });
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -188,7 +188,6 @@ final class RuntimeConfigGenerator {
         delegator.useFileWriter(target.getTargetFilename(), writer -> {
             // Inject customizations into the ~template.
             writer.indent().onSection("customizations", original -> {
-                // writer.indent();
                 // Start with defaults, use a TreeMap for keeping entries sorted.
                 Map<String, Consumer<TypeScriptWriter>> configs =
                         new TreeMap<>(getDefaultRuntimeConfigs(target));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceGenerator.java
@@ -92,7 +92,7 @@ final class ServiceGenerator implements Runnable {
     @Override
     public void run() {
         writer.addImport("Client", "__Client", "@aws-sdk/smithy-client");
-        writer.addImport("ClientDefaultValues", "__ClientDefaultValues", "./runtimeConfig");
+        writer.addImport("getRuntimeConfig", "__getRuntimeConfig", "./runtimeConfig");
 
         // Normalize the input and output types of the command to account for
         // things like an operation adding input where there once wasn't any
@@ -302,10 +302,8 @@ final class ServiceGenerator implements Runnable {
             writer.pushState(CLIENT_CONSTRUCTOR_SECTION);
 
             int configVariable = 0;
-            writer.write("let $L = {\n"
-                         + "  ...__ClientDefaultValues,\n"
-                         + "  ...configuration\n"
-                         + "};", generateConfigVariable(configVariable));
+            writer.write("let $L = __getRuntimeConfig(configuration);",
+                    generateConfigVariable(configVariable));
 
             // Add runtime plugin "resolve" method calls. These are invoked one
             // after the other until all of the runtime plugins have been called.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
@@ -86,13 +86,13 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_NODE);
                         writer.addImport("fileStreamHasher", "streamHasher",
                                 TypeScriptDependency.STREAM_HASHER_NODE.packageName);
-                        writer.write("streamHasher,");
+                        writer.write("streamHasher");
                     },
                     "md5", writer -> {
                             writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
                             writer.addImport("HashConstructor", "__HashConstructor",
                                     TypeScriptDependency.AWS_SDK_TYPES.packageName);
-                            writer.write("md5: Hash.bind(null, \"md5\"),");
+                            writer.write("Hash.bind(null, \"md5\")");
                     });
             case BROWSER:
                 return MapUtils.of(
@@ -100,12 +100,12 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_BROWSER);
                         writer.addImport("blobHasher", "streamHasher",
                                 TypeScriptDependency.STREAM_HASHER_BROWSER.packageName);
-                        writer.write("streamHasher,");
+                        writer.write("streamHasher");
                     },
                     "md5", writer -> {
                         writer.addDependency(TypeScriptDependency.MD5_BROWSER);
                         writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER.packageName);
-                        writer.write("md5: Md5,");
+                        writer.write("Md5");
                     });
             default:
                 return Collections.emptyMap();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -85,14 +85,14 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
-                    writer.write("eventStreamSerdeProvider,");
+                    writer.write("eventStreamSerdeProvider");
                 });
             case BROWSER:
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
-                    writer.write("eventStreamSerdeProvider,");
+                    writer.write("eventStreamSerdeProvider");
                 });
             default:
                 return Collections.emptyMap();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -297,18 +297,18 @@ public interface TypeScriptIntegration {
      *         // runtimeConfig file.
      *         Map<String, Consumer<TypeScriptWriter>> config = new HashMap<>();
      *         config.put("foo", writer -> {
-     *            writer.write("foo: some static value,"); // Note the trailing comma!
+     *            writer.write("some static value");
      *         });
      *
      *         switch (target) {
      *             case NODE:
      *                 config.put("bar", writer -> {
-     *                     writer.write("bar: someNodeValue,");
+     *                     writer.write("(() => someNodeValue)"); // Note the parenthesis surrounding arrow functions
      *                 });
      *                 break;
      *             case BROWSER:
      *                 config.put("bar", writer -> {
-     *                     writer.write("bar: someBrowserValue,");
+     *                     writer.write("someBrowserValue");
      *                 });
      *                 break;
      *             case SHARED:
@@ -342,7 +342,7 @@ public interface TypeScriptIntegration {
      *                 String someTraitValue = settings.getModel(model).getTrait(SomeTrait.class)
      *                             .map(SomeTrait::getValue)
      *                             .orElse("");
-     *                 writer.write("someTraitValue: $S,", someTraitValue);
+     *                 writer.write(someTraitValue);
      *             });
      *         }
      *     }
@@ -361,6 +361,6 @@ public interface TypeScriptIntegration {
             SymbolProvider symbolProvider,
             LanguageTarget target
     ) {
-        return Collections.emptyMap();
+         return Collections.emptyMap();
     }
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -1,11 +1,14 @@
-import { ClientDefaults } from "${clientModuleName}";
-import { ClientSharedValues } from "./runtimeConfig.shared";
+import { ${clientConfigName} } from "${clientModuleName}";
+import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...ClientSharedValues,
-  runtime: "browser",
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
+  const clientSharedValues = getSharedRuntimeConfig(config);
+  return {
+    ...clientSharedValues,
+    runtime: "browser",
 ${customizations}
+  };
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -8,6 +8,7 @@ export const getRuntimeConfig = (config: ${clientConfigName}) => {
   const clientSharedValues = getSharedRuntimeConfig(config);
   return {
     ...clientSharedValues,
+    ...config,
     runtime: "browser",
 ${customizations}
   };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
@@ -1,11 +1,14 @@
-import { ClientDefaults } from "${clientModuleName}";
-import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser";
+import { ${clientConfigName} } from "${clientModuleName}";
+import { getRuntimeConfig as getBrowserRuntimeConfig } from "./runtimeConfig.browser";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...BrowserDefaults,
-  runtime: "react-native",
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
+  const browserDefaults = getBrowserRuntimeConfig(config);
+  return {
+    ...browserDefaults,
+    runtime: "react-native",
 ${customizations}
+  };
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
@@ -8,6 +8,7 @@ export const getRuntimeConfig = (config: ${clientConfigName}) => {
   const browserDefaults = getBrowserRuntimeConfig(config);
   return {
     ...browserDefaults,
+    ...config,
     runtime: "react-native",
 ${customizations}
   };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
@@ -1,7 +1,9 @@
+import { ${clientConfigName} } from "${clientModuleName}";
+
 /**
  * @internal
  */
-export const ClientSharedValues = {
+export const getRuntimeConfig = (config: ${clientConfigName}) => ({
   apiVersion: "${apiVersion}",
 ${customizations}
-};
+});

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -1,11 +1,14 @@
-import { ClientDefaults } from "${clientModuleName}";
-import { ClientSharedValues } from "./runtimeConfig.shared";
+import { ${clientConfigName} } from "${clientModuleName}";
+import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 
 /**
  * @internal
  */
-export const ClientDefaultValues: Required<ClientDefaults> = {
-  ...ClientSharedValues,
-  runtime: "node",
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
+  const clientSharedValues = getSharedRuntimeConfig(config);
+  return {
+    ...clientSharedValues,
+    runtime: "node",
 ${customizations}
+  };
 };

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -8,6 +8,7 @@ export const getRuntimeConfig = (config: ${clientConfigName}) => {
   const clientSharedValues = getSharedRuntimeConfig(config);
   return {
     ...clientSharedValues,
+    ...config,
     runtime: "node",
 ${customizations}
   };

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -93,23 +93,24 @@ public class RuntimeConfigGeneratorTest {
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigContents,
-                   containsString("import { ClientDefaults } from \"./ExampleClient\";"));
+                   containsString("import { ExampleClientConfig } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
         assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.browser.ts").get();
         assertThat(runtimeConfigBrowserContents,
-                   containsString("import { ClientDefaults } from \"./ExampleClient\";"));
+                   containsString("import { ExampleClientConfig } from \"./ExampleClient\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
         assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
 
         // Does the runtimeConfig.native.ts file expand the browser template properties properly?
         String runtimeConfigNativeContents = manifest.getFileString("runtimeConfig.native.ts").get();
         assertThat(runtimeConfigNativeContents,
-                containsString("import { ClientDefaults } from \"./ExampleClient\";"));
+                containsString("import { ExampleClientConfig } from \"./ExampleClient\";"));
         assertThat(runtimeConfigNativeContents,
-                containsString("import { ClientDefaultValues as BrowserDefaults } from \"./runtimeConfig.browser\";"));
+                containsString(
+                        "import { getRuntimeConfig as getBrowserRuntimeConfig } from \"./runtimeConfig.browser\";"));
         assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
         assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
     }


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/aws/aws-sdk-js-v3/pull/2574

*Description of changes:*
See: https://github.com/aws/aws-sdk-js-v3/pull/2574

This change makes runtime default configs as a function instead of constant. As a result, different client instance won't share the same runtime config (e.g. HTTP handlers). This change also uses inline nullish coalescing in replace of fully loaded default configuration. This change makes sure the SDK won't load default value/provider at all when corresponding custom config is supplied.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
