### PR TITLE
chore: bump tslib to 2.3.0

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^2.0.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "downlevel-dts": "0.7.0",


### PR DESCRIPTION
*Description of changes:*
Related to https://github.com/aws/aws-sdk-js-v3/pull/2601.

Update the tslib version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
