### PR TITLE
feat: allow non backward compatible required member

### DIFF
--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -9,7 +9,7 @@
             "packageJson": {
                 "license": "Apache-2.0"
             },
-            "memberNullabilityCompatibilityMode": "strict"
+            "requiredMemberMode": "strict"
         }
     }
 }

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -8,7 +8,8 @@
             "packageVersion": "0.0.1",
             "packageJson": {
                 "license": "Apache-2.0"
-            }
+            },
+            "compatibilityMode": "strict"
         }
     }
 }

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -9,7 +9,7 @@
             "packageJson": {
                 "license": "Apache-2.0"
             },
-            "compatibilityMode": "strict"
+            "memberNullabilityCompatibilityMode": "strict"
         }
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -329,7 +329,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().getMemberNullabilityCompatibilityMode()
+                    directive.settings().getRequiredMemberMode()
             );
             generator.run();
         });
@@ -344,7 +344,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().getMemberNullabilityCompatibilityMode()
+                    directive.settings().getRequiredMemberMode()
             );
             generator.run();
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -329,7 +329,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().getCompatibilityMode()
+                    directive.settings().getMemberNullabilityCompatibilityMode()
             );
             generator.run();
         });
@@ -344,7 +344,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().getCompatibilityMode()
+                    directive.settings().getMemberNullabilityCompatibilityMode()
             );
             generator.run();
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -329,7 +329,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().isBackwardCompatibleRequiredMember()
+                    directive.settings().getCompatibilityMode()
             );
             generator.run();
         });
@@ -344,7 +344,7 @@ final class DirectedTypeScriptCodegen
                     writer,
                     directive.shape(),
                     directive.settings().generateServerSdk(),
-                    directive.settings().isBackwardCompatibleRequiredMember()
+                    directive.settings().getCompatibilityMode()
             );
             generator.run();
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -328,7 +328,8 @@ final class DirectedTypeScriptCodegen
                     directive.symbolProvider(),
                     writer,
                     directive.shape(),
-                    directive.settings().generateServerSdk()
+                    directive.settings().generateServerSdk(),
+                    directive.settings().isBackwardCompatibleRequiredMember()
             );
             generator.run();
         });
@@ -342,7 +343,8 @@ final class DirectedTypeScriptCodegen
                     directive.symbolProvider(),
                     writer,
                     directive.shape(),
-                    directive.settings().generateServerSdk()
+                    directive.settings().generateServerSdk(),
+                    directive.settings().isBackwardCompatibleRequiredMember()
             );
             generator.run();
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -71,7 +71,7 @@ final class StructureGenerator implements Runnable {
     private final RequiredMemberMode requiredMemberMode;
 
     /**
-     * sets 'includeValidation' to 'false' and backwards compatibility
+     * sets 'includeValidation' to 'false' and requiredMemberMode
      * to {@link RequiredMemberMode#NULLABLE}.
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -68,13 +68,15 @@ final class StructureGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final StructureShape shape;
     private final boolean includeValidation;
-    private final CompatibilityMode compatibilityMode;
+    private final MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode;
 
     /**
-     * sets 'includeValidation' to 'false' and backwards compatibility to {@link CompatibilityMode#RELAXED}.
+     * sets 'includeValidation' to 'false' and backwards compatibility
+     * to {@link MemberNullabilityCompatibilityMode#RELAXED}.
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
-        this(model, symbolProvider, writer, shape, false, CompatibilityMode.RELAXED);
+        this(model, symbolProvider, writer, shape, false,
+            MemberNullabilityCompatibilityMode.RELAXED);
     }
 
     StructureGenerator(Model model,
@@ -82,13 +84,13 @@ final class StructureGenerator implements Runnable {
                        TypeScriptWriter writer,
                        StructureShape shape,
                        boolean includeValidation,
-                       CompatibilityMode compatibilityMode) {
+                       MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.writer = writer;
         this.shape = shape;
         this.includeValidation = includeValidation;
-        this.compatibilityMode = compatibilityMode;
+        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
     }
 
     @Override
@@ -162,7 +164,7 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values(), this.compatibilityMode);
+                model, symbolProvider, shape.getAllMembers().values(), this.memberNullabilityCompatibilityMode);
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");
@@ -259,7 +261,7 @@ final class StructureGenerator implements Runnable {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(model, symbolProvider,
-                shape.getAllMembers().values(), this.compatibilityMode);
+                shape.getAllMembers().values(), this.memberNullabilityCompatibilityMode);
         // since any error interface must extend from JavaScript Error interface, message member is already
         // required in the JavaScript Error interface
         structuredMemberWriter.skipMembers.add("message");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -67,13 +68,13 @@ final class StructureGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final StructureShape shape;
     private final boolean includeValidation;
-    private final boolean backwardCompatibleRequiredMember;
+    private final CompatibilityMode compatibilityMode;
 
     /**
-     * sets 'includeValidation' to 'false' for backwards compatibility.
+     * sets 'includeValidation' to 'false' and backwards compatibility to {@link CompatibilityMode#RELAXED}.
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
-        this(model, symbolProvider, writer, shape, false, true);
+        this(model, symbolProvider, writer, shape, false, CompatibilityMode.RELAXED);
     }
 
     StructureGenerator(Model model,
@@ -81,13 +82,13 @@ final class StructureGenerator implements Runnable {
                        TypeScriptWriter writer,
                        StructureShape shape,
                        boolean includeValidation,
-                       boolean backwardCompatibleRequiredMember) {
+                       CompatibilityMode compatibilityMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.writer = writer;
         this.shape = shape;
         this.includeValidation = includeValidation;
-        this.backwardCompatibleRequiredMember = backwardCompatibleRequiredMember;
+        this.compatibilityMode = compatibilityMode;
     }
 
     @Override
@@ -161,7 +162,7 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values(), this.backwardCompatibleRequiredMember);
+                model, symbolProvider, shape.getAllMembers().values(), this.compatibilityMode);
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");
@@ -258,7 +259,7 @@ final class StructureGenerator implements Runnable {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(model, symbolProvider,
-                shape.getAllMembers().values(), this.backwardCompatibleRequiredMember);
+                shape.getAllMembers().values(), this.compatibilityMode);
         // since any error interface must extend from JavaScript Error interface, message member is already
         // required in the JavaScript Error interface
         structuredMemberWriter.skipMembers.add("message");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -67,24 +67,27 @@ final class StructureGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final StructureShape shape;
     private final boolean includeValidation;
+    private final boolean backwardCompatibleRequiredMember;
 
     /**
      * sets 'includeValidation' to 'false' for backwards compatibility.
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
-        this(model, symbolProvider, writer, shape, false);
+        this(model, symbolProvider, writer, shape, false, true);
     }
 
     StructureGenerator(Model model,
                        SymbolProvider symbolProvider,
                        TypeScriptWriter writer,
                        StructureShape shape,
-                       boolean includeValidation) {
+                       boolean includeValidation,
+                       boolean backwardCompatibleRequiredMember) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.writer = writer;
         this.shape = shape;
         this.includeValidation = includeValidation;
+        this.backwardCompatibleRequiredMember = backwardCompatibleRequiredMember;
     }
 
     @Override
@@ -158,7 +161,7 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values());
+                model, symbolProvider, shape.getAllMembers().values(), this.backwardCompatibleRequiredMember);
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");
@@ -255,7 +258,7 @@ final class StructureGenerator implements Runnable {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(model, symbolProvider,
-                shape.getAllMembers().values());
+                shape.getAllMembers().values(), this.backwardCompatibleRequiredMember);
         // since any error interface must extend from JavaScript Error interface, message member is already
         // required in the JavaScript Error interface
         structuredMemberWriter.skipMembers.add("message");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.RequiredMemberMode;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -68,15 +68,15 @@ final class StructureGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final StructureShape shape;
     private final boolean includeValidation;
-    private final MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode;
+    private final RequiredMemberMode requiredMemberMode;
 
     /**
      * sets 'includeValidation' to 'false' and backwards compatibility
-     * to {@link MemberNullabilityCompatibilityMode#RELAXED}.
+     * to {@link RequiredMemberMode#NULLABLE}.
      */
     StructureGenerator(Model model, SymbolProvider symbolProvider, TypeScriptWriter writer, StructureShape shape) {
         this(model, symbolProvider, writer, shape, false,
-            MemberNullabilityCompatibilityMode.RELAXED);
+            RequiredMemberMode.NULLABLE);
     }
 
     StructureGenerator(Model model,
@@ -84,13 +84,13 @@ final class StructureGenerator implements Runnable {
                        TypeScriptWriter writer,
                        StructureShape shape,
                        boolean includeValidation,
-                       MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
+                       RequiredMemberMode requiredMemberMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.writer = writer;
         this.shape = shape;
         this.includeValidation = includeValidation;
-        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
+        this.requiredMemberMode = requiredMemberMode;
     }
 
     @Override
@@ -164,7 +164,7 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values(), this.memberNullabilityCompatibilityMode);
+                model, symbolProvider, shape.getAllMembers().values(), this.requiredMemberMode);
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");
@@ -261,7 +261,7 @@ final class StructureGenerator implements Runnable {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(model, symbolProvider,
-                shape.getAllMembers().values(), this.memberNullabilityCompatibilityMode);
+                shape.getAllMembers().values(), this.requiredMemberMode);
         // since any error interface must extend from JavaScript Error interface, message member is already
         // required in the JavaScript Error interface
         structuredMemberWriter.skipMembers.add("message");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -45,7 +45,7 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -61,19 +61,19 @@ final class StructuredMemberWriter {
     Collection<MemberShape> members;
     String memberPrefix = "";
     boolean noDocs;
-    CompatibilityMode compatibilityMode;
+    MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode;
     final Set<String> skipMembers = new HashSet<>();
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
-        this(model, symbolProvider, members, CompatibilityMode.RELAXED);
+        this(model, symbolProvider, members, MemberNullabilityCompatibilityMode.RELAXED);
     }
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members,
-            CompatibilityMode compatibilityMode) {
+            MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);
-        this.compatibilityMode = compatibilityMode;
+        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {
@@ -87,7 +87,7 @@ final class StructuredMemberWriter {
             boolean wroteDocs = !noDocs && writer.writeMemberDocs(model, member);
             String memberName = getSanitizedMemberName(member);
             String optionalSuffix = shape.isUnionShape() || !isRequiredMember(member) ? "?" : "";
-            String typeSuffix = compatibilityMode == CompatibilityMode.RELAXED
+            String typeSuffix = memberNullabilityCompatibilityMode == MemberNullabilityCompatibilityMode.RELAXED
                          && isRequiredMember(member) ? " | undefined" : "";
             writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
                          symbolProvider.toSymbol(member), typeSuffix);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -45,7 +45,7 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.RequiredMemberMode;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -61,19 +61,19 @@ final class StructuredMemberWriter {
     Collection<MemberShape> members;
     String memberPrefix = "";
     boolean noDocs;
-    MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode;
+    RequiredMemberMode requiredMemberMode;
     final Set<String> skipMembers = new HashSet<>();
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
-        this(model, symbolProvider, members, MemberNullabilityCompatibilityMode.RELAXED);
+        this(model, symbolProvider, members, RequiredMemberMode.NULLABLE);
     }
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members,
-            MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
+            RequiredMemberMode requiredMemberMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);
-        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
+        this.requiredMemberMode = requiredMemberMode;
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {
@@ -87,7 +87,7 @@ final class StructuredMemberWriter {
             boolean wroteDocs = !noDocs && writer.writeMemberDocs(model, member);
             String memberName = getSanitizedMemberName(member);
             String optionalSuffix = shape.isUnionShape() || !isRequiredMember(member) ? "?" : "";
-            String typeSuffix = memberNullabilityCompatibilityMode == MemberNullabilityCompatibilityMode.RELAXED
+            String typeSuffix = requiredMemberMode == RequiredMemberMode.NULLABLE
                          && isRequiredMember(member) ? " | undefined" : "";
             writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
                          symbolProvider.toSymbol(member), typeSuffix);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -67,7 +67,8 @@ final class StructuredMemberWriter {
         this(model, symbolProvider, members, true);
     }
 
-    StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members, boolean backwardCompatible) {
+    StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members,
+            boolean backwardCompatible) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -45,6 +45,7 @@ import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -60,19 +61,19 @@ final class StructuredMemberWriter {
     Collection<MemberShape> members;
     String memberPrefix = "";
     boolean noDocs;
-    boolean backwardCompatible;
+    CompatibilityMode compatibilityMode;
     final Set<String> skipMembers = new HashSet<>();
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
-        this(model, symbolProvider, members, true);
+        this(model, symbolProvider, members, CompatibilityMode.RELAXED);
     }
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members,
-            boolean backwardCompatible) {
+            CompatibilityMode compatibilityMode) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);
-        this.backwardCompatible = backwardCompatible;
+        this.compatibilityMode = compatibilityMode;
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {
@@ -86,7 +87,8 @@ final class StructuredMemberWriter {
             boolean wroteDocs = !noDocs && writer.writeMemberDocs(model, member);
             String memberName = getSanitizedMemberName(member);
             String optionalSuffix = shape.isUnionShape() || !isRequiredMember(member) ? "?" : "";
-            String typeSuffix = backwardCompatible && isRequiredMember(member) ? " | undefined" : "";
+            String typeSuffix = compatibilityMode == CompatibilityMode.RELAXED
+                         && isRequiredMember(member) ? " | undefined" : "";
             writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
                          symbolProvider.toSymbol(member), typeSuffix);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -60,12 +60,18 @@ final class StructuredMemberWriter {
     Collection<MemberShape> members;
     String memberPrefix = "";
     boolean noDocs;
+    boolean backwardCompatible;
     final Set<String> skipMembers = new HashSet<>();
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
+        this(model, symbolProvider, members, true);
+    }
+
+    StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members, boolean backwardCompatible) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);
+        this.backwardCompatible = backwardCompatible;
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {
@@ -79,7 +85,7 @@ final class StructuredMemberWriter {
             boolean wroteDocs = !noDocs && writer.writeMemberDocs(model, member);
             String memberName = getSanitizedMemberName(member);
             String optionalSuffix = shape.isUnionShape() || !isRequiredMember(member) ? "?" : "";
-            String typeSuffix = isRequiredMember(member) ? " | undefined" : "";
+            String typeSuffix = backwardCompatible && isRequiredMember(member) ? " | undefined" : "";
             writer.write("${L}${L}${L}: ${T}${L};", memberPrefix, memberName, optionalSuffix,
                          symbolProvider.toSymbol(member), typeSuffix);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -307,7 +307,7 @@ public final class TypeScriptSettings {
      * Returns the compatibility mode in regards to member nullability.
      *
      * @return the configured compatibility mode in regards to member nullability.
-     *  Defaults to {@link MemberNullabilityCompatibilityMode#RELAXED}
+     * Defaults to {@link MemberNullabilityCompatibilityMode#RELAXED}
      */
     public MemberNullabilityCompatibilityMode getMemberNullabilityCompatibilityMode() {
         return memberNullabilityCompatibilityMode;
@@ -315,7 +315,14 @@ public final class TypeScriptSettings {
 
     public void setMemberNullabilityCompatibilityMode(
         MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
-        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
+            if (memberNullabilityCompatibilityMode != MemberNullabilityCompatibilityMode.RELAXED) {
+                LOGGER.warning(String.format("By setting the member nullability compatibility mode to '%s', a"
+                    + " member that has the '@required' trait applied CANNOT be 'undefined'. Differrent than"
+                    + " when it is set to '%s', it will be considered a BACKWARDS INCOMPATIBLE change for"
+                    + " Smithy services even when the required constraint is dropped from a member.",
+                    memberNullabilityCompatibilityMode.mode, MemberNullabilityCompatibilityMode.RELAXED.mode));
+            }
+            this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
     }
 
     /**
@@ -404,10 +411,11 @@ public final class TypeScriptSettings {
     public enum ArtifactType {
         CLIENT(SymbolVisitor::new,
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
-                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE)),
+                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, MEMBER_NULLABILITY_COMPATIBILITY_MODE)),
         SSDK((m, s) -> new ServerSymbolVisitor(m, new SymbolVisitor(m, s)),
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
-                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, DISABLE_DEFAULT_VALIDATION));
+                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, MEMBER_NULLABILITY_COMPATIBILITY_MODE,
+                              DISABLE_DEFAULT_VALIDATION));
 
         private final BiFunction<Model, TypeScriptSettings, SymbolProvider> symbolProviderFactory;
         private final List<String> configProperties;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -318,8 +318,8 @@ public final class TypeScriptSettings {
         RequiredMemberMode requiredMemberMode) {
             if (requiredMemberMode != RequiredMemberMode.NULLABLE) {
                 LOGGER.warning(String.format("By setting the member nullability compatibility mode to '%s', a"
-                    + " member that has the '@required' trait applied CANNOT be 'undefined'. Differrent than"
-                    + " when it is set to '%s', it will be considered a BACKWARDS INCOMPATIBLE change for"
+                    + " member that has the '@required' trait applied CANNOT be 'undefined'."
+                    + " It will be considered a BACKWARDS INCOMPATIBLE change for"
                     + " Smithy services even when the required constraint is dropped from a member.",
                     requiredMemberMode.mode, RequiredMemberMode.NULLABLE.mode));
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -440,7 +440,7 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * An enum indicating the compatibility mode in regards to required members..
+     * An enum indicating the code generation mode for required members.
      */
     public enum RequiredMemberMode {
         /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -43,6 +43,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class TypeScriptSettings {
 
     static final String DISABLE_DEFAULT_VALIDATION = "disableDefaultValidation";
+    static final String BACKWARD_COMPATIBLE_REQUIRED_MEMBER = "backwardCompatibleRequiredMember";
     static final String TARGET_NAMESPACE = "targetNamespace";
     private static final Logger LOGGER = Logger.getLogger(TypeScriptSettings.class.getName());
 
@@ -65,6 +66,7 @@ public final class TypeScriptSettings {
     private boolean isPrivate;
     private ArtifactType artifactType = ArtifactType.CLIENT;
     private boolean disableDefaultValidation = false;
+    private boolean backwardCompatibleRequiredMember = true;
     private PackageManager packageManager = PackageManager.YARN;
 
     @Deprecated
@@ -105,6 +107,7 @@ public final class TypeScriptSettings {
         if (artifactType == ArtifactType.SSDK) {
             settings.setDisableDefaultValidation(config.getBooleanMemberOrDefault(DISABLE_DEFAULT_VALIDATION));
         }
+        settings.setBackwardCompatibleRequiredMember(config.getBooleanMemberOrDefault(BACKWARD_COMPATIBLE_REQUIRED_MEMBER));
 
         settings.setPluginSettings(config);
         return settings;
@@ -293,6 +296,19 @@ public final class TypeScriptSettings {
 
     public void setDisableDefaultValidation(boolean disableDefaultValidation) {
         this.disableDefaultValidation = disableDefaultValidation;
+    }
+
+    /**
+     * Returns whether or not required members are backward-compatible.
+     *
+     * @return true if required members are backward-compatible. Default: true
+     */
+    public boolean isBackwardCompatibleRequiredMember() {
+        return backwardCompatibleRequiredMember;
+    }
+
+    public void setBackwardCompatibleRequiredMember(boolean backwardCompatibleRequiredMember) {
+        this.backwardCompatibleRequiredMember = backwardCompatibleRequiredMember;
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -43,7 +43,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public final class TypeScriptSettings {
 
     static final String DISABLE_DEFAULT_VALIDATION = "disableDefaultValidation";
-    static final String COMPATIBILITY_MODE = "compatibilityMode";
+    static final String MEMBER_NULLABILITY_COMPATIBILITY_MODE = "memberNullabilityCompatibilityMode";
     static final String TARGET_NAMESPACE = "targetNamespace";
     private static final Logger LOGGER = Logger.getLogger(TypeScriptSettings.class.getName());
 
@@ -66,7 +66,8 @@ public final class TypeScriptSettings {
     private boolean isPrivate;
     private ArtifactType artifactType = ArtifactType.CLIENT;
     private boolean disableDefaultValidation = false;
-    private CompatibilityMode compatibilityMode = CompatibilityMode.RELAXED;
+    private MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode =
+        MemberNullabilityCompatibilityMode.RELAXED;
     private PackageManager packageManager = PackageManager.YARN;
 
     @Deprecated
@@ -107,10 +108,10 @@ public final class TypeScriptSettings {
         if (artifactType == ArtifactType.SSDK) {
             settings.setDisableDefaultValidation(config.getBooleanMemberOrDefault(DISABLE_DEFAULT_VALIDATION));
         }
-        settings.setCompatibilityMode(
-            config.getStringMember(COMPATIBILITY_MODE)
-                .map(s -> CompatibilityMode.fromString(s.getValue()))
-                .orElse(CompatibilityMode.RELAXED));
+        settings.setMemberNullabilityCompatibilityMode(
+            config.getStringMember(MEMBER_NULLABILITY_COMPATIBILITY_MODE)
+                .map(s -> MemberNullabilityCompatibilityMode.fromString(s.getValue()))
+                .orElse(MemberNullabilityCompatibilityMode.RELAXED));
 
         settings.setPluginSettings(config);
         return settings;
@@ -304,14 +305,16 @@ public final class TypeScriptSettings {
     /**
      * Returns the backward-compatibility mode.
      *
-     * @return the configured backward-compatibility mode. Defaults to {@link CompatibilityMode#RELAXED}
+     * @return the configured backward-compatibility mode.
+     *  Defaults to {@link MemberNullabilityCompatibilityMode#RELAXED}
      */
-    public CompatibilityMode getCompatibilityMode() {
-        return compatibilityMode;
+    public MemberNullabilityCompatibilityMode getMemberNullabilityCompatibilityMode() {
+        return memberNullabilityCompatibilityMode;
     }
 
-    public void setCompatibilityMode(CompatibilityMode compatibilityMode) {
-        this.compatibilityMode = compatibilityMode;
+    public void setMemberNullabilityCompatibilityMode(
+        MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
+        this.memberNullabilityCompatibilityMode = memberNullabilityCompatibilityMode;
     }
 
     /**
@@ -429,13 +432,13 @@ public final class TypeScriptSettings {
     /**
      * An enum indicating the backward-compatibility mode.
      */
-    public enum CompatibilityMode {
+    public enum MemberNullabilityCompatibilityMode {
         RELAXED("relaxed"),
         STRICT("strict");
 
         private final String mode;
 
-        CompatibilityMode(String mode) {
+        MemberNullabilityCompatibilityMode(String mode) {
             this.mode = mode;
         }
 
@@ -443,7 +446,7 @@ public final class TypeScriptSettings {
             return mode;
         }
 
-        public static CompatibilityMode fromString(String s) {
+        public static MemberNullabilityCompatibilityMode fromString(String s) {
             if ("relaxed".equals(s)) {
                 return RELAXED;
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -305,9 +305,9 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * Returns the compatibility mode in regards to required members..
+     * Returns the code generation mode for required members.
      *
-     * @return the configured compatibility mode in regards to required members..
+     * @return the configured mode for required members.
      * Defaults to {@link RequiredMemberMode#NULLABLE}
      */
     public RequiredMemberMode getRequiredMemberMode() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -304,9 +305,9 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * Returns the compatibility mode in regards to member nullability.
+     * Returns the compatibility mode in regards to required members..
      *
-     * @return the configured compatibility mode in regards to member nullability.
+     * @return the configured compatibility mode in regards to required members..
      * Defaults to {@link RequiredMemberMode#NULLABLE}
      */
     public RequiredMemberMode getRequiredMemberMode() {
@@ -439,7 +440,7 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * An enum indicating the compatibility mode in regards to member nullability.
+     * An enum indicating the compatibility mode in regards to required members..
      */
     public enum RequiredMemberMode {
         /**
@@ -452,6 +453,14 @@ public final class TypeScriptSettings {
 
         /**
          * This will dissallow members marked as {@link RequiredTrait} to be {@code undefined}.
+         * Use this mode with CAUTION because it comes with certain risks. When a server drops
+         * {@link RequiredTrait} from an output shape (and it is replaced with {@link DefaultTrait}
+         * as defined by the spec), if the server does not always serialize a value,
+         * customer code consuming the client and trying to access this member, may get a
+         * NullPointerException. Smithy spec says: "Authoritative model consumers like servers
+         * SHOULD always serialize default values to remove any ambiguity about the value of
+         * the most up to default value." So one should use this mode on the client, only if
+         * the server is following the approach proposed by the spec.
          */
         STRICT("strict");
 
@@ -472,7 +481,7 @@ public final class TypeScriptSettings {
             if ("strict".equals(s)) {
                 return STRICT;
             }
-            throw new CodegenException(String.format("Unsupported member nullability compatibility mode: %s", s));
+            throw new CodegenException(String.format("Unsupported required member mode: %s", s));
         }
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -34,6 +34,7 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -303,9 +304,9 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * Returns the backward-compatibility mode.
+     * Returns the compatibility mode in regards to member nullability.
      *
-     * @return the configured backward-compatibility mode.
+     * @return the configured compatibility mode in regards to member nullability.
      *  Defaults to {@link MemberNullabilityCompatibilityMode#RELAXED}
      */
     public MemberNullabilityCompatibilityMode getMemberNullabilityCompatibilityMode() {
@@ -430,10 +431,20 @@ public final class TypeScriptSettings {
     }
 
     /**
-     * An enum indicating the backward-compatibility mode.
+     * An enum indicating the compatibility mode in regards to member nullability.
      */
     public enum MemberNullabilityCompatibilityMode {
+        /**
+         * This is the current behavior and it will be the default. When set,
+         * it allows a member that has the {@link RequiredTrait} applied to be "undefined".
+         * By doing so it can still be considered a backwards compatible change fo
+         * Smithy services even when the required constraint is dropped from a member .
+         */
         RELAXED("relaxed"),
+
+        /**
+         * This will dissallow members marked as {@link RequiredTrait} to be "undefined".
+         */
         STRICT("strict");
 
         private final String mode;
@@ -453,7 +464,7 @@ public final class TypeScriptSettings {
             if ("strict".equals(s)) {
                 return STRICT;
             }
-            throw new CodegenException(String.format("Unsupported backward compatibility mode: %s", s));
+            throw new CodegenException(String.format("Unsupported member nullability compatibility mode: %s", s));
         }
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -317,7 +317,7 @@ public final class TypeScriptSettings {
     public void setRequiredMemberMode(
         RequiredMemberMode requiredMemberMode) {
             if (requiredMemberMode != RequiredMemberMode.NULLABLE) {
-                LOGGER.warning(String.format("By setting the member nullability compatibility mode to '%s', a"
+                LOGGER.warning(String.format("By setting the required member mode to '%s', a"
                     + " member that has the '@required' trait applied CANNOT be 'undefined'."
                     + " It will be considered a BACKWARDS INCOMPATIBLE change for"
                     + " Smithy services even when the required constraint is dropped from a member.",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -107,7 +107,8 @@ public final class TypeScriptSettings {
         if (artifactType == ArtifactType.SSDK) {
             settings.setDisableDefaultValidation(config.getBooleanMemberOrDefault(DISABLE_DEFAULT_VALIDATION));
         }
-        settings.setBackwardCompatibleRequiredMember(config.getBooleanMemberOrDefault(BACKWARD_COMPATIBLE_REQUIRED_MEMBER));
+        settings.setBackwardCompatibleRequiredMember(
+                config.getBooleanMemberOrDefault(BACKWARD_COMPATIBLE_REQUIRED_MEMBER));
 
         settings.setPluginSettings(config);
         return settings;

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -6,14 +6,13 @@ import static org.hamcrest.Matchers.containsString;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
-import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.RequiredMemberMode;
 
 public class StructureGeneratorTest {
     @Test
@@ -514,14 +513,14 @@ public class StructureGeneratorTest {
         testStructureCodegenBase("test-required-member.smithy",
                                 "export interface GetFooOutput {\n"
                                 + "  someRequiredMember: string;\n"
-                                + "}\n", MemberNullabilityCompatibilityMode.STRICT);
+                                + "}\n", RequiredMemberMode.STRICT);
     }
 
     private String testStructureCodegen(String file, String expectedType) {
-        return testStructureCodegenBase(file, expectedType, MemberNullabilityCompatibilityMode.RELAXED);
+        return testStructureCodegenBase(file, expectedType, RequiredMemberMode.NULLABLE);
     }
 
-    private String testStructureCodegenBase(String file, String expectedType, MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
+    private String testStructureCodegenBase(String file, String expectedType, RequiredMemberMode requiredMemberMode) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(file))
                 .assemble()
@@ -534,7 +533,7 @@ public class StructureGeneratorTest {
                         .withMember("service", Node.from("smithy.example#Example"))
                         .withMember("package", Node.from("example"))
                         .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("memberNullabilityCompatibilityMode", Node.from(memberNullabilityCompatibilityMode.getMode()))
+                        .withMember("requiredMemberMode", Node.from(requiredMemberMode.getMode()))
                         .build())
                 .build();
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -13,7 +13,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.MemberNullabilityCompatibilityMode;
 
 public class StructureGeneratorTest {
     @Test
@@ -514,14 +514,14 @@ public class StructureGeneratorTest {
         testStructureCodegenBase("test-required-member.smithy",
                                 "export interface GetFooOutput {\n"
                                 + "  someRequiredMember: string;\n"
-                                + "}\n", CompatibilityMode.STRICT);
+                                + "}\n", MemberNullabilityCompatibilityMode.STRICT);
     }
 
     private String testStructureCodegen(String file, String expectedType) {
-        return testStructureCodegenBase(file, expectedType, CompatibilityMode.RELAXED);
+        return testStructureCodegenBase(file, expectedType, MemberNullabilityCompatibilityMode.RELAXED);
     }
 
-    private String testStructureCodegenBase(String file, String expectedType, CompatibilityMode compatibilityMode) {
+    private String testStructureCodegenBase(String file, String expectedType, MemberNullabilityCompatibilityMode memberNullabilityCompatibilityMode) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(file))
                 .assemble()
@@ -534,7 +534,7 @@ public class StructureGeneratorTest {
                         .withMember("service", Node.from("smithy.example#Example"))
                         .withMember("package", Node.from("example"))
                         .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("compatibilityMode", Node.from(compatibilityMode.getMode()))
+                        .withMember("memberNullabilityCompatibilityMode", Node.from(memberNullabilityCompatibilityMode.getMode()))
                         .build())
                 .build();
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.CompatibilityMode;
 
 public class StructureGeneratorTest {
     @Test
@@ -513,14 +514,14 @@ public class StructureGeneratorTest {
         testStructureCodegenBase("test-required-member.smithy",
                                 "export interface GetFooOutput {\n"
                                 + "  someRequiredMember: string;\n"
-                                + "}\n", false);
+                                + "}\n", CompatibilityMode.STRICT);
     }
 
     private String testStructureCodegen(String file, String expectedType) {
-        return testStructureCodegenBase(file, expectedType, true);
+        return testStructureCodegenBase(file, expectedType, CompatibilityMode.RELAXED);
     }
 
-    private String testStructureCodegenBase(String file, String expectedType, boolean backwardCompatibleRequiredMember) {
+    private String testStructureCodegenBase(String file, String expectedType, CompatibilityMode compatibilityMode) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(file))
                 .assemble()
@@ -533,7 +534,7 @@ public class StructureGeneratorTest {
                         .withMember("service", Node.from("smithy.example#Example"))
                         .withMember("package", Node.from("example"))
                         .withMember("packageVersion", Node.from("1.0.0"))
-                        .withMember("backwardCompatibleRequiredMember", Node.from(backwardCompatibleRequiredMember))
+                        .withMember("compatibilityMode", Node.from(compatibilityMode.getMode()))
                         .build())
                 .build();
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -508,7 +508,19 @@ public class StructureGeneratorTest {
                                 + "})");
     }
 
+    @Test
+    public void properlyGeneratesRequiredMessageMemberNotBackwardCompatible() {
+        testStructureCodegenBase("test-required-member.smithy",
+                                "export interface GetFooOutput {\n"
+                                + "  someRequiredMember: string;\n"
+                                + "}\n", false);
+    }
+
     private String testStructureCodegen(String file, String expectedType) {
+        return testStructureCodegenBase(file, expectedType, true);
+    }
+
+    private String testStructureCodegenBase(String file, String expectedType, boolean backwardCompatibleRequiredMember) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(file))
                 .assemble()
@@ -521,6 +533,7 @@ public class StructureGeneratorTest {
                         .withMember("service", Node.from("smithy.example#Example"))
                         .withMember("package", Node.from("example"))
                         .withMember("packageVersion", Node.from("1.0.0"))
+                        .withMember("backwardCompatibleRequiredMember", Node.from(backwardCompatibleRequiredMember))
                         .build())
                 .build();
 

--- a/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-required-member.smithy
+++ b/smithy-typescript-codegen/src/test/resources/software/amazon/smithy/typescript/codegen/test-required-member.smithy
@@ -1,0 +1,17 @@
+namespace smithy.example
+
+service Example {
+    version: "1.0.0",
+    operations: [GetFoo]
+}
+
+operation GetFoo {
+    input: GetFooInput,
+    output: GetFooOutput
+}
+
+structure GetFooInput {}
+structure GetFooOutput {
+    @required
+    someRequiredMember: String
+}


### PR DESCRIPTION
*Issue #, if available:* #503

*Description of changes:*

A continuation of PR #537, but we will allow to remove `| undefined` by setting an input configuration called `requiredMemberMode` with the following possible values:

- **nullable**: this is the current behavior and it will be the default. When set, it allows a member that has the `@required` trait applied to be `undefined`. By doing so it can still be considered a backwards compatible change for Smithy services even when the required constraint is dropped from a member .
- **strict**: this will remove `| undefined` from the generated code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
