### PR TITLE
Handle content-type and accept in ssdk

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -219,6 +219,7 @@ final class ServerGenerator {
         writer.addImport("OperationOutput", "__OperationOutput", "@aws-smithy/server-common");
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
+        writer.addImport("isFrameworkException", "__isFrameworkException", "@aws-smithy/server-common");
 
         writer.openBlock("async function handle<S, O extends keyof S & string, Context>(",
                 "): Promise<__HttpResponse> {",
@@ -241,6 +242,9 @@ final class ServerGenerator {
             });
         });
         writer.indent();
+        writer.openBlock("if (__isFrameworkException(error)) {", "};", () -> {
+            writer.write("return serializeFrameworkException(error, serdeContextBase);");
+        });
         writer.write("return serializeFrameworkException(new __SerializationException(), "
                 + "serdeContextBase);");
         writer.closeBlock("}");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1683,7 +1683,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * Writes out handling for the content-type header. The following rules apply:
      *
      *  - The content-type header may always be omitted.
-     *  - If the input shape has a member with the httpPaylaod trait then the following apply:
+     *  - If the input shape has a member with the httpPayload trait then the following apply:
      *      - If the target is a shape with the mediaType trait, the value of the content-type header must
      *        match if present.
      *      - If the target is a blob shape without a media type, the content-type header may have any value.
@@ -1737,7 +1737,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * Writes out handling for the accept header. The following rules apply:
      *
      *  - The accept header may always be omitted.
-     *  - If the output shape has a member with the httpPaylaod trait then the following apply:
+     *  - If the output shape has a member with the httpPayload trait then the following apply:
      *      - If the target is a shape with the mediaType trait, the value of the accept header must
      *        match if present.
      *      - If the target is a blob shape without a media type, the accept header may have any value.

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/framework-errors.smithy
@@ -11,3 +11,11 @@ structure UnknownOperationException {}
 @error("client")
 @httpError(400)
 structure SerializationException {}
+
+@error("client")
+@httpError(415)
+structure UnsupportedMediaTypeException {}
+
+@error("client")
+@httpError(406)
+structure NotAcceptableException {}

--- a/smithy-typescript-ssdk-libs/server-common/src/errors.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/errors.ts
@@ -15,7 +15,19 @@
 
 import { SmithyException } from "@aws-sdk/smithy-client";
 
-export type SmithyFrameworkException = InternalFailureException | UnknownOperationException | SerializationException;
+export type SmithyFrameworkException =
+  | InternalFailureException
+  | UnknownOperationException
+  | SerializationException
+  | UnsupportedMediaTypeException
+  | NotAcceptableException;
+
+export const isFrameworkException = (error: any): error is SmithyFrameworkException => {
+  if (!error.hasOwnProperty("$frameworkError")) {
+    return false;
+  }
+  return error.$frameworkError;
+};
 
 export class InternalFailureException implements SmithyException {
   readonly name = "InternalFailure";
@@ -26,14 +38,28 @@ export class InternalFailureException implements SmithyException {
 
 export class UnknownOperationException implements SmithyException {
   readonly name = "UnknownOperationException";
-  readonly $fault = "server";
+  readonly $fault = "client";
   readonly statusCode = 404;
   readonly $frameworkError = true;
 }
 
 export class SerializationException implements SmithyException {
   readonly name = "SerializationException";
-  readonly $fault = "server";
+  readonly $fault = "client";
   readonly statusCode = 400;
+  readonly $frameworkError = true;
+}
+
+export class UnsupportedMediaTypeException implements SmithyException {
+  readonly name = "UnsupportedMediaTypeException";
+  readonly $fault = "client";
+  readonly statusCode = 415;
+  readonly $frameworkError = true;
+}
+
+export class NotAcceptableException implements SmithyException {
+  readonly name = "NotAcceptableException";
+  readonly $fault = "client";
+  readonly statusCode = 406;
   readonly $frameworkError = true;
 }


### PR DESCRIPTION
This updates the SSDK to check the content-type and accept headers.

Both accept and content-type headers may be omitted in any case.

If content-type is set and the operation has a modeled content-type,
the content-type sent is validated against what is modeled. If the
operation doesn't have a modeled content-type, any value is rejected.
If the content-type is rejected, a 415 will be returned.

Accept validation works in a similar way, though it looks at the
modeled output type and a 406 will be returned in the case of a
rejection.

Opening as a draft because I'd like to wait for the malformed request headers prs to land so I can do some of those.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
