### PR TITLE
Fix scripts for npm by extracting `run` command out 

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -395,7 +395,7 @@ public final class TypeScriptSettings {
 
     public enum PackageManager {
         YARN("yarn"),
-        NPM("npm run-script");
+        NPM("npm");
 
         private final String command;
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -10,7 +10,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "prepack": "${packageManager} clean && ${packageManager} build"
+    "prepack": "${packageManager} run clean && ${packageManager} run build"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",


### PR DESCRIPTION
Currently, for `npm` the concurrently syntax was `concurrently 'npm run-script:build:cjs'` which is wrong and didn't work. `npm:build:cjs` (similar to `yarn:build:cjs`) is good syntax for concurrently.

Extracting run-script out of PackageManager.getCommand and specifying `run` directly in package.json scripts (prepack). `run` is equivalent alias to `run-script` in npm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
