### PR TITLE
Set default parameter for ClientConfig in constructor

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -333,7 +333,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     }
 
     private void generateConstructor() {
-        writer.openBlock("constructor(configuration: $L) {", "}", configType, () -> {
+        writer.openBlock("constructor(configuration: $L = {}) {", "}", configType, () -> {
             // Hook for adding/changing the client constructor.
             writer.pushState(CLIENT_CONSTRUCTOR_SECTION);
 


### PR DESCRIPTION
*Issue #, if available:*
Attempts to fix https://github.com/aws/aws-sdk-js-v3/issues/3415

*Description of changes:*
Set default parameter for ClientConfig in constructor as empty object

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
