### PR TITLE
Update to Smithy 1.12.0

### DIFF
--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -19,7 +19,7 @@ extra["moduleName"] = "software.amazon.smithy.typescript.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 repositories {
@@ -29,6 +29,6 @@ repositories {
 
 dependencies {
     implementation(project(":smithy-typescript-codegen"))
-    implementation("software.amazon.smithy:smithy-waiters:[1.5.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.5.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-waiters:[1.12.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 2.0[")
 }

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -18,7 +18,7 @@ extra["displayName"] = "Smithy :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.typescript.codegen"
 
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.5.0, 2.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.5.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.5.0, 2.0[")
+    api("software.amazon.smithy:smithy-codegen-core:[1.12.0, 2.0[")
+    api("software.amazon.smithy:smithy-waiters:[1.12.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 2.0[")
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -262,7 +262,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         List<String> unvalidatedOperations = TopDownIndex.of(model)
                 .getContainedOperations(service)
                 .stream()
-                .filter(o -> operationIndex.getErrors(o).stream()
+                .filter(o -> operationIndex.getErrors(o, service).stream()
                                 .noneMatch(e -> e.getId().equals(VALIDATION_EXCEPTION_SHAPE)))
                 .map(s -> s.getId().toString())
                 .sorted()
@@ -467,12 +467,13 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     }
 
     private void generateServerErrors(ServiceShape service) {
+        final OperationIndex operationIndex = OperationIndex.of(model);
+
         TopDownIndex.of(model)
                 .getContainedOperations(service)
                 .stream()
-                .flatMap(o -> o.getErrors().stream())
+                .flatMap(o -> operationIndex.getErrors(o, service).stream())
                 .distinct()
-                .map(id -> model.expectShape(id).asStructureShape().orElseThrow(IllegalArgumentException::new))
                 .sorted()
                 .forEachOrdered(error -> writers.useShapeWriter(service, symbolProvider, writer -> {
                     new ServerErrorGenerator(settings, model, error, symbolProvider, writer).run();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -174,7 +174,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 }
             });
             // 3. Generate test cases for each error on each operation.
-            for (StructureShape error : operationIndex.getErrors(operation)) {
+            for (StructureShape error : operationIndex.getErrors(operation, service)) {
                 if (!error.hasTag("server-only")) {
                     error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
                         for (HttpResponseTestCase testCase : trait.getTestCasesFor(AppliesTo.CLIENT)) {
@@ -208,7 +208,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 }
             });
             // 3. Generate test cases for each error on each operation.
-            for (StructureShape error : operationIndex.getErrors(operation)) {
+            for (StructureShape error : operationIndex.getErrors(operation, service)) {
                 if (!error.hasTag("client-only")) {
                     error.getTrait(HttpResponseTestsTrait.class).ifPresent(trait -> {
                         for (HttpResponseTestCase testCase : trait.getTestCasesFor(AppliesTo.SERVER)) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -111,7 +111,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         // Get each structure that's used an error.
         OperationIndex operationIndex = OperationIndex.of(model);
         model.shapes(OperationShape.class).forEach(operationShape -> {
-            errorShapes.addAll(operationIndex.getErrors(operationShape));
+            errorShapes.addAll(operationIndex.getErrors(operationShape, settings.getService()));
         });
 
         moduleNameDelegator = new ModuleNameDelegator(shapeChunkSize);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.HttpBinding;
 import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.pattern.SmithyPattern.Segment;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -50,7 +51,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
@@ -519,9 +519,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         });
         writer.write("");
 
-        for (ShapeId errorShapeId : operation.getErrors()) {
-            serializingErrorShapes.add(context.getModel().expectShape(errorShapeId).asStructureShape().get());
-        }
+        serializingErrorShapes.addAll(OperationIndex.of(context.getModel()).getErrors(operation, context.getService()));
     }
 
     private void calculateContentLength(GenerationContext context) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -27,10 +27,12 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
@@ -321,6 +323,7 @@ public final class HttpProtocolGeneratorUtils {
     ) {
         TypeScriptWriter writer = context.getWriter();
         SymbolProvider symbolProvider = context.getSymbolProvider();
+        OperationIndex operationIndex = OperationIndex.of(context.getModel());
         Set<StructureShape> errorShapes = new TreeSet<>();
 
         Symbol symbol = symbolProvider.toSymbol(operation);
@@ -352,8 +355,8 @@ public final class HttpProtocolGeneratorUtils {
             errorCodeGenerator.accept(context);
             writer.openBlock("switch (errorCode) {", "}", () -> {
                 // Generate the case statement for each error, invoking the specific deserializer.
-                new TreeSet<>(operation.getErrors()).forEach(errorId -> {
-                    StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
+                new TreeSet<>(operationIndex.getErrors(operation, context.getService())).forEach(error -> {
+                    final ShapeId errorId = error.getId();
                     // Track errors bound to the operation so their deserializers may be generated.
                     errorShapes.add(error);
                     Symbol errorSymbol = symbolProvider.toSymbol(error);


### PR DESCRIPTION
*Description of changes:*
Even though smithy-ts technically would move automatically to Smithy 1.12.0,
this bumps up the minimum version in order to ensure the new getErrors method
on OperationIndex will be available at compile time. Discovery of operation
errors globally uses OperationIndex.getErrors(Operation, Service) in order
to support service-bound errors, which were introduced in 1.12.0.

Tested this by regenerating the JS SDK v3 and running protocol tests locally. PR for that repo to fast follow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
