### PR TITLE
chore: remove redundant dot slash from typedocOptions

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -28,9 +28,9 @@
     "ignoreCompilerErrors": true,
     "includeDeclarations": true,
     "stripInternal": true,
-    "readme": "./README.md",
+    "readme": "README.md",
     "mode": "file",
-    "out": "./docs",
+    "out": "docs",
     "theme": "minimal",
     "plugin": ["@aws-sdk/client-documentation-generator"]
   }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2820

*Description of changes:*
Remove redundant dot slash from typedocOptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
