### PR TITLE
Error shapes do not explicitly need to reference MetadataBearer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -310,20 +310,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
 
     @Override
     public Symbol structureShape(StructureShape shape) {
-        Symbol.Builder builder = createObjectSymbolBuilder(shape);
-
-        // Errors won't be re-used in locations where being a MetadataBearer is an issue.
-        if (errorShapes.contains(shape)) {
-            SymbolReference reference = SymbolReference.builder()
-                    .options(SymbolReference.ContextOption.DECLARE)
-                    .alias("$MetadataBearer")
-                    .symbol(TypeScriptDependency.AWS_SDK_TYPES.createSymbol("MetadataBearer"))
-                    .putProperty(IMPLEMENTS_INTERFACE_PROPERTY, true)
-                    .build();
-            builder.addReference(reference);
-        }
-
-        return builder.build();
+        return createObjectSymbolBuilder(shape).build();
     }
 
     private Symbol.Builder addSmithyUseImport(Symbol.Builder builder, String name, String as) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -3,7 +3,6 @@ package software.amazon.smithy.typescript.codegen;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
@@ -143,42 +142,6 @@ public class SymbolProviderTest {
         Symbol listSymbol = provider.toSymbol(list);
 
         assertThat(listSymbol.getName(), equalTo("(_Record)[]"));
-    }
-
-    @Test
-    public void errorStructuresAreMetadataBearers() {
-        Model model = Model.assembler()
-                .addImport(getClass().getResource("output-structure.smithy"))
-                .assemble()
-                .unwrap();
-        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
-                .withMember("package", Node.from("example"))
-                .withMember("packageVersion", Node.from("1.0.0"))
-                .build());
-
-        Shape input = model.expectShape(ShapeId.from("smithy.example#GetFooInput"));
-        Shape output = model.expectShape(ShapeId.from("smithy.example#GetFooOutput"));
-        Shape error = model.expectShape(ShapeId.from("smithy.example#GetFooError"));
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
-        Symbol inputSymbol = provider.toSymbol(input);
-        Symbol outputSymbol = provider.toSymbol(output);
-        Symbol errorSymbol = provider.toSymbol(error);
-
-        // Input and Output does not use MetadataBearer
-        assertThat(inputSymbol.getReferences().stream()
-                .filter(ref -> ref.getProperty("extends").isPresent())
-                .count(), equalTo(0L));
-        assertThat(outputSymbol.getReferences().stream()
-                 .filter(ref -> ref.getAlias().equals("$MetadataBearer"))
-                 .count(), equalTo(0L));
-
-        // Output uses MetadataBearer
-        assertThat(errorSymbol.getReferences().stream()
-                .filter(ref -> ref.getProperty(SymbolVisitor.IMPLEMENTS_INTERFACE_PROPERTY).isPresent())
-                .count(), greaterThan(0L));
-        assertThat(errorSymbol.getReferences().stream()
-                 .filter(ref -> ref.getAlias().equals("$MetadataBearer"))
-                 .count(), greaterThan(0L));
     }
 
     @Test


### PR DESCRIPTION
This is causing unnecessary imports in generated clients like https://github.com/aws/aws-sdk-js-v3/blob/6d232d050605a9a335771562ca6d08e31ccbcdaf/clients/client-accessanalyzer/src/models/models_0.ts#L3

Corresponding update to generated AWS clients https://github.com/aws/aws-sdk-js-v3/pull/3621

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
