### PR TITLE
Support List<String> in function parameters list

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -165,12 +165,12 @@ public final class CodegenUtils {
                 } else if (value instanceof Boolean) {
                     functionParametersList.add(String.format("%s: %s", key, value));
                 } else if (value instanceof List) {
-                    if(!((List)value).isEmpty() && !(((List)value).get(0) instanceof String)) {
+                    if (!((List) value).isEmpty() && !(((List) value).get(0) instanceof String)) {
                         throw new CodegenException("Plugin function parameters not supported for type List<"
-                            + ((List)value).get(0).getClass() + ">");
+                            + ((List) value).get(0).getClass() + ">");
                     }
                     functionParametersList.add(String.format("%s: [%s]",
-                        key, ((List<String>)value).stream()
+                        key, ((List<String>) value).stream()
                             .collect(Collectors.joining("\", \"", "\"", "\""))));
                 } else {
                     // Future support for param type should be added in else if.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -164,6 +164,14 @@ public final class CodegenUtils {
                     functionParametersList.add(String.format("%s: '%s'", key, value));
                 } else if (value instanceof Boolean) {
                     functionParametersList.add(String.format("%s: %s", key, value));
+                } else if (value instanceof List) {
+                    if(!((List)value).isEmpty() && !(((List)value).get(0) instanceof String)) {
+                        throw new CodegenException("Plugin function parameters not supported for type List<"
+                            + ((List)value).get(0).getClass() + ">");
+                    }
+                    functionParametersList.add(String.format("%s: [%s]",
+                        key, ((List<String>)value).stream()
+                            .collect(Collectors.joining("\", \"", "\"", "\""))));
                 } else {
                     // Future support for param type should be added in else if.
                     throw new CodegenException("Plugin function parameters not supported for type "


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2725

*Description of changes:*
Adds support for writing List<String> in function parameters list.
Required for passing `responseAlgorithms` in [httpChecksum](https://awslabs.github.io/smithy/1.0/spec/aws/aws-core.html#aws-protocols-httpchecksum-trait) trait.

Testing was done in https://github.com/awslabs/private-smithy-typescript/pull/10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
