### PR TITLE
Use Record type in place of Object in SSDK libs

### DIFF
--- a/smithy-typescript-ssdk-libs/server-apigateway/src/lambda.ts
+++ b/smithy-typescript-ssdk-libs/server-apigateway/src/lambda.ts
@@ -77,7 +77,7 @@ export function convertVersion1Response(response: HttpResponse): APIGatewayProxy
   };
 }
 function convertResponseHeaders(headers: HeaderBag) {
-  const retVal: { [key: string]: string[] } = {};
+  const retVal: Record<string, string[]> = {};
   for (const [key, val] of Object.entries(headers)) {
     retVal[key] = val.split(",").map((v) => v.trim());
   }
@@ -93,7 +93,7 @@ function hasVersion(event: any): event is Record<"version", string> {
 }
 
 function convertMultiValueHeaders(multiValueHeaders: APIGatewayProxyEventMultiValueHeaders | null) {
-  const retVal: { [key: string]: string } = {};
+  const retVal: Record<string, string> = {};
 
   if (multiValueHeaders === null) {
     return retVal;
@@ -112,7 +112,7 @@ function convertMultiValueHeaders(multiValueHeaders: APIGatewayProxyEventMultiVa
 // but first we need to split up generated client and servers so we can have different
 // language version targets.
 function convertHeaders(headers: APIGatewayProxyEventHeaders): HeaderBag {
-  const retVal: { [key: string]: string } = {};
+  const retVal: Record<string, string> = {};
 
   for (const [key, val] of Object.entries(headers)) {
     if (val !== undefined) {
@@ -128,7 +128,7 @@ function convertMultiValueQueryStringParameters(params: APIGatewayProxyEventMult
     return undefined;
   }
 
-  const retVal: { [key: string]: string[] } = {};
+  const retVal: Record<string, string[]> = {};
 
   for (const [key, val] of Object.entries(params)) {
     if (val !== undefined) {

--- a/smithy-typescript-ssdk-libs/server-common/src/unique.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/unique.ts
@@ -20,7 +20,7 @@ import * as util from "util";
  * A shortcut for JSON and Smithy primitives, as well as documents and Smithy-
  * modeled structures composed of those primitives
  */
-export type Input = { [key: string]: Input } | Array<Input> | Date | Uint8Array | string | number | boolean | null;
+export type Input = Record<string, Input> | Array<Input> | Date | Uint8Array | string | number | boolean | null;
 
 /**
  * Returns an array of duplicated values in the input. This is equivalent to using

--- a/smithy-typescript-ssdk-libs/server-common/src/unique.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/unique.ts
@@ -20,7 +20,7 @@ import * as util from "util";
  * A shortcut for JSON and Smithy primitives, as well as documents and Smithy-
  * modeled structures composed of those primitives
  */
-export type Input = Record<string, Input> | Array<Input> | Date | Uint8Array | string | number | boolean | null;
+export type Input = { [key: string]: Input } | Array<Input> | Date | Uint8Array | string | number | boolean | null;
 
 /**
  * Returns an array of duplicated values in the input. This is equivalent to using

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -90,13 +90,13 @@ export class CompositeCollectionValidator<T> implements MultiConstraintValidator
   }
 }
 
-export class CompositeMapValidator<T> implements MultiConstraintValidator<{ [key: string]: T }> {
-  private readonly referenceValidator: MultiConstraintValidator<{ [key: string]: T }>;
+export class CompositeMapValidator<T> implements MultiConstraintValidator<Record<string, T>> {
+  private readonly referenceValidator: MultiConstraintValidator<Record<string, T>>;
   private readonly keyValidator: MultiConstraintValidator<string>;
   private readonly valueValidator: MultiConstraintValidator<T>;
 
   constructor(
-    referenceValidator: MultiConstraintValidator<{ [key: string]: T }>,
+    referenceValidator: MultiConstraintValidator<Record<string, T>>,
     keyValidator: MultiConstraintValidator<string>,
     valueValidator: MultiConstraintValidator<T>
   ) {
@@ -105,7 +105,7 @@ export class CompositeMapValidator<T> implements MultiConstraintValidator<{ [key
     this.valueValidator = valueValidator;
   }
 
-  validate(input: { [key: string]: T } | undefined | null, path: string): ValidationFailure[] {
+  validate(input: Record<string, T> | undefined | null, path: string): ValidationFailure[] {
     const retVal: ValidationFailure[] = [];
     retVal.push(...this.referenceValidator.validate(input, path));
     if (input !== null && input !== undefined) {
@@ -175,7 +175,7 @@ export class EnumValidator implements SingleConstraintValidator<string, EnumVali
   }
 }
 
-type LengthCheckable = string | { length: number } | { [key: string]: any };
+type LengthCheckable = string | { length: number } | Record<string, any>;
 
 export class LengthValidator implements SingleConstraintValidator<LengthCheckable, LengthValidationFailure> {
   private readonly min?: number;


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3299

*Description of changes:*
Use Record type instead Object type.
Searched for regular expression `\{ \[key: string\]: ([^ ]*) \}` and replacing it with `Record<string, $1>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
