### PR TITLE
Parse unions strictly

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -271,13 +271,18 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public final String unionShape(UnionShape shape) {
-        return getDelegateDeserializer(shape);
+        context.getWriter().addImport("expectUnion", "__expectUnion", "@aws-sdk/smithy-client");
+        return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 
     private String getDelegateDeserializer(Shape shape) {
+        return getDelegateDeserializer(shape, dataSource);
+    }
+
+    private String getDelegateDeserializer(Shape shape, String customDataSource) {
         // Use the shape for the function name.
         Symbol symbol = context.getSymbolProvider().toSymbol(shape);
         return ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
-                + "(" + dataSource + ", context)";
+                + "(" + customDataSource + ", context)";
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2281,10 +2281,16 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         } else if (target instanceof BlobShape) {
             // If payload is non-streaming Blob, only need to collect stream to binary data (Uint8Array).
             writer.write("const data: any = await collectBody(output.body, context);");
-        } else if (target instanceof StructureShape || target instanceof UnionShape) {
-            // If payload is Structure or Union, then we need to parse the string into JavaScript object.
+        } else if (target instanceof StructureShape) {
+            // If payload is a Structure, then we need to parse the string into JavaScript object.
             writer.addImport("expectObject", "__expectObject", "@aws-sdk/smithy-client");
-            writer.write("const data: object | undefined = __expectObject(await parseBody(output.body, context));");
+            writer.write("const data: { [key: string]: any } | undefined "
+                    + "= __expectObject(await parseBody(output.body, context));");
+        } else if (target instanceof UnionShape) {
+            // If payload is a Union, then we need to parse the string into JavaScript object.
+            writer.addImport("expectUnion", "__expectUnion", "@aws-sdk/smithy-client");
+            writer.write("const data: { [key: string]: any } | undefined "
+                    + "= __expectUnion(await parseBody(output.body, context));");
         } else if (target instanceof StringShape || target instanceof DocumentShape) {
             // If payload is String or Document, we need to collect body and convert binary to string.
             writer.write("const data: any = await collectBodyString(output.body, context);");

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -99,7 +99,6 @@ public class DocumentMemberDeserVisitorTest {
                 {SetShape.builder().id(id).member(member).build(), delegate, source},
                 {MapShape.builder().id(id).key(key).value(value).build(), delegate, source},
                 {StructureShape.builder().id(id).build(), delegate, source},
-                {UnionShape.builder().id(id).addMember(member).build(), delegate, source},
                 {
                     TimestampShape.builder().id(id).build(),
                     "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
@@ -114,6 +113,12 @@ public class DocumentMemberDeserVisitorTest {
                     TimestampShape.builder().id(id).build(),
                     "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
                     source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
+                },
+                {
+                    UnionShape.builder().id(id).addMember(member).build(),
+                    "deserialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+                        + "(__expectUnion(" + DATA_SOURCE + "), context)",
+                    source
                 },
         });
     }


### PR DESCRIPTION
*Description of changes:*
Unions must be objects with exactly one key set.

Relies on https://github.com/aws/aws-sdk-js-v3/pull/2746 and tested with protocol tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
