### PR TITLE
feat: remove comments from transpiled JS files

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -70,8 +70,9 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
      */
     private static final Map<String, String> STATIC_FILE_COPIES = MapUtils.of(
             "jest.config.js", "jest.config.js",
+            "tsconfig.json", "tsconfig.json",
             "tsconfig.es.json", "tsconfig.es.json",
-            "tsconfig.json", "tsconfig.json"
+            "tsconfig.types.json", "tsconfig.types.json"
     );
     private static final ShapeId VALIDATION_EXCEPTION_SHAPE =
             ShapeId.fromParts("smithy.framework", "ValidationException");

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": [
       "dom",
       "es5",

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": [

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "declaration": false,
+    "declarationDir": null,
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.symbol.wellknown"
+    ],
+    "outDir": "dist/es"
+  }
+}

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.types.json
@@ -1,19 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "es5",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
-    "lib": [
-      "dom",
-      "es5",
-      "es2015.promise",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.symbol.wellknown"
-    ],
-    "outDir": "dist/es"
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/2797
Experimental PR in https://github.com/trivikr/temp-client-s3/pull/9

*Description of changes:*
Removes comments from transpiled JS files as follows:
* Sets `removeComments: true` for CJS and ES TSConfigs, and removes config to emit declaration files.
* Creates new `tsconfig.types.json` for emitting declaration files.
* Adds `build:types` script for generating types, and calls it from `build`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
