### PR TITLE
Parse timestamps strictly

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2579,7 +2579,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         } else if (target instanceof TimestampShape) {
             HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
             Format format = httpIndex.determineTimestampFormat(member, bindingType, getDocumentTimestampFormat());
-            return HttpProtocolGeneratorUtils.getTimestampOutputParam(dataSource, bindingType, member, format);
+            return HttpProtocolGeneratorUtils.getTimestampOutputParam(
+                    context.getWriter(), dataSource, bindingType, member, format,
+                    requiresNumericEpochSecondsInPayload());
         } else if (target instanceof BlobShape) {
             return getBlobOutputParam(bindingType, dataSource);
         } else if (target instanceof CollectionShape) {
@@ -2933,4 +2935,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             StructureShape error,
             List<HttpBinding> documentBindings
     );
+
+    /**
+     * @return true if this protocol disallows string epoch timestamps in payloads.
+     */
+    protected abstract boolean requiresNumericEpochSecondsInPayload();
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -39,13 +39,16 @@ public class HttpProtocolGeneratorUtilsTest {
     @Test
     public void givesCorrectTimestampDeserialization() {
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
 
-        assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME)));
-        assertThat("new Date(Math.round(" + DATA_SOURCE + " * 1000))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS)));
-        assertThat("new Date(" + DATA_SOURCE + ")",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE)));
+        assertThat("__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME, false)));
+        assertThat("__expectNonNull(__parseEpochTimestamp(__expectNumber(" + DATA_SOURCE + ")))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, true)));
+        assertThat("__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, false)));
+        assertThat("__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE, false)));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Timestamp formats are modeled, and instead of relying on the JavaScript Date
constructor's undefined behavior to support all three styles of timestamp,
we use a specific strict parsing method based on the modeled type to ensure
that we are only accepting timestamps in the correct format.

`DocumentMemberDeserVisitor` did not have a reference to the member being
deserialized, so it could not discover traits that were applied to the member
(such as `@timestampFormat`). It also needed to know whether epoch
timestamps are allowed to be strings, which is protocol-specific.

This relies on https://github.com/aws/aws-sdk-js-v3/pull/2737 and there will be a follow-up PR for SDK-specific generation changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
