### PR TITLE
chore: bump typescript to ~4.4.2

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.2"
+    "typescript": "~4.4.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "useUnknownInCatchVariables": false,
   },
   "typedocOptions": {
     "exclude": [


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2733

*Description of changes:*
Bump typescript to ~4.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
