### PR TITLE
Fix the implementation of length validation for strings

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -114,6 +114,10 @@ describe("length validation", () => {
       });
     });
   }
+
+  it("properly assesses string length", () => {
+    expect(new LengthValidator(3, 3).validate("👍👍👍", "threeEmojis")).toBeNull();
+  });
 });
 
 describe("pattern validation", () => {

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -174,7 +174,7 @@ export class EnumValidator implements SingleConstraintValidator<string, EnumVali
   }
 }
 
-type LengthCheckable = { length: number } | { [key: string]: any };
+type LengthCheckable = string | { length: number } | { [key: string]: any };
 
 export class LengthValidator implements SingleConstraintValidator<LengthCheckable, LengthValidationFailure> {
   private readonly min?: number;
@@ -194,7 +194,9 @@ export class LengthValidator implements SingleConstraintValidator<LengthCheckabl
     }
 
     let length: number;
-    if (LengthValidator.hasLength(input)) {
+    if (typeof input === "string") {
+      length = [...input].length; // string length is defined by the number of code points
+    } else if (LengthValidator.hasLength(input)) {
       length = input.length;
     } else {
       length = Object.keys(input).length;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/smithy-typescript/issues/509

*Description of changes:*
The Smithy spec specifies that string length is defined as the number of code
points. JavaScript's String.length returns the number of code units, leading to
inaccurate validation when a string contains characters that use multiple code
units to represent one code point.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
