### PR TITLE
feat: support @httpApiKeyAuth trait

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add config and middleware to support a service with the @httpApiKeyAuth trait.
+ */
+@SmithyInternalApi
+public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
+
+    /**
+     * Plug into code generation for the client.
+     *
+     * This adds the configuration items to the client config and plugs in the
+     * middleware to operations that need it.
+     *
+     * The middleware will inject the client's configured API key into the
+     * request as defined by the @httpApiKeyAuth trait. If the trait says to
+     * put the API key into a named header, that header will be used, optionally
+     * prefixed with a scheme. If the trait says to put the API key into a named
+     * query parameter, that query parameter will be used.
+     */
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return ListUtils.of(
+            // Add the config if the service uses HTTP API key authorization.
+            RuntimeClientPlugin.builder()
+                    .inputConfig(Symbol.builder()
+                            .namespace("./" + CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth", "/")
+                            .name("HttpApiKeyAuthInputConfig")
+                            .build())
+                    .resolvedConfig(Symbol.builder()
+                            .namespace("./" + CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth", "/")
+                            .name("HttpApiKeyAuthResolvedConfig")
+                            .build())
+                    .resolveFunction(Symbol.builder()
+                            .namespace("./" + CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth", "/")
+                            .name("resolveHttpApiKeyAuthConfig")
+                            .build())
+                    .servicePredicate((m, s) -> hasEffectiveHttpApiKeyAuthTrait(m, s))
+                    .build(),
+
+            // Add the middleware to operations that use HTTP API key authorization.
+            RuntimeClientPlugin.builder()
+                    .pluginFunction(Symbol.builder()
+                            .namespace("./" + CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth", "/")
+                            .name("getHttpApiKeyAuthPlugin")
+                            .build())
+                    .additionalPluginFunctionParamsSupplier((m, s, o) -> new HashMap<String, Object>() {{
+                            // It's safe to do expectTrait() because the operation predicate ensures that the trait
+                            // exists `in` and `name` are required attributes of the trait, `scheme` is optional.
+                            put("in", s.expectTrait(HttpApiKeyAuthTrait.class).getIn().toString());
+                            put("name", s.expectTrait(HttpApiKeyAuthTrait.class).getName());
+                            s.expectTrait(HttpApiKeyAuthTrait.class).getScheme().ifPresent(scheme ->
+                                    put("scheme", scheme));
+                    }})
+                    .operationPredicate((m, s, o) -> ServiceIndex.of(m).getEffectiveAuthSchemes(s, o)
+                            .keySet()
+                            .contains(HttpApiKeyAuthTrait.ID)
+                            && !o.hasTrait(OptionalAuthTrait.class))
+                    .build()
+        );
+    }
+
+    @Override
+    public void writeAdditionalFiles(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory
+    ) {
+        ServiceShape service = settings.getService(model);
+
+        // If the service doesn't use HTTP API keys, we don't need to do anything and the generated
+        // code doesn't need any additional files.
+        if (!hasEffectiveHttpApiKeyAuthTrait(model, service)) {
+            return;
+        }
+
+        String noTouchNoticePrefix = "// Please do not touch this file. It's generated from a template in:\n"
+                + "// https://github.com/awslabs/smithy-typescript/blob/main/smithy-typescript-codegen/"
+                + "src/main/resources/software/amazon/smithy/aws/typescript/codegen/integration/";
+
+        // Write the middleware source.
+        writerFactory.accept(
+                Paths.get(CodegenUtils.SOURCE_FOLDER, "middleware", "HttpApiKeyAuth", "index.ts").toString(),
+                writer -> {
+                        String source = IoUtils.readUtf8Resource(getClass(), "http-api-key-auth.ts");
+                        writer.write("$L$L", noTouchNoticePrefix, "http-api-key-auth.ts");
+                        writer.write("$L", source);
+                });
+
+        // Write the middleware tests.
+        writerFactory.accept(
+                Paths.get(CodegenUtils.SOURCE_FOLDER, "middleware", "HttpApiKeyAuth", "index.spec.ts").toString(),
+                writer -> {
+                        String source = IoUtils.readUtf8Resource(getClass(), "http-api-key-auth.spec.ts");
+                        writer.write("$L$L", noTouchNoticePrefix, "http-api-key-auth.spec.ts");
+                        writer.write("$L", source);
+                });
+    }
+
+    // The service has the effective trait if it's in the "effective auth schemes" response
+    // AND if not all of the operations have the optional auth trait.
+    private static boolean hasEffectiveHttpApiKeyAuthTrait(Model model, ServiceShape service) {
+        return ServiceIndex.of(model).getEffectiveAuthSchemes(service)
+                .keySet()
+                .contains(HttpApiKeyAuthTrait.ID)
+                && !areAllOptionalAuthOperations(model, service);
+    }
+
+
+    // This is derived from https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java.
+    private static boolean areAllOptionalAuthOperations(Model model, ServiceShape service) {
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
+        ServiceIndex index = ServiceIndex.of(model);
+
+        for (OperationShape operation : operations) {
+            if (index.getEffectiveAuthSchemes(service, operation).isEmpty()
+                    || !operation.hasTrait(OptionalAuthTrait.class)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
@@ -129,6 +130,12 @@ public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
         writerFactory.accept(
                 Paths.get(CodegenUtils.SOURCE_FOLDER, "middleware", "HttpApiKeyAuth", "index.spec.ts").toString(),
                 writer -> {
+                        writer.addDependency(SymbolDependency.builder()
+                                .dependencyType("devDependencies")
+                                .packageName("@types/jest")
+                                .version("latest")
+                                .build());
+
                         String source = IoUtils.readUtf8Resource(getClass(), "http-api-key-auth.spec.ts");
                         writer.write("$L$L", noTouchNoticePrefix, "http-api-key-auth.spec.ts");
                         writer.write("$L", source);

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,2 +1,3 @@
 software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
+software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
@@ -1,0 +1,172 @@
+import {
+  getHttpApiKeyAuthPlugin,
+  httpApiKeyAuthMiddleware,
+  resolveHttpApiKeyAuthConfig,
+} from "./index";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+describe("resolveHttpApiKeyAuthConfig", () => {
+  it("should return the input unchanged", () => {
+    const config = {
+      apiKey: "exampleApiKey",
+    };
+    expect(resolveHttpApiKeyAuthConfig(config)).toEqual(config);
+  });
+});
+
+describe("getHttpApiKeyAuthPlugin", () => {
+  it("should apply the middleware to the stack", () => {
+    const plugin = getHttpApiKeyAuthPlugin(
+      {
+        apiKey: "exampleApiKey",
+      },
+      {
+        in: "query",
+        name: "key",
+      }
+    );
+
+    const mockAdd = jest.fn();
+    const mockOther = jest.fn();
+
+    // TODO there's got to be a better way to do this mocking
+    plugin.applyToStack({
+      add: mockAdd,
+      // We don't expect any of these others to be called.
+      addRelativeTo: mockOther,
+      concat: mockOther,
+      resolve: mockOther,
+      applyToStack: mockOther,
+      use: mockOther,
+      clone: mockOther,
+      remove: mockOther,
+      removeByTag: mockOther,
+    });
+
+    expect(mockAdd.mock.calls.length).toEqual(1);
+    expect(mockOther.mock.calls.length).toEqual(0);
+  });
+});
+
+describe("httpApiKeyAuthMiddleware", () => {
+  describe("returned middleware function", () => {
+    const mockNextHandler = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should set the query parameter if the location is `query`", async () => {
+      const middleware = httpApiKeyAuthMiddleware(
+        {
+          apiKey: "exampleApiKey",
+        },
+        {
+          in: "query",
+          name: "key",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(
+        mockNextHandler.mock.calls[0][0].request.query.key
+      ).toBe("exampleApiKey");
+    });
+
+    it("should throw an error if the api key has not been set", async () => {
+      const middleware = httpApiKeyAuthMiddleware(
+        {},
+        {
+          in: "header",
+          name: "auth",
+          scheme: "scheme",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await expect(
+        handler({
+          input: {},
+          request: new HttpRequest({}),
+        })
+      ).rejects.toThrow("no API key was provided");
+
+      expect(mockNextHandler.mock.calls.length).toEqual(0);
+    });
+
+    it("should skip if the request is not an HttpRequest", async () => {
+      const middleware = httpApiKeyAuthMiddleware(
+        {},
+        {
+          in: "header",
+          name: "Authorization",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: {},
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+    });
+
+    it("should set the API key in the lower-cased named header", async () => {
+      const middleware = httpApiKeyAuthMiddleware(
+        {
+          apiKey: "exampleApiKey",
+        },
+        {
+          in: "header",
+          name: "Authorization",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(
+        mockNextHandler.mock.calls[0][0].request.headers.authorization
+      ).toBe("exampleApiKey");
+    });
+
+    it("should set the API key in the named header with the provided scheme", async () => {
+      const middleware = httpApiKeyAuthMiddleware(
+        {
+          apiKey: "exampleApiKey",
+        },
+        {
+          in: "header",
+          name: "authorization",
+          scheme: "exampleScheme",
+        }
+      );
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(
+        mockNextHandler.mock.calls[0][0].request.headers.authorization
+      ).toBe("exampleScheme exampleApiKey");
+    });
+  });
+});

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
@@ -80,7 +80,7 @@ describe("httpApiKeyAuthMiddleware", () => {
       ).toBe("exampleApiKey");
     });
 
-    it("should throw an error if the api key has not been set", async () => {
+    it("should skip if the api key has not been set", async () => {
       const middleware = httpApiKeyAuthMiddleware(
         {},
         {
@@ -92,14 +92,12 @@ describe("httpApiKeyAuthMiddleware", () => {
 
       const handler = middleware(mockNextHandler, {});
 
-      await expect(
-        handler({
-          input: {},
-          request: new HttpRequest({}),
-        })
-      ).rejects.toThrow("no API key was provided");
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
 
-      expect(mockNextHandler.mock.calls.length).toEqual(0);
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
     });
 
     it("should skip if the request is not an HttpRequest", async () => {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
@@ -83,10 +83,10 @@ export const httpApiKeyAuthMiddleware =
     if (!HttpRequest.isInstance(args.request)) return next(args);
 
     // This middleware will not be injected if the operation has the @optionalAuth trait.
+    // We don't know if we're the only auth middleware, so let the service deal with the
+    // absence of the API key (or let other middleware do its job).
     if (!pluginConfig.apiKey) {
-      throw new Error(
-        "API key authorization is required but no API key was provided in the client configuration"
-      );
+      return next(args);
     }
 
     return next({

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
+
+public class AddHttpApiKeyAuthPluginTest {
+    @Test
+    public void httpApiKeyAuthClientOnService() {
+        testInjects("http-api-key-auth-trait.smithy", ", { scheme: 'ApiKey', in: 'header', name: 'Authorization'}");
+    }
+
+    @Test
+    public void httpApiKeyAuthClientOnOperation() {
+        testInjects("http-api-key-auth-trait-on-operation.smithy",
+                ", { scheme: 'ApiKey', in: 'header', name: 'Authorization'}");
+    }
+
+    // This should be identical to the httpApiKeyAuthClient test except for the parameters provided
+    // to the middleware.
+    @Test
+    public void httpApiKeyAuthClientNoScheme() {
+        testInjects("http-api-key-auth-trait-no-scheme.smithy", ", { in: 'header', name: 'Authorization'}");
+    }
+
+    private void testInjects(String filename, String extra) {
+        MockManifest manifest = generate(filename);
+
+        // Ensure that the client imports the config properly and calls the resolve function.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts").get(),
+                containsString("from \"./middleware/HttpApiKeyAuth\""));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts").get(),
+                containsString("= resolveHttpApiKeyAuthConfig("));
+
+        // Ensure that the GetFoo operation imports the middleware and uses it with all the options.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetFooCommand.ts").get(),
+                containsString("from \"../middleware/HttpApiKeyAuth\""));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetFooCommand.ts").get(),
+                containsString("this.middlewareStack.use(getHttpApiKeyAuthPlugin(configuration" + extra + "));"));
+
+        // Ensure that the GetBar operation does not import the middleware or use it.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetBarCommand.ts").get(),
+                not(containsString("from \"../middleware/HttpApiKeyAuth\"")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetBarCommand.ts").get(),
+                not(containsString("this.middlewareStack.use(getHttpApiKeyAuthPlugin")));
+
+        // Make sure that the middleware file was written and exports the plugin symbol.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth/index.ts").get(),
+                containsString("export const getHttpApiKeyAuthPlugin"));
+    }
+
+    private MockManifest generate(String filename)
+    {
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .pluginClassLoader(getClass().getClassLoader())
+                .model(Model.assembler()
+                        .addImport(getClass().getResource(filename))
+                        .discoverModels()
+                        .assemble()
+                        .unwrap())
+                .fileManifest(manifest)
+                .settings(Node.objectNodeBuilder()
+                        .withMember("service", Node.from("smithy.example#Example"))
+                        .withMember("package", Node.from("example"))
+                        .withMember("packageVersion", Node.from("1.0.0"))
+                        .build())
+                .build();
+
+        new TypeScriptCodegenPlugin().execute(context);
+
+        return manifest;
+    }
+
+    @Test
+    public void notAnHttpApiKeyAuthClient() {
+        testDoesNotInject("endpoint-trait.smithy");
+    }
+
+    @Test
+    public void httpApiKeyAuthClientWithAllOptionalAuthOperations() {
+        testDoesNotInject("http-api-key-auth-trait-all-optional.smithy");
+    }
+
+    private void testDoesNotInject(String filename) {
+        MockManifest manifest = generate(filename);
+
+        // Make sure that the config and middleware were not added to the client.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts").get(),
+                not(containsString("= resolveHttpApiKeyAuthConfig(")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts").get(),
+                not(containsString("from \"./middleware/HttpApiKeyAuth\"")));
+
+        // Make sure that the import and middleware were not used in the operation.
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetFooCommand.ts").get(),
+                not(containsString("from \"../middleware/HttpApiKeyAuth\"")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/commands/GetFooCommand.ts").get(),
+                not(containsString("this.middlewareStack.use(getHttpApiKeyAuthPlugin(configuration")));
+
+        // Make sure that the middleware file was not written.
+        assertThat(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/middleware/HttpApiKeyAuth/index.ts"),
+                is(false));
+    }
+}

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-all-optional.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-all-optional.smithy
@@ -1,0 +1,40 @@
+namespace smithy.example
+
+// This test input is used to validate that the generated client properly injects
+// the HTTP API key authentication middleware with the correct options.
+//
+// In this case the operations all have the `@optionalAuth` trait, so the middleware
+// should not be injected at all.
+
+@httpApiKeyAuth(in: "header", name: "Authorization", scheme: "ApiKey")
+service Example {
+    version: "2019-10-15",
+    operations: [GetFoo, GetBar]
+}
+
+@optionalAuth
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}
+
+@optionalAuth
+operation GetBar {
+    input: GetBarInput,
+    output: GetBarOutput,
+    errors: [GetBarError]
+}
+
+structure GetBarInput {}
+structure GetBarOutput {}
+
+@error("client")
+structure GetBarError {}
+

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-no-scheme.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-no-scheme.smithy
@@ -1,0 +1,39 @@
+namespace smithy.example
+
+// This test input is used to validate that the generated client properly injects
+// the HTTP API key authentication middleware with the correct options.
+//
+// In this case the options should not include the `scheme` attribute.
+
+@httpApiKeyAuth(in: "header", name: "Authorization")
+@auth([httpApiKeyAuth])
+service Example {
+    version: "2019-10-15",
+    operations: [GetFoo, GetBar]
+}
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}
+
+@optionalAuth
+operation GetBar {
+    input: GetBarInput,
+    output: GetBarOutput,
+    errors: [GetBarError]
+}
+
+structure GetBarInput {}
+structure GetBarOutput {}
+
+@error("client")
+structure GetBarError {}
+

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-on-operation.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait-on-operation.smithy
@@ -1,0 +1,39 @@
+namespace smithy.example
+
+// This test input is used to validate that the generated client properly injects
+// the HTTP API key authentication middleware with the correct options.
+//
+// In this scenario the `@auth` trait is on the operation rather than the service.
+
+@httpApiKeyAuth(in: "header", name: "Authorization", scheme: "ApiKey")
+service Example {
+    version: "2019-10-15",
+    operations: [GetFoo, GetBar]
+}
+
+@auth([httpApiKeyAuth])
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}
+
+@optionalAuth
+operation GetBar {
+    input: GetBarInput,
+    output: GetBarOutput,
+    errors: [GetBarError]
+}
+
+structure GetBarInput {}
+structure GetBarOutput {}
+
+@error("client")
+structure GetBarError {}
+

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth-trait.smithy
@@ -1,0 +1,40 @@
+namespace smithy.example
+
+// This test input is used to validate that the generated client properly injects
+// the HTTP API key authentication middleware with the correct options.
+//
+// In this scenario the `@auth` trait is on the service and therefore applies to
+// all operations except operations with the `@optionalAuth` trait.
+
+@httpApiKeyAuth(in: "header", name: "Authorization", scheme: "ApiKey")
+@auth([httpApiKeyAuth])
+service Example {
+    version: "2019-10-15",
+    operations: [GetFoo, GetBar]
+}
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput,
+    errors: [GetFooError]
+}
+
+structure GetFooInput {}
+structure GetFooOutput {}
+
+@error("client")
+structure GetFooError {}
+
+@optionalAuth
+operation GetBar {
+    input: GetBarInput,
+    output: GetBarOutput,
+    errors: [GetBarError]
+}
+
+structure GetBarInput {}
+structure GetBarOutput {}
+
+@error("client")
+structure GetBarError {}
+


### PR DESCRIPTION
*Issue #, if available:* Fixes #453.

*Description of changes:* This adds codegen support for services and operations that use the `@httpApiKeyAuth` trait.

The generated client will have a new `apiKey` config attribute. This value will be injected into the header/query parameter that's specified in the trait by new middleware that's included in the codegen client.

⚠️ I've done my best to base this on existing patterns but I'm sure that there will be comments and things that need to change. Please let me know and I'll happily make adjustments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.