### PR TITLE
Use 'test' as standard folder for tests (#435)

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class CodegenUtils {
 
     public static final String SOURCE_FOLDER = "src";
+    public static final String TEST_FOLDER = "test";
 
     private CodegenUtils() {}
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -409,7 +409,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
         String getHandlerName = "get" + handlerSymbol.getName();
         writer.addImport(getHandlerName, null,
-            Paths.get(".", CodegenUtils.SOURCE_FOLDER, ServerSymbolVisitor.SERVER_FOLDER).toString());
+            Paths.get(".", CodegenUtils.TEST_FOLDER, ServerSymbolVisitor.SERVER_FOLDER).toString());
 
         if (!usesDefaultValidation) {
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
@@ -747,7 +747,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                         + " { return new TestSerializer(); };", serviceOperationsSymbol, serviceSymbol);
 
         writer.addImport("serializeFrameworkException", null,
-            Paths.get(".", CodegenUtils.SOURCE_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
+            Paths.get(".", CodegenUtils.TEST_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
                 ProtocolGenerator.getSanitizedName(protocolGenerator.getName())).toString());
         writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
         writer.write("const handler = new $T(service, testMux, serFn, serializeFrameworkException, "


### PR DESCRIPTION
Issue #435 

Description of changes:
Creates a new constant for tests folder and utilizes that in `HttpProtocolTestGenerator` (Which does not to be used anywhere thus far)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
