### PR TITLE
Fix query parameters in SSDK

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -449,13 +449,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
         ObjectNode.Builder nodeBuilder = ObjectNode.objectNodeBuilder();
         for (Map.Entry<String, List<String>> entry : query.entrySet()) {
-            // The value of the query bag can either be a single string or a list, so we need to ensure individual
-            // values are written out as individual strings.
-            if (entry.getValue().size() == 1) {
-                nodeBuilder.withMember(entry.getKey(), StringNode.from(entry.getValue().get(0)));
-            } else {
-                nodeBuilder.withMember(entry.getKey(), ArrayNode.fromStrings(entry.getValue()));
-            }
+            nodeBuilder.withMember(entry.getKey(), ArrayNode.fromStrings(entry.getValue()));
         }
         return nodeBuilder.build();
     }


### PR DESCRIPTION
*Description of changes:*
Query parameters in protocol tests were being generated in a way that did not match how our APIGateway integration code would present them to our generated code. Query parameters are actually broken right now, but protocol tests do not detect this. These commits align our protocol test generation to how APIGateway treats query parameter values, and fixes code generation to handle them appropriately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
