### PR TITLE
Remove MetadataBearer from output type

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -133,14 +133,11 @@ final class ServerCommandGenerator implements Runnable {
     }
 
     private void writeOutputType(String typeName, Optional<StructureShape> outputShape) {
-        // Output types should always be MetadataBearers, possibly in addition
-        // to a defined output shape.
-        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         if (outputShape.isPresent()) {
-            writer.write("export interface $L extends $T, __MetadataBearer {}",
+            writer.write("export interface $L extends $T {}",
                     typeName, symbolProvider.toSymbol(outputShape.get()));
         } else {
-            writer.write("export interface $L extends __MetadataBearer {}", typeName);
+            writer.write("export interface $L {}", typeName);
         }
     }
 


### PR DESCRIPTION
Metadata on output type on client SDK makes sense, but on the server
SDK does not.

Tested by building this change locally and updating our demo service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
