### PR TITLE
chore: support delegation of determining errors for an operation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2044,7 +2044,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation);
+                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -373,7 +373,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation);
+                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -262,6 +263,17 @@ public interface ProtocolGenerator {
             default:
                 return symbol.getName();
         }
+    }
+
+    /**
+     * Returns a map of error names to their {@link ShapeId}.
+     *
+     * @param context the generation context
+     * @param operation the operation shape to retrieve errors for
+     * @return map of error names to {@link ShapeId}
+     */
+    default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
+        return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2681
Similar to https://github.com/aws/smithy-go/pull/304

*Description of changes:*
Supports delegation of determining errors for an operation, needed to support [awsQueryError](https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#aws-protocols-awsqueryerror-trait) trait

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
