### PR TITLE
Remove unnecessary src folder prepend in useShapeWriter

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegator.java
@@ -91,9 +91,6 @@ final class TypeScriptDelegator {
         // Checkout/create the appropriate writer for the shape.
         Symbol symbol = symbolProvider.toSymbol(shape);
         String fileName = symbol.getDefinitionFile();
-        if (!fileName.startsWith(Paths.get(".", CodegenUtils.SOURCE_FOLDER).toString())) {
-            fileName = Paths.get(".", CodegenUtils.SOURCE_FOLDER, fileName).toString();
-        }
         TypeScriptWriter writer = checkoutWriter(fileName);
 
         // Add any needed DECLARE symbols.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/CodegenVisitorTest.java
@@ -3,13 +3,12 @@ package software.amazon.smithy.typescript.codegen;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
-import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -36,10 +35,10 @@ public class CodegenVisitorTest {
 
         // Did we generate the runtime config files?
         // note that asserting the contents of runtime config files is handled in its own unit tests.
-        Assertions.assertTrue(manifest.hasFile("package.json"));
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts"));
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts"));
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/index.ts"));
+        assertTrue(manifest.hasFile("package.json"));
+        assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts"));
+        assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts"));
+        assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/index.ts"));
 
         // Does the package.json file point to the runtime config?
         String packageJsonContents = manifest.getFileString("package.json").get();
@@ -69,8 +68,8 @@ public class CodegenVisitorTest {
 
         new TypeScriptCodegenPlugin().execute(context);
 
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/Foo.ts"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/Foo.ts").get(), containsString("export class Foo"));
+        assertTrue(manifest.hasFile("Foo.ts"));
+        assertThat(manifest.getFileString("Foo.ts").get(), containsString("export class Foo"));
     }
 
     @Test
@@ -91,11 +90,11 @@ public class CodegenVisitorTest {
                 .build();
         new TypeScriptCodegenPlugin().execute(context);
 
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/Example.ts"));
+        assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/Example.ts"));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/Example.ts").get(),
                    containsString("export class Example extends ExampleClient"));
 
-        Assertions.assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts"));
+        assertTrue(manifest.hasFile(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts"));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleClient.ts").get(), containsString("export class ExampleClient"));
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegatorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptDelegatorTest.java
@@ -1,5 +1,11 @@
 package software.amazon.smithy.typescript.codegen;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -10,13 +16,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.Pair;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 
 public class TypeScriptDelegatorTest {
     @Test
@@ -32,7 +31,7 @@ public class TypeScriptDelegatorTest {
         delegator.useShapeWriter(fooShape, writer -> writer.write("Hello!"));
         delegator.flushWriters();
 
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/Foo.txt").get(), equalTo("Hello!\n"));
+        assertThat(manifest.getFileString("Foo.txt").get(), equalTo("Hello!\n"));
     }
 
     @Test
@@ -61,7 +60,7 @@ public class TypeScriptDelegatorTest {
         delegator.useShapeWriter(fooShape, writer -> writer.write("Goodbye!"));
         delegator.flushWriters();
 
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/Foo.txt").get(), equalTo("Hello!\n\nGoodbye!\n"));
+        assertThat(manifest.getFileString("Foo.txt").get(), equalTo("Hello!\n\nGoodbye!\n"));
     }
 
     @Test


### PR DESCRIPTION
The SymbolProvider(SymbolVisitor) also includes the src folder, so this is
unnecessary. Conceptually it also makes sense that the filename is responsibility of the Symbol Provider, not the Delegator.

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` locally with and there is no change to generated clients.

This is in preparation to use WriterDelegator (as part of DirectedCodegen) so that [WriterDelegator.useShapeWriter](https://github.com/awslabs/smithy/blob/df456a514f72f4e35f0fb07c7e26006ff03b2071/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/WriterDelegator.java#L198) can be used directly without needing to override in TypeScriptDelegator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
