### PR TITLE
Use a very specific version of server-common

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -98,7 +98,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
 
     // Server dependency for SSDKs
-    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "^1.0.0-alpha.2", false);
+    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.0-alpha.2", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";


### PR DESCRIPTION
While the server-common package is in an alpha state, every bump can mean a breaking change. So this updates the resolved dependency to only pick a specific version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
