### PR TITLE
Change `preprocessModel` to take `Model` instead of `PluginContext`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -61,12 +60,12 @@ public interface TypeScriptIntegration {
      * <p>This can be used to remove unsupported features, remove traits
      * from shapes (e.g., make members optional), etc.
      *
-     * @param context Plugin context.
+     * @param model Model being generated.
      * @param settings Setting used to generate.
      * @return Returns the updated model.
      */
-    default Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        return context.getModel();
+    default Model preprocessModel(Model model, TypeScriptSettings settings) {
+        return model;
     }
 
     /**


### PR DESCRIPTION
This is to simplify the existing code in preparation for using [SmithyIntegration](https://github.com/awslabs/smithy/blob/b7b48cf78a745af27a5d9889080cfa4743ba732f/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java#L109) interface as part of [DirectedCodgen](https://github.com/awslabs/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java).

Currently CodegenVisitor recreated TypeScriptSettings object after each preprocessModel. The only thing that could change in TypeScriptSettings based on the model would be the [service ShapeId](https://github.com/awslabs/smithy-typescript/blob/5405242969e11b5d81ec936fb0ea078875e9ef3e/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java#L91), but non of the existing TypeScriptIntegrations change the service shape and it doesn't seem like a use case to support. One can do [model transform] https://awslabs.github.io/smithy/1.0/guides/building-models/build-config.html#transforms] in Smithy-Build if really needed.

Simplifying this logic to not recreate TypeScriptSettings each time, makes it ready for implementing the new SmithyIntegration interface.

Corresponding change in aws-sdk-js-v3/codegen: https://github.com/aws/aws-sdk-js-v3/pull/3604

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
