### PR TITLE
chore: explicitly pass maven uri in repositories

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,8 @@ include(":smithy-typescript-codegen-test")
 pluginManagement {
     repositories {
         mavenLocal()
-        gradlePluginPortal()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
CI is failing https://github.com/aws/aws-sdk-js-v3/runs/4794293011

*Description of changes:*
Explicitly pass maven uri in repositories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
