### PR TITLE
Better handling of Accept headers

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/accept.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/accept.spec.ts
@@ -1,0 +1,30 @@
+import { acceptMatches } from "./accept";
+
+describe("acceptMatches", () => {
+  it.each([null, undefined, "*/*"])("always returns true for %s", (value) => {
+    expect(acceptMatches(value, "text/plain")).toEqual(true);
+  });
+
+  it("handles explicit matches", () => {
+    expect(acceptMatches("text/plain", "text/plain")).toEqual(true);
+    expect(acceptMatches("text/plain; q=5", "text/plain")).toEqual(true);
+  });
+
+  it("handles wildcard subtypes", () => {
+    expect(acceptMatches("text/*", "text/plain")).toEqual(true);
+    expect(acceptMatches("text/*; q=5", "text/plain")).toEqual(true);
+  });
+
+  it("handles multiple acceptable values", () => {
+    expect(acceptMatches("application/json, text/plain; q=5", "text/plain")).toEqual(true);
+    expect(acceptMatches("application/json, text/*; q=5", "text/plain")).toEqual(true);
+    expect(acceptMatches("application/json, text/xml; q=5, */*", "text/plain")).toEqual(true);
+  });
+
+  it.each(["application/*", "application/json", "application/*; q=5; text/xml"])(
+    "does not match text/plain to %s",
+    (value) => {
+      expect(acceptMatches(value, "text/plain")).toEqual(false);
+    }
+  );
+});

--- a/smithy-typescript-ssdk-libs/server-common/src/accept.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/accept.ts
@@ -1,0 +1,26 @@
+/**
+ * A function for matching the 'Accept' header to an explicit MIME type.
+ *
+ * @param acceptHeader the header as specified by the caller
+ * @param responseContentType the content type that we expect to return
+ * @return true if the specified content-type is acceptable given the Accept value
+ */
+export const acceptMatches = (acceptHeader: string | null | undefined, responseContentType: string): boolean => {
+  if (acceptHeader === null || acceptHeader === undefined) {
+    return true;
+  }
+
+  // see: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+  // we only care if anything in Accept matches a content-type we want to respond with,
+  // so we disregard all of the accept-params
+  const acceptableContentTypes = acceptHeader.split(",").map((s) => s.split(";")[0].trim());
+  const responsePrimaryType = responseContentType.split("/")[0];
+
+  for (const type of acceptableContentTypes) {
+    if (type === "*/*" || type === `${responsePrimaryType}/*` || type === responseContentType) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -14,6 +14,7 @@
  */
 
 export * as httpbinding from "./httpbinding";
+export * from "./accept";
 export * from "./errors";
 export * from "./validation";
 


### PR DESCRIPTION
*Description of changes:*
Currently, we do an exact-match of the Accept header (if present) against the document media type for the protocol. Accept headers can be [much more complicated](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2) than a single media type, so we must parse it to be sure that the client cannot handle our preferred response type before sending a 406 response.

I tested this by regenerating and re-running the server protocol tests against the tip of the SDK's main. They pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
