### PR TITLE
Use operation symbol name consistently

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -165,7 +165,7 @@ final class ServerCommandGenerator implements Runnable {
 
         writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
         writer.openBlock("export class $L implements __OperationSerializer<$T<any>, $S, $T> {", "}",
-                serializerName, serverSymbol, operation.getId().getName(), errorsType, () -> {
+                serializerName, serverSymbol, operationSymbol.getName(), errorsType, () -> {
             String serializerFunction = ProtocolGenerator.getGenericSerFunctionName(operationSymbol) + "Response";
             String deserializerFunction = ProtocolGenerator.getGenericDeserFunctionName(operationSymbol) + "Request";
             writer.addImport(serializerFunction, null,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -36,7 +36,7 @@ final class ServerGenerator {
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         writer.writeInline("export type $L = ", serviceSymbol.expectProperty("operations", Symbol.class).getName());
         for (Iterator<OperationShape> iter = operations.iterator(); iter.hasNext();) {
-            writer.writeInline("$S", iter.next().getId().getName());
+            writer.writeInline("$S", symbolProvider.toSymbol(iter.next()).getName());
             if (iter.hasNext()) {
                 writer.writeInline(" | ");
             }
@@ -109,14 +109,13 @@ final class ServerGenerator {
                 });
                 writer.openBlock("switch (target.operation) {", "}", () -> {
                     for (OperationShape operation : operations) {
-                        String opName = operation.getId().getName();
                         Symbol operationSymbol = symbolProvider.toSymbol(operation);
                         Symbol inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
-                        writer.openBlock("case $S : {", "}", opName, () -> {
+                        writer.openBlock("case $S : {", "}", operationSymbol.getName(), () -> {
                             writer.write("return handle(request, context, $1S, this.serializerFactory($1S), "
-                                    + "this.service.$2L, this.serializeFrameworkException, $3T.validate, "
+                                    + "this.service.$1L, this.serializeFrameworkException, $2T.validate, "
                                     + "this.validationCustomizer);",
-                                    opName, operationSymbol.getName(), inputSymbol);
+                                    operationSymbol.getName(), inputSymbol);
                         });
                     }
                 });
@@ -133,9 +132,9 @@ final class ServerGenerator {
         writeSerdeContextBase(writer);
         writeHandleFunction(writer);
 
-        String operationName = operation.getId().getName();
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol operationSymbol = symbolProvider.toSymbol(operation);
+        String operationName = operationSymbol.getName();
 
         Symbol inputSymbol = operationSymbol.expectProperty("inputType", Symbol.class);
         Symbol outputSymbol = operationSymbol.expectProperty("outputType", Symbol.class);


### PR DESCRIPTION
This updates any usage of an operation name to go through the symbol provider. This avoids issues where the operation name's casing differs from that of the symbol.

Note: this has no impact on client generation, which already exclusively uses the symbol provider name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
