### PR TITLE
Be more specific about Smithy versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ allprojects {
     version = "0.7.0"
 }
 
+extra["smithyVersion"] = "[1.12.0,1.13.0["
+
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false
 

--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -18,6 +18,16 @@ extra["moduleName"] = "software.amazon.smithy.typescript.codegen.test"
 
 tasks["jar"].enabled = false
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+    }
+}
+
+
 plugins {
     id("software.amazon.smithy").version("0.5.3")
 }
@@ -29,6 +39,6 @@ repositories {
 
 dependencies {
     implementation(project(":smithy-typescript-codegen"))
-    implementation("software.amazon.smithy:smithy-waiters:[1.12.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-waiters:${rootProject.extra["smithyVersion"]}")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
 }

--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -17,8 +17,18 @@ description = "Generates TypeScript code from Smithy models"
 extra["displayName"] = "Smithy :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.typescript.codegen"
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+    }
+}
+
+
 dependencies {
-    api("software.amazon.smithy:smithy-codegen-core:[1.12.0, 2.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.12.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 2.0[")
+    api("software.amazon.smithy:smithy-codegen-core:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-waiters:${rootProject.extra["smithyVersion"]}")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
 }


### PR DESCRIPTION
*Description of changes:*
Use a specific version of smithy-cli, and restrict Smithy versions to the
bugfix version range of 1.12, instead of any minor version of 1, so that we
don't introduce mismatches in the Smithy version downstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
