### PR TITLE
Set bodyLengthChecker type to BodyLengthCalculator

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -226,9 +226,10 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                              + "@internal");
             writer.write("urlParser?: __UrlParser;\n");
 
+            writer.addImport("BodyLengthCalculator", "__BodyLengthCalculator", "@aws-sdk/types");
             writer.writeDocs("A function that can calculate the length of a request body.\n"
                             + "@internal");
-            writer.write("bodyLengthChecker?: (body: any) => number | undefined;\n");
+            writer.write("bodyLengthChecker?: __BodyLengthCalculator;\n");
 
             writer.addImport("StreamCollector", "__StreamCollector", "@aws-sdk/types");
             writer.writeDocs("A function that converts a stream into an array of bytes.\n"


### PR DESCRIPTION
*Issue #, if available:*
Noticed while updating BodyLengthCalculator type in https://github.com/aws/aws-sdk-js-v3/pull/3404

*Description of changes:*
Set bodyLengthChecker type to BodyLengthCalculator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
