### PR TITLE
Use Record type in place of Object in HttpBindingProtocolGenerator

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2245,7 +2245,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (operationOrError instanceof StructureShape) {
                 bodyLocation = getErrorBodyLocation(context, bodyLocation);
             }
-            writer.write("const data: { [key: string] : any } = __expectNonNull($L, $S);", bodyLocation, "body");
+            writer.write("const data: Record<string, any> = __expectNonNull($L, $S);", bodyLocation, "body");
 
             if (isInput) {
                 deserializeInputDocumentBody(context, operationOrError.asOperationShape().get(), documentBindings);


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3299

*Description of changes:*
Uses Record type in place of Object in HttpBindingProtocolGenerator. This was missed in https://github.com/awslabs/smithy-typescript/pull/557, as the regular expression didn't search for space after square bracket ends.

This PR searches for regular expression `\{ \[key: string\] : ([^ ]*) \}` and replacing it with `Record<string, $1>`
It also searched for regular expressions `string[ ?]*\]`, and verified there are none in Java code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
