### PR TITLE
check for pagination stopOnSameToken option

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -202,9 +202,9 @@ final class PaginationGenerator implements Runnable {
                 });
 
                 writer.write("yield page;");
+                writer.write("const prevToken = token;");
                 writer.write("token = page$L;", destructurePath(outputTokenName));
-
-                writer.write("hasNext = !!(token);");
+                writer.write("hasNext = !!(token && (!config.stopOnSameToken || token !== prevToken));");
             });
 
             writer.write("// @ts-ignore");


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/3490

Add check for optional pagination halt condition of prevToken equalling nextToken.

In test output:

```js
    const prevToken = token;
    token = page.nextToken;
    hasNext = !!(token && (!config.stopOnSameToken || token !== prevToken));
```

This depends on https://github.com/aws/aws-sdk-js-v3/pull/3524