### PR TITLE
Add contextual keywords to the reserved words list

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words.txt
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/reserved-words.txt
@@ -26,7 +26,7 @@
 # continue to prefix the word with "_" until it's no longer considered
 # reserved.
 #
-# See: https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#221-reserved-words
+# See: https://github.com/Microsoft/TypeScript/blob/main/src/compiler/types.ts#L113
 
 # Reserved and cannot be used as identifiers
 break
@@ -66,7 +66,7 @@ void
 while
 with
 
-# Not valid for identifiers
+# Not valid for identifiers (strict mode reserved words)
 implements
 interface
 let
@@ -76,6 +76,35 @@ protected
 public
 static
 yield
+
+# contextual keywords
+abstract
+as
+asserts
+assert
+any
+async
+await
+constructor
+declare
+get
+infer
+intrinsic
+is
+keyof
+module
+namespace
+never
+readonly
+require
+type
+undefined
+unique
+unknown
+from
+global
+override
+of
 
 # Not valid for user defined type names.
 any


### PR DESCRIPTION
*Description of changes:*
This extends the reserved words list to include the words included in the "contextual keywords" list of the TypeScript grammar. It does not change generation of any of the existing AWS SDKs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
