### PR TITLE
add option for smithy codegen attribution comment in generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: local test build
+
+# used with another locally situated consuming codebase to test changes.
+local:
+	./gradlew clean build publishToMavenLocal
+
+build:
+	./gradlew build
+
+# run tests
+test:
+	./gradlew test

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -6,6 +6,7 @@
             "targetNamespace": "Weather",
             "package": "weather",
             "packageVersion": "0.0.1",
+            "withAttribution": true,
             "packageJson": {
                 "license": "Apache-2.0"
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -194,7 +194,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         for (Shape shape : TopologicalIndex.of(prunedModel).getRecursiveShapes()) {
             shape.accept(this);
         }
-        SymbolVisitor.writeModelIndex(prunedModel, symbolProvider, fileManifest);
+        SymbolVisitor.writeModelIndex(settings, prunedModel, symbolProvider, fileManifest);
 
         // Generate the client Node and Browser configuration files. These
         // files are switched between in package.json based on the targeted
@@ -446,7 +446,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         }
 
         if (containedOperations.stream().anyMatch(operation -> operation.hasTrait(PaginatedTrait.ID))) {
-            PaginationGenerator.writeIndex(model, service, fileManifest);
+            PaginationGenerator.writeIndex(settings, model, service, fileManifest);
             writers.useFileWriter(PaginationGenerator.PAGINATION_INTERFACE_FILE, paginationWriter ->
                     PaginationGenerator.generateServicePaginationInterfaces(
                             aggregatedClientName,
@@ -455,7 +455,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         }
 
         if (containedOperations.stream().anyMatch(operation -> operation.hasTrait(WaitableTrait.ID))) {
-            WaiterGenerator.writeIndex(model, service, fileManifest);
+            WaiterGenerator.writeIndex(settings, model, service, fileManifest);
         }
     }
 
@@ -476,14 +476,14 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         for (OperationShape operation : containedOperations) {
             // Right now this only generates stubs
             if (settings.generateClient()) {
-                CommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
+                CommandGenerator.writeIndex(settings, model, service, symbolProvider, fileManifest);
                 writers.useShapeWriter(operation, commandWriter -> new CommandGenerator(
                         settings, model, operation, symbolProvider, commandWriter,
                         runtimePlugins, protocolGenerator, applicationProtocol).run());
             }
 
             if (settings.generateServerSdk()) {
-                ServerCommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
+                ServerCommandGenerator.writeIndex(settings, model, service, symbolProvider, fileManifest);
                 writers.useShapeWriter(operation, symbolProvider, commandWriter -> new ServerCommandGenerator(
                         settings, model, operation, symbolProvider, commandWriter,
                         protocolGenerator, applicationProtocol).run());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -308,12 +308,13 @@ final class CommandGenerator implements Runnable {
     }
 
     static void writeIndex(
+            TypeScriptSettings settings,
             Model model,
             ServiceShape service,
             SymbolProvider symbolProvider,
             FileManifest fileManifest
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -47,7 +47,7 @@ final class IndexGenerator {
         List<TypeScriptIntegration> integrations,
         ProtocolGenerator protocolGenerator
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
 
         if (settings.generateClient()) {
             writeClientExports(settings, model, symbolProvider, writer, fileManifest, integrations);
@@ -80,7 +80,7 @@ final class IndexGenerator {
             SymbolProvider symbolProvider,
             FileManifest fileManifest
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
         ServiceShape service = settings.getService(model);
         Symbol symbol = symbolProvider.toSymbol(service);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -139,11 +139,12 @@ final class PaginationGenerator implements Runnable {
     }
 
     static void writeIndex(
+            TypeScriptSettings settings,
             Model model,
             ServiceShape service,
             FileManifest fileManifest
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
         writer.write("export * from \"./$L\"", getModulePath(PAGINATION_INTERFACE_FILE));
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -241,12 +241,13 @@ final class ServerCommandGenerator implements Runnable {
     }
 
     static void writeIndex(
+            TypeScriptSettings settings,
             Model model,
             ServiceShape service,
             SymbolProvider symbolProvider,
             FileManifest fileManifest
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -118,8 +118,11 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         moduleNameDelegator = new ModuleNameDelegator(shapeChunkSize);
     }
 
-    static void writeModelIndex(Model model, SymbolProvider symbolProvider, FileManifest fileManifest) {
-        ModuleNameDelegator.writeModelIndex(model, symbolProvider, fileManifest);
+    static void writeModelIndex(TypeScriptSettings settings,
+                                Model model,
+                                SymbolProvider symbolProvider,
+                                FileManifest fileManifest) {
+        ModuleNameDelegator.writeModelIndex(settings, model, symbolProvider, fileManifest);
     }
 
     @Override
@@ -455,8 +458,11 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             return path;
         }
 
-        static void writeModelIndex(Model model, SymbolProvider symbolProvider, FileManifest fileManifest) {
-            TypeScriptWriter writer = new TypeScriptWriter("");
+        static void writeModelIndex(TypeScriptSettings settings,
+                                    Model model,
+                                    SymbolProvider symbolProvider,
+                                    FileManifest fileManifest) {
+            TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
             String modelPrefix = Paths.get(".", CodegenUtils.SOURCE_FOLDER, SHAPE_NAMESPACE_PREFIX).toString();
             model.shapes()
                     .map(shape -> symbolProvider.toSymbol(shape).getNamespace())

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -151,7 +151,7 @@ final class TypeScriptDelegator {
 
         TypeScriptWriter writer = writers.computeIfAbsent(formattedFilename, f -> {
             String moduleName = filename.endsWith(".ts") ? filename.substring(0, filename.length() - 3) : filename;
-            return new TypeScriptWriter(moduleName);
+            return new TypeScriptWriter(moduleName, settings.isWithAttribution());
         });
 
         // Add newlines/separators between types in the same file.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -54,6 +54,7 @@ public final class TypeScriptSettings {
     private static final String PROTOCOL = "protocol";
     private static final String PRIVATE = "private";
     private static final String PACKAGE_MANAGER = "packageManager";
+    private static final String WITH_ATTRIBUTION = "withAttribution";
 
     private String packageName;
     private String packageDescription = "";
@@ -66,6 +67,7 @@ public final class TypeScriptSettings {
     private ArtifactType artifactType = ArtifactType.CLIENT;
     private boolean disableDefaultValidation = false;
     private PackageManager packageManager = PackageManager.YARN;
+    private boolean withAttribution = false;
 
     @Deprecated
     public static TypeScriptSettings from(Model model, ObjectNode config) {
@@ -101,6 +103,7 @@ public final class TypeScriptSettings {
                 config.getStringMember(PACKAGE_MANAGER)
                     .map(s -> PackageManager.fromString(s.getValue()))
                     .orElse(PackageManager.YARN));
+        settings.setWithAttribution(config.getBooleanMemberOrDefault(WITH_ATTRIBUTION, false));
 
         if (artifactType == ArtifactType.SSDK) {
             settings.setDisableDefaultValidation(config.getBooleanMemberOrDefault(DISABLE_DEFAULT_VALIDATION));
@@ -359,6 +362,14 @@ public final class TypeScriptSettings {
      */
     public void setProtocol(ShapeId protocol) {
         this.protocol = Objects.requireNonNull(protocol);
+    }
+
+    public boolean isWithAttribution() {
+        return withAttribution;
+    }
+
+    public void setWithAttribution(boolean withAttribution) {
+        this.withAttribution = withAttribution;
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
@@ -209,11 +209,12 @@ class WaiterGenerator implements Runnable {
     }
 
     static void writeIndex(
+            TypeScriptSettings settings,
             Model model,
             ServiceShape service,
             FileManifest fileManifest
     ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
+        TypeScriptWriter writer = new TypeScriptWriter("", settings.isWithAttribution());
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -58,7 +58,7 @@ public class SymbolProviderTest {
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
         MockManifest manifest = new MockManifest();
-        SymbolVisitor.writeModelIndex(model, provider, manifest);
+        SymbolVisitor.writeModelIndex(settings, model, provider, manifest);
 
         assertThat(symbol1.getName(), equalTo("Hello"));
         assertThat(symbol1.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -1,11 +1,20 @@
 package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 
 public class TypeScriptWriterTest {
+    private static class ExampleGenerator {
+        final TypeScriptWriter writer = new TypeScriptWriter("", true);
+        public String doWrite() {
+            writer.write("");
+            return writer.toString();
+        }
+    }
+
     @Test
     public void writesDocStrings() {
         TypeScriptWriter writer = new TypeScriptWriter("foo");
@@ -45,6 +54,23 @@ public class TypeScriptWriterTest {
         String result = writer.toString();
 
         assertThat(result, equalTo("/**\n * This is *\\/ valid documentation.\n */\n"));
+    }
+
+    @Test
+    public void includesAttribution() {
+        TypeScriptWriter writer = new TypeScriptWriter("", true);
+        writer.write("");
+        String result = writer.toString();
+
+        assertThat(result, containsString("// smithy-codegen: TypeScriptWriterTest"));
+    }
+
+    @Test
+    public void includesAttributionCallerClass() {
+        ExampleGenerator caller = new ExampleGenerator();
+        String result = caller.doWrite();
+
+        assertThat(result, containsString("// smithy-codegen: TypeScriptWriterTest$ExampleGenerator"));
     }
 
     @Test


### PR DESCRIPTION
This is a proposed new codegen option.

- add `withAttribution: boolean` default `false`.
```json
    "plugins": {
        "typescript-codegen": {
            "service": "example.weather#Weather",
            "targetNamespace": "Weather",
            "package": "weather",
            "packageVersion": "0.0.1",
            "withAttribution": true,
            "packageJson": {
                "license": "Apache-2.0"
            }
        }
    }
```

- when true, calls to `TypeScriptWriter::write` will note down the caller class and allow a comment to be added at the head of generated files.

Top of Weather.ts:
```typescript
// smithy-codegen: ServiceAggregatedClientGenerator
import ...
```

Top of WeatherClient.ts:
```typescript
// smithy-codegen: AddDefaultsModeDependency, AddEventStreamDependency, ServiceBareBonesClientGenerator
import ...
```

- The comment has two proposed uses:
    - prevent editing of the file by hand
    - point developers reading the source file back to the responsible generator(s)