### PR TITLE
chore: rename downlevel-dts to build:types:downlevel

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -8,10 +8,10 @@
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "${packageManager} clean:dist && ${packageManager} clean:docs",
     "clean:dist": "rimraf ./dist-*",
-    "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
+    "clean:docs": "rimraf ./docs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*
Internal discussion on Slack

*Description of changes:*
Renames npm script `downlevel-dts` to `build:types:downlevel`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
