### PR TITLE
chore: check for ErrorName to be thrown in protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -761,8 +761,6 @@ public final class HttpProtocolTestGenerator implements Runnable {
             StructureShape error,
             HttpResponseTestCase testCase
     ) {
-        Symbol errorSymbol = symbolProvider.toSymbol(error);
-
         // Use a compound test_case name so we generate unique tests
         // for each error on each operation safely. This is useful in validating
         // that operation parsers are all correctly identifying errors and that
@@ -776,12 +774,12 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  if (err.name !== \"$T\") {\n"
+                       + "  if (err.name !== \"$1L\") {\n"
                        + "    console.log(err);\n"
-                       + "    fail(`Expected a $L to be thrown, got $${err.name} instead`);\n"
+                       + "    fail(`Expected a $1L to be thrown, got $${err.name} instead`);\n"
                        + "    return;\n"
                        + "  }\n"
-                       + "  const r: any = err;", errorSymbol, error.getId().getName())
+                       + "  const r: any = err;", error.getId().getName())
                     .indent()
                     .call(() -> writeResponseAssertions(error, testCase))
                     .write("return;")


### PR DESCRIPTION
*Issue #, if available:*
Improvement noticed while investigating https://github.com/aws/aws-sdk-js-v3/pull/3174

*Description of changes:*
 Check for ErrorName to be thrown in protocol tests, thus removing unused imports

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
