### PR TITLE
fix: move SSDK source code to 'src' folder

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -751,7 +751,8 @@ public final class HttpProtocolTestGenerator implements Runnable {
                         + " { return new TestSerializer(); };", serviceOperationsSymbol, serviceSymbol);
 
         writer.addImport("serializeFrameworkException", null,
-                "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
+                "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+                + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
         writer.write("const handler = new $T(service, testMux, serFn, serializeFrameworkException, "
                 + "(ctx: {}, f: __ValidationFailure[]) => { if (f) { throw f; } return undefined;});", handlerSymbol);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -86,7 +86,7 @@ final class IndexGenerator {
             writer.write("export * from \"./operations/$L\";", symbolProvider.toSymbol(operation).getName());
         }
         writer.write("export * from \"./$L\"", symbol.getName());
-        fileManifest.writeFile("server/index.ts", writer.toString());
+        fileManifest.writeFile(CodegenUtils.SOURCE_FOLDER + "/server/index.ts", writer.toString());
     }
 
     private static String getModulePath(String fileLocation) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -169,9 +169,11 @@ final class ServerCommandGenerator implements Runnable {
             String serializerFunction = ProtocolGenerator.getGenericSerFunctionName(operationSymbol) + "Response";
             String deserializerFunction = ProtocolGenerator.getGenericDeserFunctionName(operationSymbol) + "Request";
             writer.addImport(serializerFunction, null,
-                    "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
+                    "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+                    + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
             writer.addImport(deserializerFunction, null,
-                    "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
+                    "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+                    + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
             writer.write("serialize = $L;", serializerFunction);
             writer.write("deserialize = $L;", deserializerFunction);
             writer.write("");
@@ -222,7 +224,8 @@ final class ServerCommandGenerator implements Runnable {
         Symbol errorSymbol = symbolProvider.toSymbol(model.expectShape(errorId));
         String serializerFunction = ProtocolGenerator.getGenericSerFunctionName(errorSymbol) + "Error";
         writer.addImport(serializerFunction, null,
-                "./protocols/" + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
+                "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+                + ProtocolGenerator.getSanitizedName(protocolGenerator.getName()));
         writer.openBlock("case $S: {", "}", errorId.getName(), () -> {
             writer.write("return $L(error, ctx);", serializerFunction);
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java
@@ -118,8 +118,10 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
     }
 
     private Symbol.Builder createGeneratedSymbolBuilder(Shape shape, String typeName, String namespace) {
-        return createSymbolBuilder(shape, typeName, namespace)
-                .definitionFile(toFilename(namespace));
+        String prefixedNamespace = "./" + CodegenUtils.SOURCE_FOLDER
+            + (namespace.startsWith(".") ? namespace.substring(1) : namespace);
+        return createSymbolBuilder(shape, typeName, prefixedNamespace)
+                .definitionFile(toFilename(prefixedNamespace));
     }
 
     private Symbol.Builder createSymbolBuilder(Shape shape, String typeName, String namespace) {
@@ -137,9 +139,9 @@ final class ServerSymbolVisitor extends ShapeVisitor.Default<Symbol> implements 
 
         public String formatModuleName(Shape shape, String name) {
             if (shape.getType() == ShapeType.SERVICE) {
-                return "./server/" + name;
+                return "/server/" + name;
             } else if (shape.getType() == ShapeType.OPERATION) {
-                return "./server/operations/" + name;
+                return "/server/operations/" + name;
             }
 
             throw new IllegalArgumentException("Unsupported shape type: " + shape.getType());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -336,7 +336,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-                "./protocols/" + ProtocolGenerator.getSanitizedName(getName()));
+            "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+            + ProtocolGenerator.getSanitizedName(getName()));
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
@@ -390,7 +391,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-                "./protocols/" + ProtocolGenerator.getSanitizedName(getName()));
+                "./" + CodegenUtils.SOURCE_FOLDER + "/protocols/"
+                + ProtocolGenerator.getSanitizedName(getName()));
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes server protocol tests.
Example failure: https://github.com/aws/aws-sdk-js-v3/runs/3747465220

*Description of changes:*
Move SSDK source code to 'src' folder

*Testing:*

Verified that source files are generated in `"src"` folder and build is successful.

The tests fails with the following error, but it's unrelated to moving source code to 'src' folder in `protocol_tests/aws-restjson-server`
```console
lerna ERR! yarn run build exited 2 in '@aws-sdk/aws-restjson-server'
lerna ERR! yarn run build stdout:
$ yarn build:cjs && yarn build:es && yarn build:types
$ tsc -p tsconfig.json
src/protocols/Aws_restJson1.ts(38,3): error TS2305: Module '"@aws-smithy/server-common"' has no exported member 'acceptMatches'.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
