### PR TITLE
Remove usused code from ProtocolGenerator.GenerationContext

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -346,17 +346,15 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                     protocolGenerator.generateResponseDeserializers(context);
                 }
                 if (context.getSettings().generateServerSdk()) {
-                    ProtocolGenerator.GenerationContext serverContext =
-                            context.withSymbolProvider(symbolProvider);
-                    protocolGenerator.generateRequestDeserializers(serverContext);
-                    protocolGenerator.generateResponseSerializers(serverContext);
-                    protocolGenerator.generateFrameworkErrorSerializer(serverContext);
+                    protocolGenerator.generateRequestDeserializers(context);
+                    protocolGenerator.generateResponseSerializers(context);
+                    protocolGenerator.generateFrameworkErrorSerializer(context);
                     writers.useShapeWriter(shape, w -> {
-                        protocolGenerator.generateServiceHandlerFactory(serverContext.withWriter(w));
+                        protocolGenerator.generateServiceHandlerFactory(context.withWriter(w));
                     });
                     for (OperationShape operation: TopDownIndex.of(model).getContainedOperations(service)) {
                         writers.useShapeWriter(operation, w -> {
-                            protocolGenerator.generateOperationHandlerFactory(serverContext.withWriter(w), operation);
+                            protocolGenerator.generateOperationHandlerFactory(context.withWriter(w), operation);
                         });
                     }
                 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -223,7 +223,6 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             ShapeId protocol = protocolGenerator.getProtocol();
             ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();
             context.setProtocolName(protocolGenerator.getName());
-            context.setIntegrations(integrations);
             context.setModel(model);
             context.setService(service);
             context.setSettings(settings);
@@ -337,7 +336,6 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             writers.useFileWriter(fileName, writer -> {
                 ProtocolGenerator.GenerationContext context = new ProtocolGenerator.GenerationContext();
                 context.setProtocolName(protocolGenerator.getName());
-                context.setIntegrations(integrations);
                 context.setModel(model);
                 context.setService(shape);
                 context.setSettings(settings);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -348,12 +348,6 @@ public interface ProtocolGenerator {
             return copy;
         }
 
-        public GenerationContext withSymbolProvider(SymbolProvider newProvider) {
-            GenerationContext copyContext = copy();
-            copyContext.setSymbolProvider(newProvider);
-            return copyContext;
-        }
-
         public GenerationContext withWriter(TypeScriptWriter newWriter) {
             GenerationContext copyContext = copy();
             copyContext.setWriter(newWriter);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -274,7 +273,6 @@ public interface ProtocolGenerator {
         private SymbolProvider symbolProvider;
         private TypeScriptWriter writer;
         private Supplier<TypeScriptWriter> writerSupplier;
-        private List<TypeScriptIntegration> integrations;
         private String protocolName;
 
         public TypeScriptSettings getSettings() {
@@ -330,14 +328,6 @@ public interface ProtocolGenerator {
             }
         }
 
-        public List<TypeScriptIntegration> getIntegrations() {
-            return integrations;
-        }
-
-        public void setIntegrations(List<TypeScriptIntegration> integrations) {
-            this.integrations = integrations;
-        }
-
         public String getProtocolName() {
             return protocolName;
         }
@@ -354,7 +344,6 @@ public interface ProtocolGenerator {
             copy.setSymbolProvider(symbolProvider);
             copy.setWriter(writer);
             copy.setDeferredWriter(writerSupplier);
-            copy.setIntegrations(integrations);
             copy.setProtocolName(protocolName);
             return copy;
         }


### PR DESCRIPTION
There are 2 changes:

1. Remove unused integrations from ProtocolGenerator.GenerationContext
Didn't look into history, but is unused.

2. Remove unused ProtocolGenerator.GenerationContext.withSymbolProvider
This method was introduced in https://github.com/awslabs/smithy-typescript/commit/6e8f0902a20a432125f9b64a39f27d709f68f4c7#diff-29f426bcf693083ef5343733b2f9813bd61186bf026c2dd81e6795824027ce0eR328 but become unnecessary with https://github.com/awslabs/smithy-typescript/commit/91c6b12e9615ca59cf48d544bd06d1c1ef3610b5#diff-29f426bcf693083ef5343733b2f9813bd61186bf026c2dd81e6795824027ce0eR337.

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` locally and there is no change to generated clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
