### PR TITLE
Update README example to lock smithy-cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ are as follows:
 2. Create a `build.gradle.kts` file with the following contents:
 
    ```kotlin
+    buildscript {
+        repositories {
+            mavenCentral()
+        }
+        dependencies {
+            "classpath"("software.amazon.smithy:smithy-cli:[1.19.0,1.20.0[")
+        }
+    }
+
     plugins {
         id("software.amazon.smithy").version("0.6.0")
     }
@@ -27,7 +36,7 @@ are as follows:
     }
 
     dependencies {
-        implementation("software.amazon.smithy:smithy-model:[1.17.0, 2.0[")
+        implementation("software.amazon.smithy:smithy-model:[1.19.0,1.20.0[")
         implementation("software.amazon.smithy.typescript:smithy-typescript-codegen:0.11.0")
     }
    ```


### PR DESCRIPTION
*Description of changes:*
When there is a new version of Smithy that is not compatible with
the version of Smithy specified in normal dependencies, the
example given in the README can break. This locks the smithy-cli
version to the same version that is specified in the build.

See https://github.com/aws-samples/smithy-server-generator-typescript-sample/issues/3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
