### PR TITLE
Use Record type in event stream deserializer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2404,7 +2404,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 writer.openBlock("const eventHeaders = Object.entries(event[eventName].headers).reduce(", ");", () -> {
                     writer.write(
                             "(accummulator, curr) => {accummulator[curr[0]] = curr[1].value; return accummulator; },");
-                    writer.write("{} as {[key: string]: any}");
+                    writer.write("{} as Record<string, any>");
                 });
                 writer.openBlock("const eventMessage = {", "};", () -> {
                     writer.write("headers: eventHeaders,");


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3299

*Description of changes:*
Use Record<string, any> in event stream deserializer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
