### PR TITLE
Use base64 en/decoder from context in bindings

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1081,7 +1081,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case HEADER:
                 // Encode these to base64 if a MediaType is present.
                 if (target.hasTrait(MediaTypeTrait.ID)) {
-                    return "Buffer.from(" + baseParam + ").toString('base64')";
+                    return "context.base64Encoder(Buffer.from(" + baseParam + "))";
                 }
             default:
                 return baseParam;
@@ -2643,7 +2643,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         // Decode these to base64 if a MediaType is present.
         if (bindingType == Location.HEADER && target.hasTrait(MediaTypeTrait.ID)) {
-            dataSource = "Buffer.from(" + dataSource + ", 'base64').toString('ascii')";
+            dataSource = "Buffer.from(context.base64Decoder(" + dataSource + ")).toString('utf8')";
         }
 
         return HttpProtocolGeneratorUtils.getStringOutputParam(


### PR DESCRIPTION
This updates the http binding generator to use the context's http encoder / decoder for base64 rather than relying on Buffer's implementation. We do still use Buffer for converting between utf8 and Uint8Array though.

Codegen pr: https://github.com/aws/aws-sdk-js-v3/pull/2786


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
