### PR TITLE
Call emitWarningIfUnsupportedVersion from getRuntimeConfig

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -2,11 +2,13 @@ import { ${clientConfigName} } from "${clientModuleName}";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@aws-sdk/smithy-client";
 import { resolveDefaultsModeConfig } from "@aws-sdk/util-defaults-mode-node";
+import { emitWarningIfUnsupportedVersion } from "@aws-sdk/smithy-client";
 
 /**
  * @internal
  */
 export const getRuntimeConfig = (config: ${clientConfigName}) => {
+  emitWarningIfUnsupportedVersion(process.version);
   const defaultsMode = resolveDefaultsModeConfig(config);
   const defaultConfigProvider = () => defaultsMode().then(loadConfigsForDefaultMode);
   const clientSharedValues = getSharedRuntimeConfig(config);


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3236

*Description of changes:*
Call emitWarningIfUnsupportedVersion from getRuntimeConfig

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
