### PR TITLE
fix: override typescript version for typedoc

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -27,9 +27,6 @@
     "typedoc": "^0.19.2",
     "typescript": "~4.6.2"
   },
-  "resolutions": {
-    "typedoc/**/typescript": "~4.6.2"
-  },
   "overrides": {
     "typedoc": {
       "typescript": "~4.6.2"

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -27,6 +27,14 @@
     "typedoc": "^0.19.2",
     "typescript": "~4.6.2"
   },
+  "resolutions": {
+    "typedoc/**/typescript": "~4.6.2"
+  },
+  "overrides": {
+    "typedoc": {
+      "typescript": "~4.6.2"
+    }
+  },
   "engines": {
     "node": ">=12.0.0"
   },


### PR DESCRIPTION
*Issue #, if available:* #560

*Description of changes:*

We will add the proper sub-dependencies overrides for both NPM and Yarn. This way we will not need to install with force resolution enabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
