### PR TITLE
Remove unnecessary useShapeWriter method

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -347,7 +347,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     @Override
     public Void operationShape(OperationShape operation) {
         if (settings.generateServerSdk()) {
-            writers.useShapeWriter(operation, symbolProvider, w -> {
+            writers.useShapeWriter(operation, w -> {
                 ServerGenerator.generateOperationHandler(symbolProvider, service, operation, w);
             });
         }
@@ -395,11 +395,11 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     protocolGenerator.generateRequestDeserializers(serverContext);
                     protocolGenerator.generateResponseSerializers(serverContext);
                     protocolGenerator.generateFrameworkErrorSerializer(serverContext);
-                    writers.useShapeWriter(shape, symbolProvider, w -> {
+                    writers.useShapeWriter(shape, w -> {
                         protocolGenerator.generateServiceHandlerFactory(serverContext.withWriter(w));
                     });
                     for (OperationShape operation: TopDownIndex.of(model).getContainedOperations(service)) {
-                        writers.useShapeWriter(operation, symbolProvider, w -> {
+                        writers.useShapeWriter(operation, w -> {
                             protocolGenerator.generateOperationHandlerFactory(serverContext.withWriter(w), operation);
                         });
                     }
@@ -462,7 +462,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
     private void generateServiceInterface(ServiceShape shape) {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = new TreeSet<>(topDownIndex.getContainedOperations(shape));
-        writers.useShapeWriter(shape, symbolProvider, writer -> {
+        writers.useShapeWriter(shape, writer -> {
             ServerGenerator.generateOperationsType(symbolProvider, shape, operations, writer);
             ServerGenerator.generateServerInterfaces(symbolProvider, shape, operations, writer);
             ServerGenerator.generateServiceHandler(symbolProvider, shape, operations, writer);
@@ -484,7 +484,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
 
             if (settings.generateServerSdk()) {
                 ServerCommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
-                writers.useShapeWriter(operation, symbolProvider, commandWriter -> new ServerCommandGenerator(
+                writers.useShapeWriter(operation, commandWriter -> new ServerCommandGenerator(
                         settings, model, operation, symbolProvider, commandWriter,
                         protocolGenerator, applicationProtocol).run());
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -85,12 +85,11 @@ final class TypeScriptDelegator {
      * with the writer.
      *
      * @param shape Shape to create the writer for.
-     * @param provider The symbol provider to use (instead of the default one).
      * @param writerConsumer Consumer that accepts and works with the file.
      */
-    void useShapeWriter(Shape shape, SymbolProvider provider, Consumer<TypeScriptWriter> writerConsumer) {
+    void useShapeWriter(Shape shape, Consumer<TypeScriptWriter> writerConsumer) {
         // Checkout/create the appropriate writer for the shape.
-        Symbol symbol = provider.toSymbol(shape);
+        Symbol symbol = symbolProvider.toSymbol(shape);
         String fileName = symbol.getDefinitionFile();
         if (!fileName.startsWith(Paths.get(".", CodegenUtils.SOURCE_FOLDER).toString())) {
             fileName = Paths.get(".", CodegenUtils.SOURCE_FOLDER, fileName).toString();
@@ -106,24 +105,11 @@ final class TypeScriptDelegator {
         // Allow integrations to do things like add onSection callbacks.
         // These onSection callbacks are removed when popState is called.
         for (TypeScriptIntegration integration : integrations) {
-            integration.onShapeWriterUse(settings, model, provider, writer, shape);
+            integration.onShapeWriterUse(settings, model, symbolProvider, writer, shape);
         }
 
         writerConsumer.accept(writer);
         writer.popState();
-    }
-
-    /**
-     * Gets a previously created writer or creates a new one if needed.
-     *
-     * <p>Any imports required by the given symbol are automatically registered
-     * with the writer.
-     *
-     * @param shape Shape to create the writer for.
-     * @param writerConsumer Consumer that accepts and works with the file.
-     */
-    void useShapeWriter(Shape shape, Consumer<TypeScriptWriter> writerConsumer) {
-        useShapeWriter(shape, symbolProvider, writerConsumer);
     }
 
     /**


### PR DESCRIPTION
The overloaded useShapeWriter method was introduced in https://github.com/awslabs/smithy-typescript/commit/6e8f0902a20a432125f9b64a39f27d709f68f4c7 but become unnecessary with https://github.com/awslabs/smithy-typescript/commit/91c6b12e9615ca59cf48d544bd06d1c1ef3610b5.

Every instance of symbolProvider passed into useShapeWriter was already the instance passed to TypeScriptDelegator's constructor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
