### PR TITLE
Remove unnecessary getOrder in a test

### DIFF
--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -45,10 +45,6 @@ public class RuntimeConfigGeneratorTest {
 
         integrations.add(new TypeScriptIntegration() {
             @Override
-            public byte getOrder() {
-                return 1;
-            }
-            @Override
             public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(
                     TypeScriptSettings settings,
                     Model model,


### PR DESCRIPTION
`getOrder` was added in https://github.com/awslabs/smithy-typescript/commit/edca7f62ab935c9acdaac1e87aaf6f37ac643d12 from https://github.com/awslabs/smithy-typescript/pull/153, but it is unnecessary. `RuntimeConfigGenerator` itself does not do sorting/rely on getOrder. It expects the `integrations` passed in to already be sorted. So in the `expandsRuntimeConfigFile` test, the 2nd integration's `writer.write("syn: 'ack1',");` is used and that's what is asserted in the test, which is independent of whether getOrder would return `1`, `-1`, `0` or any value.

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` locally with and there is no change to generated clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
