### PR TITLE
generate protocol-specific event payload

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1359,7 +1359,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      *
      * <p>Three parameters will be available in scope:
      * <ul>
-     *   <li>{@code body}: The serialized event payload object to needs to be serialized</li>
+     *   <li>{@code body}: The serialized event payload object that needs to be transformed to binary data</li>
      *   <li>{@code message: <T>}: The partially constructed event message.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
@@ -1649,11 +1649,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             model.expectShape(payloadMember.getTarget())));
         } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
             // handle implicit event payload by removing members with eventHeader trait.
-            List<MemberShape> headerMembers = event.getAllMembers().values().stream()
-                    .filter(member -> member.hasTrait(EventHeaderTrait.class)).collect(Collectors.toList());
-            for (MemberShape headerMember : headerMembers) {
-                String memberName = headerMember.getMemberName();
-                writer.write("delete input[$S]", memberName);
+            for (MemberShape memberShape : event.members()) {
+                if (memberShape.hasTrait(EventHeaderTrait.class)) {
+                    writer.write("delete input[$S]", memberShape.getMemberName());
+                }
             }
             SymbolProvider symbolProvider = context.getSymbolProvider();
             Symbol symbol = symbolProvider.toSymbol(payloadShape);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1351,6 +1351,32 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     );
 
     /**
+     * Writes the code needed to serialize an event payload as a protocol-specific document.
+     *
+     * <p>Implementations of this method are expected to set a value to the ${@code message.body} property.
+     * The value set is expected to by a JavaScript ${@code Uint8Array} type and is to be encoded as the
+     * event payload.
+     *
+     * <p>Two parameters will be available in scope:
+     * <ul>
+     *   <li>{@code message: <T>}: The partially constructed event message.</li>
+     *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
+     * </ul>
+     *
+     * <p>For example:
+     *
+     * <pre>{@code
+     * message.body = context.utf8Decoder(JSON.stringify(bodyParams));
+     * }</pre>
+     * @param context The generation context.
+     * @param payloadShape The payload shape. Only structure and union shape is serialized as document.
+     */
+    protected abstract void serializeInputEventDocumentPayload(
+            GenerationContext context,
+            Shape payloadShape
+    );
+
+    /**
      * Writes the code needed to serialize a protocol output document.
      *
      * <p>Implementations of this method are expected to set a value to the
@@ -1611,25 +1637,24 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         TypeScriptWriter writer = context.getWriter();
         Model model = context.getModel();
         List<MemberShape> payloadMembers = event.getAllMembers().values().stream()
-                .filter(member -> member.hasTrait(EventPayloadTrait.class)).collect(Collectors.toList());
-        List<MemberShape> documentMembers = event.getAllMembers().values().stream()
-                .filter(member -> !member.hasTrait(EventHeaderTrait.class)
-                        && !member.hasTrait(EventPayloadTrait.class))
+                .filter(member -> member.hasTrait(EventPayloadTrait.class))
                 .collect(Collectors.toList());
-        if (!payloadMembers.isEmpty()) {
-            // Write event payload if exists. There is at most 1 payload member.
+        Shape payloadShape = payloadMembers.isEmpty()
+                        ? event
+                        : model.expectShape(payloadMembers.get(0).getTarget());
+        if (payloadShape instanceof BlobShape || payloadShape instanceof StringShape) {
+            // Since event itself must be a structure shape, so string or blob payload member must has eventPayload
+            // trait explicitly.
             MemberShape payloadMember = payloadMembers.get(0);
-            String memberName = payloadMember.getMemberName();
+            String payloadMemberName = payloadMember.getMemberName();
             writer.write("message.body = $L || message.body;",
-                    getInputValue(context, Location.PAYLOAD, "input." + memberName, payloadMember,
+                    getInputValue(context, Location.PAYLOAD, "input." + payloadMemberName, payloadMember,
                             model.expectShape(payloadMember.getTarget())));
-        } else if (!documentMembers.isEmpty()) {
-            // Write event document bindings if exist.
-            SymbolProvider symbolProvider = context.getSymbolProvider();
-            Symbol symbol = symbolProvider.toSymbol(event);
-            // Use normal structure serializer instead of event serializer to serialize document body.
-            String serFunctionName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
-            writer.write("message.body = $L(input, context);", serFunctionName);
+        } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
+            serializeInputEventDocumentPayload(context, payloadShape);
+        } else {
+            throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
+                    payloadShape.getType()));
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
The Lex-runtime-v2 service cannot serialzie the event correctly because the events without `eventHeader` or `eventPayload` trait are not serialized, but returned as plain JavaScript object. 

For example:
1. The `TextEvent` is modeled as structure and serialized into a JavaScript Object([link](https://github.com/aws/aws-sdk-js-v3/blob/567a5304232fcc1f9db3fd3df545054de8336b4b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts#L1719-L1726)). 
1. The JavaScript Object was directly passed to the event body([link](https://github.com/aws/aws-sdk-js-v3/blob/567a5304232fcc1f9db3fd3df545054de8336b4b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts#L1107)) without serializing. 
1. This results in the event marshaller fails to the allocate correct bytelength, because it assumes the body to be binary data([link](https://github.com/aws/aws-sdk-js-v3/blob/47770fa493c3405f193069cd18319882529ff484/packages/eventstream-marshaller/src/EventStreamMarshaller.ts#L23-L42))

*Description of changes:*
This change expose a new interface `serializeInputEventDocumentPayload()` which generates the protocol-specific event payload. Specificly as mentioned in the [Smithy spec](https://awslabs.github.io/smithy/1.0/spec/core/stream-traits.html#smithy-api-eventpayload-trait):
> A structure and union is serialized as a protocol-specific document.
It should only handle the serialization of structure and union shape into the event payload. 

This change refactors the generator caused by the misunderstanding previously.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
