### PR TITLE
fix: use optional chaining while processing runtime config

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -197,7 +197,7 @@ final class RuntimeConfigGenerator {
                 }
                 int indentation = target.equals(LanguageTarget.SHARED) ? 1 : 2;
                 configs.forEach((key, value) -> {
-                    writer.indent(indentation).disableNewlines().openBlock("$1L: config.$1L ?? ", ",\n", key,
+                    writer.indent(indentation).disableNewlines().openBlock("$1L: config?.$1L ?? ", ",\n", key,
                         () -> {
                             value.accept(writer);
                         });

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -4,7 +4,7 @@ import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shar
 /**
  * @internal
  */
-export const getRuntimeConfig = (config: ${clientConfigName} = {}) => {
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
   const clientSharedValues = getSharedRuntimeConfig(config);
   return {
     ...clientSharedValues,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.native.ts.template
@@ -4,7 +4,7 @@ import { getRuntimeConfig as getBrowserRuntimeConfig } from "./runtimeConfig.bro
 /**
  * @internal
  */
-export const getRuntimeConfig = (config: ${clientConfigName} = {}) => {
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
   const browserDefaults = getBrowserRuntimeConfig(config);
   return {
     ...browserDefaults,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.shared.ts.template
@@ -3,7 +3,7 @@ import { ${clientConfigName} } from "${clientModuleName}";
 /**
  * @internal
  */
-export const getRuntimeConfig = (config: ${clientConfigName} = {}) => ({
+export const getRuntimeConfig = (config: ${clientConfigName}) => ({
   apiVersion: "${apiVersion}",
 ${customizations}
 });

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -5,7 +5,7 @@ import { emitWarningIfUnsupportedVersion } from "@aws-sdk/smithy-client";
 /**
  * @internal
  */
-export const getRuntimeConfig = (config: ${clientConfigName} = {}) => {
+export const getRuntimeConfig = (config: ${clientConfigName}) => {
   emitWarningIfUnsupportedVersion(process.version);
   const clientSharedValues = getSharedRuntimeConfig(config);
   return {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -86,23 +86,29 @@ public class RuntimeConfigGeneratorTest {
 
         // Does the runtimeConfig.shared.ts file expand the template properties properly?
         String runtimeConfigSharedContents = manifest.getFileString("runtimeConfig.shared.ts").get();
+        assertThat(runtimeConfigSharedContents,
+                containsString("export const getRuntimeConfig = (config: ExampleClientConfig) =>"));
         assertThat(runtimeConfigSharedContents, containsString("apiVersion: \"1.0.0\","));
-        assertThat(runtimeConfigSharedContents, containsString("syn: 'ack2',"));
-        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
+        assertThat(runtimeConfigSharedContents, containsString("config?.syn ?? syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("config?.foo ?? foo: 'bar',"));
 
         // Does the runtimeConfig.ts file expand the template properties properly?
         String runtimeConfigContents = manifest.getFileString("runtimeConfig.ts").get();
         assertThat(runtimeConfigContents,
                    containsString("import { ExampleClientConfig } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
-        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
+        assertThat(runtimeConfigSharedContents,
+                containsString("export const getRuntimeConfig = (config: ExampleClientConfig) =>"));
+        assertThat(runtimeConfigContents, containsString("config?.syn ?? syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("config?.foo ?? foo: 'bar',"));
 
         // Does the runtimeConfig.browser.ts file expand the template properties properly?
         String runtimeConfigBrowserContents = manifest.getFileString("runtimeConfig.browser.ts").get();
         assertThat(runtimeConfigBrowserContents,
                    containsString("import { ExampleClientConfig } from \"./ExampleClient\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
-        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
+        assertThat(runtimeConfigSharedContents,
+                containsString("export const getRuntimeConfig = (config: ExampleClientConfig) =>"));
+        assertThat(runtimeConfigContents, containsString("config?.syn ?? syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("config?.foo ?? foo: 'bar',"));
 
         // Does the runtimeConfig.native.ts file expand the browser template properties properly?
         String runtimeConfigNativeContents = manifest.getFileString("runtimeConfig.native.ts").get();
@@ -111,7 +117,9 @@ public class RuntimeConfigGeneratorTest {
         assertThat(runtimeConfigNativeContents,
                 containsString(
                         "import { getRuntimeConfig as getBrowserRuntimeConfig } from \"./runtimeConfig.browser\";"));
-        assertThat(runtimeConfigContents, containsString("syn: 'ack2',"));
-        assertThat(runtimeConfigSharedContents, containsString("foo: 'bar',"));
+        assertThat(runtimeConfigSharedContents,
+                containsString("export const getRuntimeConfig = (config: ExampleClientConfig) =>"));
+        assertThat(runtimeConfigContents, containsString("config?.syn ?? syn: 'ack2',"));
+        assertThat(runtimeConfigSharedContents, containsString("config?.foo ?? foo: 'bar',"));
     }
 }


### PR DESCRIPTION
This is an alternate solution to https://github.com/awslabs/smithy-typescript/pull/391 that works for generic clients too.

Using default value of `{}` assumed that client configs have no
required properties, which may not be true for generic non-AWS clients
where endpoint may be required.

Using `?.` operator for cases where `config` may be null/undefined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
