### PR TITLE
Add a generator for @httpMalformedRequestTests

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/malformed-request-test-regex-json-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/malformed-request-test-regex-json-stub.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns 'true' if the 'message' field in the serialized JSON document matches the given regex.
+ */
+const matchMessageInJsonBody = (body: string, messageRegex: string): Object => {
+  const parsedBody = JSON.parse(body);
+  if (!parsedBody.hasOwnProperty("message")) {
+    return false;
+  }
+  return new RegExp(messageRegex).test(parsedBody["message"]);
+}


### PR DESCRIPTION
*Description of changes:*
@httpMalformedRequestTests allow server implementations to generate tests
that exercise how the implementation deals with requests that are rejected
before they reach the customer's business logic. See
https://github.com/awslabs/smithy/pull/871 for more information.

This will not succeed build checks until https://github.com/awslabs/smithy/pull/871 is committed and released.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
