### PR TITLE
chore: downgrade typescript to ~4.3.5

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
-    "typescript": "~4.4.2"
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -13,8 +13,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/cjs",
-    "useUnknownInCatchVariables": false,
+    "outDir": "dist/cjs"
   },
   "typedocOptions": {
     "exclude": [


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2782

*Description of changes:*
Downgrade typescript to ~4.3.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
