### PR TITLE
Fix the generation of collections of documents in protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -1034,7 +1034,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         public Void objectNode(ObjectNode node) {
             // Short circuit document types, as the direct value is what we want.
             if (workingShape.isDocumentShape()) {
-                writer.writeInline(Node.prettyPrintJson(node));
+                writer.writeInline(Node.prettyPrintJson(node)).writeInline(",");
                 return null;
             }
 
@@ -1256,7 +1256,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         public Void objectNode(ObjectNode node) {
             // Short circuit document types, as the direct value is what we want.
             if (workingShape.isDocumentShape()) {
-                writer.writeInline(Node.prettyPrintJson(node));
+                writer.writeInline(Node.prettyPrintJson(node)).writeInline(",");
                 return null;
             }
 


### PR DESCRIPTION
*Description of changes:*
https://github.com/awslabs/smithy/pull/1097 adds a protocol test for sets of
documents and without this change the generated tests are invalid, as they
are missing the separating commas that other types receive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
