### PR TITLE
chore: use clean to remove dist-* folders

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -9,9 +9,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "clean": "${packageManager} clean:dist && ${packageManager} clean:docs",
-    "clean:dist": "rimraf ./dist-*",
-    "clean:docs": "rimraf ./docs"
+    "clean": "rimraf ./dist-*"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",


### PR DESCRIPTION
*Issue #, if available:*
Internal discussions on Slack.

Reasons for update:
* We don't use `clean:docs` command in clients in aws-sdk-js-v3 repo.
* We do not have any clean commands in non-clients.
* The docs may have been created in a different folder.

Ideally, the typedoc script should clean the folder used for docs be default, or provide an option or plugin to perform that function (like webpack does). Follow-up feature request created at https://github.com/aws/aws-sdk-js-v3/issues/3167

*Description of changes:*
Use clean to remove dist-* folders

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
