### PR TITLE
Do not use getModelWithoutTraitShapes

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.typescript.codegen;
 import static java.lang.String.format;
 
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -118,8 +119,8 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         moduleNameDelegator = new ModuleNameDelegator(shapeChunkSize);
     }
 
-    static void writeModelIndex(Model model, SymbolProvider symbolProvider, FileManifest fileManifest) {
-        ModuleNameDelegator.writeModelIndex(model, symbolProvider, fileManifest);
+    static void writeModelIndex(Collection<Shape> shapes, SymbolProvider symbolProvider, FileManifest fileManifest) {
+        ModuleNameDelegator.writeModelIndex(shapes, symbolProvider, fileManifest);
     }
 
     @Override
@@ -442,19 +443,21 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             return path;
         }
 
-        static void writeModelIndex(Model model, SymbolProvider symbolProvider, FileManifest fileManifest) {
+        static void writeModelIndex(Collection<Shape> shapes, SymbolProvider symbolProvider,
+                                    FileManifest fileManifest) {
             TypeScriptWriter writer = new TypeScriptWriter("");
             String modelPrefix = Paths.get(".", CodegenUtils.SOURCE_FOLDER, SHAPE_NAMESPACE_PREFIX).toString();
-            model.shapes()
+            shapes.stream()
                     .map(shape -> symbolProvider.toSymbol(shape).getNamespace())
                     .filter(namespace -> namespace.startsWith(modelPrefix))
                     .distinct()
                     .sorted(Comparator.naturalOrder())
                     .forEach(namespace -> writer.write(
-                        "export * from $S;", namespace.replaceFirst(modelPrefix, ".")));
+                            "export * from $S;", namespace.replaceFirst(modelPrefix, ".")));
             fileManifest.writeFile(
-                Paths.get(CodegenUtils.SOURCE_FOLDER, SHAPE_NAMESPACE_PREFIX, "index.ts").toString(),
-                writer.toString());
+                    Paths.get(CodegenUtils.SOURCE_FOLDER, SHAPE_NAMESPACE_PREFIX, "index.ts").toString(),
+                    writer.toString());
         }
+
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/SymbolProviderTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -57,7 +58,7 @@ public class SymbolProviderTest {
         Symbol symbol1 = provider.toSymbol(shape1);
         Symbol symbol2 = provider.toSymbol(shape2);
         MockManifest manifest = new MockManifest();
-        SymbolVisitor.writeModelIndex(model, provider, manifest);
+        SymbolVisitor.writeModelIndex(Arrays.asList(shape1, shape2), provider, manifest);
 
         assertThat(symbol1.getName(), equalTo("Hello"));
         assertThat(symbol1.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/models/models_0"));


### PR DESCRIPTION
The Walker does not traverse relationships create by traits anyways.

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` in aws-sdk-js-v3 with this change to confirm there is no change to clients. Though there is some rearrangement of code within a file in protocol tests. Here's the diff https://github.com/aws/aws-sdk-js-v3/pull/3633

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
