### PR TITLE
chore: move typedocOptions to typedoc.json

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -70,6 +70,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
      * A mapping of static resource files to copy over to a new filename.
      */
     private static final Map<String, String> STATIC_FILE_COPIES = MapUtils.of(
+            "typedoc.json", "typedoc.json",
             "tsconfig.json", "tsconfig.json",
             "tsconfig.es.json", "tsconfig.es.json",
             "tsconfig.types.json", "tsconfig.types.json"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -14,25 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": [
-      "**/node_modules/**",
-      "**/*.spec.ts",
-      "**/protocols/*.ts",
-      "**/e2e/*.ts",
-      "**/endpoints.ts"
-    ],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/typedoc.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/typedoc.json
@@ -1,0 +1,20 @@
+{
+  "exclude": [
+    "**/node_modules/**",
+    "**/*.spec.ts",
+    "**/protocols/*.ts",
+    "**/e2e/*.ts",
+    "**/endpoints.ts"
+  ],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}


### PR DESCRIPTION
*Issue #, if available:*
Part of using root tsconfig for all clients in aws-sdk-js-v3
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1307

*Description of changes:*
Moves typedocOptions to typedoc.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
