### PR TITLE
Use Record type in place of Object

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -530,7 +530,7 @@ final class StructuredMemberWriter {
             Shape collectionMemberTargetShape = model.expectShape(collectionMemberShape.getTarget());
             writer.writeInline("Iterable<$T>", getSymbolForValidatedType(collectionMemberTargetShape));
         } else if (shape.isMapShape()) {
-            writer.writeInline("{ [key: string]: $T }", getSymbolForValidatedType(((MapShape) shape).getValue()));
+            writer.writeInline("Record<string, $T>", getSymbolForValidatedType(((MapShape) shape).getValue()));
         } else if (shape instanceof SimpleShape) {
             writer.writeInline("$T", getSymbolForValidatedType(shape));
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -175,7 +175,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
      *
      * <pre>{@code
      * interface MyStructureShape {
-     *   memberPointingToMap: {[key: string]: string};
+     *   memberPointingToMap: Record<string, string>;
      * }
      * }</pre>
      *

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -184,7 +184,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     @Override
     public Symbol mapShape(MapShape shape) {
         Symbol reference = toSymbol(shape.getValue());
-        return createSymbolBuilder(shape, format("{ [key: string]: %s }", reference.getName()), null)
+        return createSymbolBuilder(shape, format("Record<string, %s>", reference.getName()), null)
                 .addReference(reference)
                 .build();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -177,7 +177,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
      *
-     * <p>The function signature specifies a {@code { [key: string]: Field }} return type.
+     * <p>The function signature specifies a {@code Record<string, Field>} return type.
      *
      * <p>This function would generate the following:
      *
@@ -408,7 +408,7 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
      * const deserializeAws_restJson1_1FieldMap = (
      *   output: any,
      *   context: SerdeContext
-     * ): { [key: string]: Field } => {
+     * ): Record<string, Field> => {
      *   let mapParams: any = {};
      *   Object.keys(output).forEach(key => {
      *     mapParams[key] = deserializeAws_restJson1_1Field(output[key], context);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -175,7 +175,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *
      * <p>The function signature for this body will have two parameters available in scope:
      * <ul>
-     *   <li>{@code input: { [key: string]: Field }}: the type generated for the MapShape shape parameter.</li>
+     *   <li>{@code input: Record<string, Field>}: the type generated for the MapShape shape parameter.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
      *
@@ -403,7 +403,7 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
      *
      * <pre>{@code
      * const serializeAws_restJson1_1FieldMap = (
-     *   input: { [key: string]: Field },
+     *   input: Record<string, Field>,
      *   context: SerdeContext
      * ): any => {
      *   let mapParams: any = {};

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1867,7 +1867,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         if (valueShape instanceof CollectionShape) {
             valueType = "string[]";
         }
-        writer.write("let parsedQuery: { [key: string]: $L } = {}", valueType);
+        writer.write("let parsedQuery: Record<string, $L> = {}", valueType);
         writer.openBlock("for (const [key, value] of Object.entries(query)) {", "}", () -> {
             writer.write("let queryValue: string;");
             final String parsedValue;
@@ -2315,12 +2315,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         } else if (target instanceof StructureShape) {
             // If payload is a Structure, then we need to parse the string into JavaScript object.
             writer.addImport("expectObject", "__expectObject", "@aws-sdk/smithy-client");
-            writer.write("const data: { [key: string]: any } | undefined "
+            writer.write("const data: Record<string, any> | undefined "
                     + "= __expectObject(await parseBody(output.body, context));");
         } else if (target instanceof UnionShape) {
             // If payload is a Union, then we need to parse the string into JavaScript object.
             writer.addImport("expectUnion", "__expectUnion", "@aws-sdk/smithy-client");
-            writer.write("const data: { [key: string]: any } | undefined "
+            writer.write("const data: Record<string, any> | undefined "
                     + "= __expectUnion(await parseBody(output.body, context));");
         } else if (target instanceof StringShape || target instanceof DocumentShape) {
             // If payload is String or Document, we need to collect body and convert binary to string.

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-form-urlencoded-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-form-urlencoded-stub.ts
@@ -3,8 +3,8 @@
  * discrepancies between the components.
  */
 const compareEquivalentFormUrlencodedBodies = (expectedBody: string, generatedBody: string): Object => {
-  const fromEntries = (components: string[][]): { [key: string]: string } => {
-    const parts: { [key: string]: string } = {};
+  const fromEntries = (components: string[][]): Record<string, string> => {
+    const parts: Record<string, string> = {};
 
     components.forEach(component => {
       parts[component[0]] = component[1];


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3299

*Description of changes:*
Use Record type instead Object type.
Searched for regular expression `\{ \[key: string\]: ([^ ]*) \}` and replacing it with `Record<string, $1>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
