### PR TITLE
Refactor decorateSymbolProvider to match SmithyIntegration

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -136,7 +136,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         // Decorate the symbol provider using integrations.
         SymbolProvider resolvedProvider = artifactType.createSymbolProvider(model, settings);
         for (TypeScriptIntegration integration : integrations) {
-            resolvedProvider = integration.decorateSymbolProvider(settings, model, resolvedProvider);
+            resolvedProvider = integration.decorateSymbolProvider(model, settings, resolvedProvider);
         }
         symbolProvider = SymbolProvider.cache(resolvedProvider);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
@@ -90,8 +90,8 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
      */
     @Override
     public SymbolProvider decorateSymbolProvider(
-            TypeScriptSettings settings,
             Model model,
+            TypeScriptSettings settings,
             SymbolProvider symbolProvider
     ) {
         return shape -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -75,14 +75,14 @@ public interface TypeScriptIntegration {
      * <p>This can be used to customize the names of shapes, the package
      * that code is generated into, add dependencies, add imports, etc.
      *
-     * @param settings Setting used to generate.
      * @param model Model being generated.
+     * @param settings Setting used to generate.
      * @param symbolProvider The original {@code SymbolProvider}.
      * @return The decorated {@code SymbolProvider}.
      */
     default SymbolProvider decorateSymbolProvider(
-            TypeScriptSettings settings,
             Model model,
+            TypeScriptSettings settings,
             SymbolProvider symbolProvider
     ) {
         return symbolProvider;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolDecoratorIntegration.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolDecoratorIntegration.java
@@ -13,8 +13,8 @@ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegrati
 public final class SymbolDecoratorIntegration implements TypeScriptIntegration {
     @Override
     public SymbolProvider decorateSymbolProvider(
-            TypeScriptSettings settings,
             Model model,
+            TypeScriptSettings settings,
             SymbolProvider symbolProvider
     ) {
         String name = settings.getPluginSettings().getStringMemberOrDefault("__customServiceName", null);


### PR DESCRIPTION
This is in preparation for using [SmithyIntegration](https://github.com/awslabs/smithy/blob/ee4af1095cbb4900533da6298bbd28221c446b6c/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java#L129) interface as part of [DirectedCodgen](https://github.com/awslabs/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java).

Corresponding change in aws-sdk-js-v3/codegen: https://github.com/aws/aws-sdk-js-v3/pull/3607

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
