### PR TITLE
chore: remove filterSensitiveLog for service exceptions

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -168,10 +168,6 @@ final class StructureGenerator implements Runnable {
      *   $fault: "client";
      *   resourceType: string | undefined;
      * }
-     *
-     * export namespace NoSuchResource {
-     *   export const filterSensitiveLog = (obj: NoSuchResource): any => ({...obj});
-     * }
      * }</pre>
      */
     private void renderErrorStructure() {
@@ -197,7 +193,6 @@ final class StructureGenerator implements Runnable {
         structuredMemberWriter.writeMembers(writer, shape);
         writer.closeBlock("}"); // interface
         writer.write("");
-        renderStructureNamespace(structuredMemberWriter, false);
     }
 
     private void renderStructureNamespace(StructuredMemberWriter structuredMemberWriter, boolean includeValidation) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.LengthTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
@@ -163,6 +164,9 @@ final class StructuredMemberWriter {
         } else if (structureTarget.hasTrait(StreamingTrait.class) && structureTarget.isUnionShape()) {
             // disable logging for StreamingTrait
             writer.write("'STREAMING_CONTENT'");
+        } else if (structureTarget.hasTrait(ErrorTrait.class)) {
+            // Sensitive logs are not filtered from errors.
+            writer.write("$L", structureParam);
         } else {
             // Call filterSensitiveLog on Structure.
             writer.write("$T.filterSensitiveLog($L)", symbolProvider.toSymbol(structureTarget), structureParam);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -481,7 +481,6 @@ public class StructureGeneratorTest {
         String contents = testStructureCodegen(file, expectedType);
 
         assertThat(contents, containsString("as __SmithyException"));
-        assertThat(contents, containsString("namespace Err {"));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3090

*Description of changes:*
Removes emission for filterSensitiveLog for service exceptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
