### PR TITLE
Fix query matching against list query values

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
@@ -129,7 +129,12 @@ export class UriSpec<S extends string, O extends string> {
         return false;
       }
       if (querySegment.type === "query_literal") {
-        if (querySegment.value && querySegment.value !== req.query[querySegment.key]) {
+        const input_query_value = req.query[querySegment.key];
+        if (Array.isArray(input_query_value)) {
+          if (querySegment.value && !input_query_value.includes(querySegment.value)) {
+            return false;
+          }
+        } else if (querySegment.value && querySegment.value !== input_query_value) {
           return false;
         }
       }


### PR DESCRIPTION
*Description of changes:*
The existing code doesn't account for the fact that all query parameter values
can be multi-valued, even when there's only one value in the input URL. Also,
a query string literal can be satisfied by any of the values in the input URL,
whereas the existing code would insist that there exist no other value for the
key in the literal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
