### PR TITLE
Revert "Parse timestamps strictly"

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -90,21 +90,6 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     }
 
     /**
-     * @return the member this visitor is being run against. Used to discover member-applied
-     * traits, such as @timestampFormat. Can be, and defaults, to, null.
-     */
-    protected MemberShape getMemberShape() {
-        return null;
-    }
-
-    /**
-     * @return true if string-formatted epoch seconds in payloads are disallowed. Defaults to false.
-     */
-    protected boolean requiresNumericEpochSecondsInPayload() {
-        return false;
-    }
-
-    /**
      * Gets the generation context.
      *
      * @return The generation context.
@@ -223,25 +208,8 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     @Override
     public String timestampShape(TimestampShape shape) {
         HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
-        Format format;
-        if (getMemberShape() == null) {
-            format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
-        } else {
-            if (!shape.getId().equals(getMemberShape().getTarget())) {
-                throw new IllegalArgumentException(
-                        String.format("Encountered timestamp shape %s that was not the target of member shape %s",
-                                shape.getId(), getMemberShape().getId()));
-            }
-            format = httpIndex.determineTimestampFormat(getMemberShape(), Location.DOCUMENT, defaultTimestampFormat);
-        }
-
-        return HttpProtocolGeneratorUtils.getTimestampOutputParam(
-                context.getWriter(),
-                dataSource,
-                Location.DOCUMENT,
-                shape,
-                format,
-                requiresNumericEpochSecondsInPayload());
+        Format format = httpIndex.determineTimestampFormat(shape, Location.DOCUMENT, defaultTimestampFormat);
+        return HttpProtocolGeneratorUtils.getTimestampOutputParam(dataSource, Location.DOCUMENT, shape, format);
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2579,9 +2579,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         } else if (target instanceof TimestampShape) {
             HttpBindingIndex httpIndex = HttpBindingIndex.of(context.getModel());
             Format format = httpIndex.determineTimestampFormat(member, bindingType, getDocumentTimestampFormat());
-            return HttpProtocolGeneratorUtils.getTimestampOutputParam(
-                    context.getWriter(), dataSource, bindingType, member, format,
-                    requiresNumericEpochSecondsInPayload());
+            return HttpProtocolGeneratorUtils.getTimestampOutputParam(dataSource, bindingType, member, format);
         } else if (target instanceof BlobShape) {
             return getBlobOutputParam(bindingType, dataSource);
         } else if (target instanceof CollectionShape) {
@@ -2935,9 +2933,4 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             StructureShape error,
             List<HttpBinding> documentBindings
     );
-
-    /**
-     * @return true if this protocol disallows string epoch timestamps in payloads.
-     */
-    protected abstract boolean requiresNumericEpochSecondsInPayload();
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -88,44 +88,35 @@ public final class HttpProtocolGeneratorUtils {
      * Given a format and a source of data, generate an output value provider for the
      * timestamp.
      *
-     * @param writer The current writer (so that imports may be added)
      * @param dataSource The in-code location of the data to provide an output of
      *                   ({@code output.foo}, {@code entry}, etc.)
      * @param bindingType How this value is bound to the operation output.
      * @param shape The shape that represents the value being received.
      * @param format The timestamp format to provide.
-     * @param requireNumericEpochSecondsInPayload if true, paylaod epoch seconds are not allowed to be coerced
-     *                                            from strings.
      * @return Returns a value or expression of the output timestamp.
      */
-    public static String getTimestampOutputParam(TypeScriptWriter writer,
-                                                 String dataSource,
-                                                 Location bindingType,
-                                                 Shape shape,
-                                                 Format format,
-                                                 boolean requireNumericEpochSecondsInPayload) {
-        // This has always explicitly wrapped the dataSource in "new Date(..)", so it could never generate
-        // an expression that evaluates to null. Codegen relies on this.
-        writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
+    public static String getTimestampOutputParam(String dataSource, Location bindingType, Shape shape, Format format) {
+        String modifiedSource;
         switch (format) {
             case DATE_TIME:
-                writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime", "@aws-sdk/smithy-client");
-                return String.format("__expectNonNull(__parseRfc3339DateTime(%s))", dataSource);
             case HTTP_DATE:
-                writer.addImport("parseRfc7231DateTime", "__parseRfc7231DateTime", "@aws-sdk/smithy-client");
-                return String.format("__expectNonNull(__parseRfc7231DateTime(%s))", dataSource);
+                modifiedSource = dataSource;
+                break;
             case EPOCH_SECONDS:
-                writer.addImport("parseEpochTimestamp", "__parseEpochTimestamp", "@aws-sdk/smithy-client");
-                String modifiedDataSource = dataSource;
-                if (requireNumericEpochSecondsInPayload
-                        && (bindingType == Location.DOCUMENT || bindingType == Location.PAYLOAD)) {
-                    writer.addImport("expectNumber", "__expectNumber", "@aws-sdk/smithy-client");
-                    modifiedDataSource = String.format("__expectNumber(%s)", dataSource);
+                modifiedSource = dataSource;
+                // Make sure we turn a header, label, or query's forced string into a number.
+                if (bindingType.equals(Location.HEADER) || bindingType.equals(Location.QUERY)
+                        || bindingType.equals(Location.LABEL)) {
+                    modifiedSource = "parseInt(" + modifiedSource + ", 10)";
                 }
-                return String.format("__expectNonNull(__parseEpochTimestamp(%s))", modifiedDataSource);
+                // Convert whole and decimal numbers to milliseconds.
+                modifiedSource = "Math.round(" + modifiedSource + " * 1000)";
+                break;
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
         }
+
+        return "new Date(" + modifiedSource + ")";
     }
 
     /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.ByteShape;
@@ -32,10 +31,8 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
-import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
@@ -56,23 +53,14 @@ public class DocumentMemberDeserVisitorTest {
 
     @ParameterizedTest
     @MethodSource("validMemberTargetTypes")
-    public void providesExpectedDefaults(Shape shape, String expected, MemberShape memberShape) {
-        Shape fakeStruct = StructureShape.builder().id("com.smithy.example#Enclosing").addMember(memberShape).build();
-        mockContext.setModel(Model.builder().addShapes(shape, fakeStruct).build());
-        DocumentMemberDeserVisitor visitor =
-                new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT) {
-                    @Override
-                    protected MemberShape getMemberShape() {
-                        return memberShape;
-                    }
-                };
+    public void providesExpectedDefaults(Shape shape, String expected) {
+        DocumentMemberDeserVisitor visitor = new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT);
         assertThat(expected, equalTo(shape.accept(visitor)));
     }
 
     public static Collection<Object[]> validMemberTargetTypes() {
         String id = "com.smithy.example#Foo";
         String targetId = id + "Target";
-        MemberShape source = MemberShape.builder().id("com.smithy.example#Enclosing$sourceMember").target(id).build();
         MemberShape member = MemberShape.builder().id(id + "$member").target(targetId).build();
         MemberShape key = MemberShape.builder().id(id + "$key").target(targetId).build();
         MemberShape value = MemberShape.builder().id(id + "$value").target(targetId).build();
@@ -80,41 +68,25 @@ public class DocumentMemberDeserVisitorTest {
                 + "(" + DATA_SOURCE + ", context)";
 
         return ListUtils.of(new Object[][]{
-                {BooleanShape.builder().id(id).build(), "__expectBoolean(" + DATA_SOURCE + ")", source},
-                {ByteShape.builder().id(id).build(), "__expectByte(" + DATA_SOURCE + ")", source},
-                {DoubleShape.builder().id(id).build(), "__limitedParseDouble(" + DATA_SOURCE + ")", source},
-                {FloatShape.builder().id(id).build(), "__limitedParseFloat32(" + DATA_SOURCE + ")", source},
-                {IntegerShape.builder().id(id).build(), "__expectInt32(" + DATA_SOURCE + ")", source},
-                {LongShape.builder().id(id).build(), "__expectLong(" + DATA_SOURCE + ")", source},
-                {ShortShape.builder().id(id).build(), "__expectShort(" + DATA_SOURCE + ")", source},
-                {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")", source},
+                {BooleanShape.builder().id(id).build(), "__expectBoolean(" + DATA_SOURCE + ")"},
+                {ByteShape.builder().id(id).build(), "__expectByte(" + DATA_SOURCE + ")"},
+                {DoubleShape.builder().id(id).build(), "__limitedParseDouble(" + DATA_SOURCE + ")"},
+                {FloatShape.builder().id(id).build(), "__limitedParseFloat32(" + DATA_SOURCE + ")"},
+                {IntegerShape.builder().id(id).build(), "__expectInt32(" + DATA_SOURCE + ")"},
+                {LongShape.builder().id(id).build(), "__expectLong(" + DATA_SOURCE + ")"},
+                {ShortShape.builder().id(id).build(), "__expectShort(" + DATA_SOURCE + ")"},
+                {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")"},
                 {
                     StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                    "new __LazyJsonString(" + DATA_SOURCE + ")",
-                    source
+                    "new __LazyJsonString(" + DATA_SOURCE + ")"
                 },
-                {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")", source},
-                {DocumentShape.builder().id(id).build(), delegate, source},
-                {ListShape.builder().id(id).member(member).build(), delegate, source},
-                {SetShape.builder().id(id).member(member).build(), delegate, source},
-                {MapShape.builder().id(id).key(key).value(value).build(), delegate, source},
-                {StructureShape.builder().id(id).build(), delegate, source},
-                {UnionShape.builder().id(id).addMember(member).build(), delegate, source},
-                {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
-                    source
-                },
-                {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
-                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME)).build()
-                },
-                {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
-                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
-                },
+                {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")"},
+                {DocumentShape.builder().id(id).build(), delegate},
+                {ListShape.builder().id(id).member(member).build(), delegate},
+                {SetShape.builder().id(id).member(member).build(), delegate},
+                {MapShape.builder().id(id).key(key).value(value).build(), delegate},
+                {StructureShape.builder().id(id).build(), delegate},
+                {UnionShape.builder().id(id).addMember(member).build(), delegate},
         });
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -39,16 +39,13 @@ public class HttpProtocolGeneratorUtilsTest {
     @Test
     public void givesCorrectTimestampDeserialization() {
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
-        TypeScriptWriter writer = new TypeScriptWriter("foo");
 
-        assertThat("__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME, false)));
-        assertThat("__expectNonNull(__parseEpochTimestamp(__expectNumber(" + DATA_SOURCE + ")))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, true)));
-        assertThat("__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, false)));
-        assertThat("__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE, false)));
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME)));
+        assertThat("new Date(Math.round(" + DATA_SOURCE + " * 1000))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS)));
+        assertThat("new Date(" + DATA_SOURCE + ")",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE)));
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 885fec0c14387f627e01c18dd511b4a6949b1409.

*Description of changes:*
Temporary revert to unblock https://github.com/aws/aws-sdk-js-v3/pull/2759

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
