### PR TITLE
Use sized number parsing in codegen

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -130,42 +130,38 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String byteShape(ByteShape shape) {
-        return expectInteger();
+        context.getWriter().addImport("expectByte", "__expectByte", "@aws-sdk/smithy-client");
+        return "__expectByte(" + dataSource + ")";
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        return expectInteger();
+        context.getWriter().addImport("expectShort", "__expectShort", "@aws-sdk/smithy-client");
+        return "__expectShort(" + dataSource + ")";
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        return expectInteger();
+        context.getWriter().addImport("expectInt32", "__expectInt32", "@aws-sdk/smithy-client");
+        return "__expectInt32(" + dataSource + ")";
     }
 
     @Override
     public String longShape(LongShape shape) {
-        return expectInteger();
+        context.getWriter().addImport("expectLong", "__expectLong", "@aws-sdk/smithy-client");
+        return "__expectLong(" + dataSource + ")";
     }
 
     @Override
     public String floatShape(FloatShape shape) {
-        return limitedParseFloat();
+        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32", "@aws-sdk/smithy-client");
+        return "__limitedParseFloat32(" + dataSource + ")";
     }
 
     @Override
     public String doubleShape(DoubleShape shape) {
-        return limitedParseFloat();
-    }
-
-    private String expectInteger() {
-        context.getWriter().addImport("expectInt", "__expectInt", "@aws-sdk/smithy-client");
-        return "__expectInt(" + dataSource + ")";
-    }
-
-    private String limitedParseFloat() {
-        context.getWriter().addImport("limitedParseFloat", "__limitedParseFloat", "@aws-sdk/smithy-client");
-        return "__limitedParseFloat(" + dataSource + ")";
+        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble", "@aws-sdk/smithy-client");
+        return "__limitedParseDouble(" + dataSource + ")";
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2781,12 +2781,34 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case QUERY:
             case LABEL:
             case HEADER:
-                if (target instanceof FloatShape || target instanceof DoubleShape) {
-                    context.getWriter().addImport("strictParseFloat", "__strictParseFloat", "@aws-sdk/smithy-client");
-                    return "__strictParseFloat(" + dataSource + ")";
+                switch (target.getType()) {
+                    case DOUBLE:
+                        context.getWriter().addImport(
+                                "strictParseDouble", "__strictParseDouble", "@aws-sdk/smithy-client");
+                        return "__strictParseDouble(" + dataSource + ")";
+                    case FLOAT:
+                        context.getWriter().addImport(
+                                "strictParseFloat", "__strictParseFloat", "@aws-sdk/smithy-client");
+                        return "__strictParseFloat(" + dataSource + ")";
+                    case LONG:
+                        context.getWriter().addImport(
+                                "strictParseLong", "__strictParseLong", "@aws-sdk/smithy-client");
+                        return "__strictParseLong(" + dataSource + ")";
+                    case INTEGER:
+                        context.getWriter().addImport(
+                                "strictParseInt32", "__strictParseInt32", "@aws-sdk/smithy-client");
+                        return "__strictParseInt32(" + dataSource + ")";
+                    case SHORT:
+                        context.getWriter().addImport(
+                                "strictParseShort", "__strictParseShort", "@aws-sdk/smithy-client");
+                        return "__strictParseShort(" + dataSource + ")";
+                    case BYTE:
+                        context.getWriter().addImport(
+                                "strictParseByte", "__strictParseByte", "@aws-sdk/smithy-client");
+                        return "__strictParseByte(" + dataSource + ")";
+                    default:
+                        throw new CodegenException("Unexpected number shape `" + target.getType() + "`");
                 }
-                context.getWriter().addImport("strictParseInt", "__strictParseInt", "@aws-sdk/smithy-client");
-                return "__strictParseInt(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected number binding location `" + bindingType + "`");
         }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -69,12 +69,12 @@ public class DocumentMemberDeserVisitorTest {
 
         return ListUtils.of(new Object[][]{
                 {BooleanShape.builder().id(id).build(), "__expectBoolean(" + DATA_SOURCE + ")"},
-                {ByteShape.builder().id(id).build(), "__expectInt(" + DATA_SOURCE + ")"},
-                {DoubleShape.builder().id(id).build(), "__limitedParseFloat(" + DATA_SOURCE + ")"},
-                {FloatShape.builder().id(id).build(), "__limitedParseFloat(" + DATA_SOURCE + ")"},
-                {IntegerShape.builder().id(id).build(), "__expectInt(" + DATA_SOURCE + ")"},
-                {LongShape.builder().id(id).build(), "__expectInt(" + DATA_SOURCE + ")"},
-                {ShortShape.builder().id(id).build(), "__expectInt(" + DATA_SOURCE + ")"},
+                {ByteShape.builder().id(id).build(), "__expectByte(" + DATA_SOURCE + ")"},
+                {DoubleShape.builder().id(id).build(), "__limitedParseDouble(" + DATA_SOURCE + ")"},
+                {FloatShape.builder().id(id).build(), "__limitedParseFloat32(" + DATA_SOURCE + ")"},
+                {IntegerShape.builder().id(id).build(), "__expectInt32(" + DATA_SOURCE + ")"},
+                {LongShape.builder().id(id).build(), "__expectLong(" + DATA_SOURCE + ")"},
+                {ShortShape.builder().id(id).build(), "__expectShort(" + DATA_SOURCE + ")"},
                 {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")"},
                 {
                     StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),


### PR DESCRIPTION
This updates codegen to used sized number parsing to assert that numbers are in the range we expect.

This is associated with: https://github.com/aws/aws-sdk-js-v3/pull/2710


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
