### PR TITLE
Bump TypeScript to ~4.6.2

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -17,7 +17,7 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
@@ -25,7 +25,7 @@
     "downlevel-dts": "0.7.0",
     "rimraf": "^3.0.0",
     "typedoc": "^0.19.2",
-    "typescript": "~4.3.5"
+    "typescript": "~4.6.2"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -6,7 +6,8 @@
     "incremental": true,
     "removeComments": true,
     "resolveJsonModule": true,
-    "rootDir": "src"
+    "rootDir": "src",
+    "useUnknownInCatchVariables": false
   },
   "exclude": ["test/"]
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3448

*Description of changes:*
Bumps TypeScript to ~4.6.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
