### PR TITLE
chore: gitignore smithy-typescript-codegen/bin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ wrapper/
 smithy-typescript-integ-tests/dist
 smithy-typescript-integ-tests/node_modules
 smithy-typescript-integ-tests/yarn.lock
+
+# Issue https://github.com/awslabs/smithy-typescript/issues/425
+smithy-typescript-codegen/bin/


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/issues/425

*Description of changes:*
gitignore `smithy-typescript-codegen/bin/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
