### PR TITLE
chore: do not clean docs during build

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "${packageManager} build:cjs && ${packageManager} build:es && ${packageManager} build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "${packageManager} clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "${packageManager} clean:dist && ${packageManager} clean:docs",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3138#issuecomment-1005861884

*Description of changes:*
The `build:docs` command now calls typedoc directly, so that it can be used in internal release automation.

Reasons for removing clean:docs call:
* The build:docs command should do work only what it's asked to do. Cleaning docs is an additional work.
* The docs may not have been generated in the default docs folder. We'll decide later if `clean:docs` script should be removed altogether.
* The typedoc dependency is being moved to root package.json in https://github.com/aws/aws-sdk-js-v3/pull/3138, so typedoc will not be available in node_modules for each client and they need to use `build:docs` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
