### PR TITLE
Revert support delegation of determining errors for an operation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2044,7 +2044,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
+                isErrorCodeInBody, this::getErrorBodyLocation);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -16,21 +16,18 @@
 package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
+import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -314,7 +311,6 @@ public final class HttpProtocolGeneratorUtils {
      * @param errorCodeGenerator A consumer
      * @param shouldParseErrorBody Flag indicating whether need to parse response body in this dispatcher function
      * @param bodyErrorLocationModifier A function that returns the location of an error in a body given a data source.
-     * @param operationErrorsToShapes A map of error names to their {@link ShapeId}.
      * @return A set of all error structure shapes for the operation that were dispatched to.
      */
     static Set<StructureShape> generateErrorDispatcher(
@@ -323,11 +319,11 @@ public final class HttpProtocolGeneratorUtils {
             SymbolReference responseType,
             Consumer<GenerationContext> errorCodeGenerator,
             boolean shouldParseErrorBody,
-            BiFunction<GenerationContext, String, String> bodyErrorLocationModifier,
-            BiFunction<GenerationContext, OperationShape, Map<String, ShapeId>> operationErrorsToShapes
+            BiFunction<GenerationContext, String, String> bodyErrorLocationModifier
     ) {
         TypeScriptWriter writer = context.getWriter();
         SymbolProvider symbolProvider = context.getSymbolProvider();
+        OperationIndex operationIndex = OperationIndex.of(context.getModel());
         Set<StructureShape> errorShapes = new TreeSet<>();
 
         Symbol symbol = symbolProvider.toSymbol(operation);
@@ -359,14 +355,14 @@ public final class HttpProtocolGeneratorUtils {
             errorCodeGenerator.accept(context);
             writer.openBlock("switch (errorCode) {", "}", () -> {
                 // Generate the case statement for each error, invoking the specific deserializer.
-                operationErrorsToShapes.apply(context, operation).forEach((name, errorId) -> {
-                    StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
+                new TreeSet<>(operationIndex.getErrors(operation, context.getService())).forEach(error -> {
+                    final ShapeId errorId = error.getId();
                     // Track errors bound to the operation so their deserializers may be generated.
                     errorShapes.add(error);
                     Symbol errorSymbol = symbolProvider.toSymbol(error);
                     String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
                             context.getProtocolName()) + "Response";
-                    writer.openBlock("case $S:\ncase $S:", "  break;", name, errorId.toString(), () -> {
+                    writer.openBlock("case $S:\ncase $S:", "  break;", errorId.getName(), errorId.toString(), () -> {
                         // Dispatch to the error deserialization function.
                         String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
                         writer.openBlock("response = {", "}", () -> {
@@ -447,25 +443,5 @@ public final class HttpProtocolGeneratorUtils {
                 writer.write("throw new Error(\"ValidationError: prefixed hostname must be hostname compatible.\");");
             });
         });
-    }
-
-    /**
-     * Returns a map of error names to their {@link ShapeId}.
-     *
-     * @param context   the generation context
-     * @param operation the operation shape to retrieve errors for
-     * @return map of error names to {@link ShapeId}
-     */
-    public static Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
-        return operation.getErrors().stream()
-                .collect(Collectors.toMap(
-                        shapeId -> shapeId.getName(context.getService()),
-                        Function.identity(),
-                        (x, y) -> {
-                            if (!x.equals(y)) {
-                                throw new CodegenException(String.format("conflicting error shape ids: %s, %s", x, y));
-                            }
-                            return x;
-                        }, TreeMap::new));
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -373,7 +373,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
+                isErrorCodeInBody, this::getErrorBodyLocation);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -263,17 +262,6 @@ public interface ProtocolGenerator {
             default:
                 return symbol.getName();
         }
-    }
-
-    /**
-     * Returns a map of error names to their {@link ShapeId}.
-     *
-     * @param context the generation context
-     * @param operation the operation shape to retrieve errors for
-     * @return map of error names to {@link ShapeId}
-     */
-    default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
-        return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3027

This code change surfaced a bug in our error deserializer, where the error message is modeled to be in key `message` but the actual message is response payload with key `Message`.

*Description of changes:*
This reverts commit a56d3525d6617a5a205a4fca04872cafbfb7eaff added in https://github.com/awslabs/smithy-typescript/pull/489.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
