### PR TITLE
feat(codegen): add a default prepack script

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -9,7 +9,8 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "clean": "rimraf ./dist-*"
+    "clean": "rimraf ./dist-*",
+    "prepack": "${packageManager} clean && ${packageManager} build"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",


### PR DESCRIPTION
*Description of changes:*
Doing a clean build in prepack works for both package managers and makes a
simple process of codegen && (npm|yarn) publish work out of the box. Also
adds an "omitPrepack" configuration option to allow the SDK to disable this
script for backwards compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
