### PR TITLE
fix(protocol-test): compare xml payload with outmost node

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -89,6 +89,14 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     }
 
     /**
+     * @return the member this visitor is being run against. Used to discover member-applied
+     * traits, such as @xmlName. Can be, and defaults, to, null.
+     */
+    protected MemberShape getMemberShape() {
+        return null;
+    }
+
+    /**
      * Gets the generation context.
      *
      * @return The generation context.

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -24,7 +24,7 @@ const compareEquivalentXmlBodies = (
       parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
       delete parsedObjToReturn[textNodeName];
     }
-    return parsedObjToReturn;
+    return parsedObj;
   };
 
   const expectedParts = parseXmlBody(expectedBody);


### PR DESCRIPTION
*Description of changes:*
Previously the protocol test won't throw if the xml payload's outmost node name is different. For example, it succeeded if payload is `<Hola><name>Phreddy</name></Hola>` but expected `<Hello><name>Phreddy</name></Hello>`. This change fixes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
