### PR TITLE
chore(package.json): bump engines to node >=12.0.0

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -30,7 +30,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {


### PR DESCRIPTION
*Issue #, if available:*
We announced [the end of support for Node.js 10.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-10-x-in-the-aws-sdk-for-javascript-v3/) starting January 1, 2022 back in July.

*Description of changes:*
Bump engines to node >=12.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
