### PR TITLE
Prefix `dist/` for typesVersions TS<4

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -40,7 +40,7 @@
   },
   "typesVersions": {
     "<4.0": {
-      "types/*": ["types/ts3.4/*"]
+      "dist/types/*": ["dist/types/ts3.4/*"]
     }
   }
 }

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -42,8 +42,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "types/*": [
-        "types/ts3.4/*"
+      "dist/types/*": [
+        "dist/types/ts3.4/*"
       ]
     }
   },

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -43,8 +43,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "types/*": [
-        "types/ts3.4/*"
+      "dist/types/*": [
+        "dist/types/ts3.4/*"
       ]
     }
   },


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2580

*Description of changes:*
Prefix `dist/` for typesVersions TS<4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
