### PR TITLE
allow more permissive input type of binary payload

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -15,8 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobStreamingMembers;
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeStreamingMemberType;
+import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobInputPayloadMember;
+import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeBlobInputPayloadMemberType;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -224,11 +224,12 @@ final class CommandGenerator implements Runnable {
     private void writeInputType(String typeName, Optional<StructureShape> inputShape) {
         if (inputShape.isPresent()) {
             StructureShape input = inputShape.get();
-            List<MemberShape> blobStreamingMembers = getBlobStreamingMembers(model, input);
-            if (blobStreamingMembers.isEmpty()) {
-                writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
+            Optional<MemberShape> unstructuredPayloadMember = getBlobInputPayloadMember(model, input);
+            if (unstructuredPayloadMember.isPresent()) {
+                writeBlobInputPayloadMemberType(writer, symbolProvider.toSymbol(input), typeName,
+                                unstructuredPayloadMember.get());
             } else {
-                writeStreamingMemberType(writer, symbolProvider.toSymbol(input), typeName, blobStreamingMembers.get(0));
+                writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
             }
         } else {
             // If the input is non-existent, then use an empty object.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -15,9 +15,6 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobInputPayloadMember;
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeBlobInputPayloadMemberType;
-
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Iterator;
@@ -31,7 +28,6 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
-import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -102,13 +98,7 @@ final class ServerCommandGenerator implements Runnable {
     private void writeInputType(String typeName, Optional<StructureShape> inputShape) {
         if (inputShape.isPresent()) {
             StructureShape input = inputShape.get();
-            Optional<MemberShape> unstructuredPayloadMember = getBlobInputPayloadMember(model, input);
-            if (unstructuredPayloadMember.isPresent()) {
-                writeBlobInputPayloadMemberType(writer, symbolProvider.toSymbol(input), typeName,
-                                unstructuredPayloadMember.get());
-            } else {
-                writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
-            }
+            writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
             renderNamespace(typeName, input);
         } else {
             // If the input is non-existent, then use an empty object.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -15,8 +15,8 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobStreamingMembers;
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeStreamingMemberType;
+import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobInputPayloadMember;
+import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeBlobInputPayloadMemberType;
 
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -102,11 +102,12 @@ final class ServerCommandGenerator implements Runnable {
     private void writeInputType(String typeName, Optional<StructureShape> inputShape) {
         if (inputShape.isPresent()) {
             StructureShape input = inputShape.get();
-            List<MemberShape> blobStreamingMembers = getBlobStreamingMembers(model, input);
-            if (blobStreamingMembers.isEmpty()) {
-                writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
+            Optional<MemberShape> unstructuredPayloadMember = getBlobInputPayloadMember(model, input);
+            if (unstructuredPayloadMember.isPresent()) {
+                writeBlobInputPayloadMemberType(writer, symbolProvider.toSymbol(input), typeName,
+                                unstructuredPayloadMember.get());
             } else {
-                writeStreamingMemberType(writer, symbolProvider.toSymbol(input), typeName, blobStreamingMembers.get(0));
+                writer.write("export interface $L extends $T {}", typeName, symbolProvider.toSymbol(input));
             }
             renderNamespace(typeName, input);
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -15,10 +15,10 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobStreamingMembers;
+import static software.amazon.smithy.typescript.codegen.CodegenUtils.getBlobInputPayloadMember;
 import static software.amazon.smithy.typescript.codegen.CodegenUtils.writeInlineStreamingMemberType;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -159,12 +159,12 @@ final class StructureGenerator implements Runnable {
 
             writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
             writer.writeDocs("@internal");
-            List<MemberShape> blobStreamingMembers = getBlobStreamingMembers(model, shape);
+            Optional<MemberShape> unstructuredPayloadMember = getBlobInputPayloadMember(model, shape);
             writer.writeInline("export const validate = ($L: ", objectParam);
-            if (blobStreamingMembers.isEmpty()) {
-                writer.writeInline("$L", symbol.getName());
+            if (unstructuredPayloadMember.isPresent()) {
+                writeInlineStreamingMemberType(writer, symbol, unstructuredPayloadMember.get());
             } else {
-                writeInlineStreamingMemberType(writer, symbol, blobStreamingMembers.get(0));
+                writer.writeInline("$L", symbol.getName());
             }
             writer.openBlock(", path: string = \"\"): __ValidationFailure[] => {", "}", () -> {
                 structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/aws/aws-sdk-js-v3/pull/3443

*Description of changes:*
Previously only streaming blob payload are allow for extra types `Uint8Array | string | Buffer`. The non-streaming blob payload are still required to be casted to `Uint8Array`. However, casting is not required and may cause potential encoding issue, this change permits more types to be supplied to the binary payload shapes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
