### PR TITLE
Avoid messing with prototypes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -96,9 +96,13 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         ReservedWords reservedWords = new ReservedWordsBuilder()
                 .loadWords(TypeScriptCodegenPlugin.class.getResource("reserved-words.txt"))
                 .build();
+        ReservedWords memberReservedWords = new ReservedWordsBuilder()
+                .loadWords(TypeScriptCodegenPlugin.class.getResource("reserved-words-members.txt"))
+                .build();
 
         escaper = ReservedWordSymbolProvider.builder()
                 .nameReservedWords(reservedWords)
+                .memberReservedWords(memberReservedWords)
                 // Only escape words when the symbol has a definition file to
                 // prevent escaping intentional references to built-in types.
                 .escapePredicate((shape, symbol) -> !StringUtils.isEmpty(symbol.getDefinitionFile()))

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words-members.txt
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words-members.txt
@@ -1,0 +1,24 @@
+# TypeScript reserved words for members.
+#
+# Smithy's rules around the names of types are already pretty strict and
+# mostly compatible with TypeScript's naming conventions. Furthermore, the
+# code generator will automatically uppercase every instance where a
+# TypeScript type is generated from a Smithy type. This makes the majority
+# of all of the reserved words in TypeScript something that will never be
+# encountered when generating code. However, it's possible that other
+# SymbolProvider implementations could be used that do emit reserved
+# words for identifiers, hence this code is useful as an extra layer of
+# protection.
+#
+# Adding new reserved words to this list could potentially result in a
+# breaking change to previously generated clients, so adding new reserved words
+# is discouraged. Ideally we could have just automatically added an alias for
+# built-in types that conflict with generated types, but, unfortunately, it's
+# not currently possible to alias a built-in TypeScript or JavaScript type.
+#
+# When a reserved word is encountered, this implementation will
+# continue to prefix the word with "_" until it's no longer considered
+# reserved.
+
+# Prevent prototype pollution
+__proto__


### PR DESCRIPTION
This prevents a member from being called `__proto__` in an effort to avoid issues with prototype pollution. One would hope that things would break long before it got to that point, but we should still be extra cautious.

Basically the concern is that we'd generate a type like:

```typescript
interface Example {
    __proto__: SmithyDocument
}
```

And then when we get to deserialization we'd do something like:

```typescript
contents.__proto__ = {'pwned': true}
```

There is no associated PR to aws-sdk-js-v3 because no AWS service has a member called `__proto__`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
