### PR TITLE
refactor eventstream generation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -45,12 +45,35 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
+/**
+ * Evnetstream code generator.
+ */
 @SmithyUnstableApi
 public class EventStreamGenerator {
     public static boolean isEventStreamShape(Shape shape) {
         return shape instanceof UnionShape && shape.hasTrait(StreamingTrait.class);
     }
 
+    /**
+     * Generate eventstream serializers, and related serializers for events.
+     * @param context Code generation context instance.
+     * @param service The service shape.
+     * @param documentContentType The default content-type value of current protocol.
+     * @param getEventHeaderInputValue The function that given a source of data, generate an input value provider for a
+     *                                  given shape that bind to event header. It takes 2 parameters: dataSource--the
+     *                                  in-code location of the data to provide an input of ({@code input.foo},
+     *                                  {@code entry}, etc.); member--the member that points to the value being
+     *                                  provided. The function retuns a value or expression of the input value.
+     * @param getEventPayloadInputValue The function that given a source of data, generate an input value provider for a
+     *                                  given shape that bind to event payload. It takes 2 parameters: dataSource--the
+     *                                  in-code location of the data to provide an input of ({@code input.foo},
+     *                                  {@code entry}, etc.); member--the member that points to the value being
+     *                                  provided. The function retuns a value or expression of the input value.
+     * @param serializeInputEventDocumentPayload Function writes the code needed to serialize an event payload as a
+     *                                          protocol-specific document.
+     * @param documentShapesToSerialize The set of shapes that needs to be serialized as document payload.
+     *                                  Shapes that referred by event will be added.
+     */
     public void generateEventStreamSerializers(
         GenerationContext context,
         ServiceShape service,
@@ -94,6 +117,25 @@ public class EventStreamGenerator {
         });
     }
 
+    /**
+     * Generate eventstream deserializers, and related deserializers for events.
+     * @param context Code generation context instance.
+     * @param service The service shape.
+     * @param errorShapesToDeserialize A set of error shapes referred by events will be added to this set.
+     * @param eventShapesToDeserialize A set of event shapes that needs to be treated as regular structure shapes will
+     *                                  be added to this set.
+     * @param isErrorCodeInBody A boolean that indicates if the error code for the implementing protocol is located in
+     *                          the error response body, meaning this generator will parse the body before attempting to
+     *                          load an error code.
+     * @param getEventHeaderOutputValue The function that given a source of data, generate an output value provider for
+     *                                  a given shape that bind to event header. This may use native types (like
+     *                                  generating a Date for timestamps,) converters (like a base64Decoder,) or invoke
+     *                                  complex type deserializers to manipulate the dataSource into the proper output
+     *                                  content. It takes 2 parameters: dataSource--the in-code location of the data to
+     *                                  provide an output of ({@code output.foo}, {@code entry}, etc.); member--the
+     *                                  member that points to the value being provided. The function retuns a value or
+     *                                  expression of the output value.
+     */
     public void generateEventStreamDeserializers(
         GenerationContext context,
         ServiceShape service,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -326,7 +326,7 @@ public class EventStreamGenerator {
                 + "  context: $L\n"
                 + "): AsyncIterable<$T> => {", "}", methodName, contextType, eventsUnionSymbol, () -> {
             writer.openBlock("return context.eventStreamMarshaller.deserialize(", ");", () -> {
-                writer.write("output.body,");
+                writer.write("output,");
                 writer.openBlock("async event => {", "}", () -> {
                     writer.write("const eventName = Object.keys(event)[0];");
                     writer.openBlock(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.EventStreamIndex;
+import software.amazon.smithy.model.knowledge.EventStreamInfo;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EventHeaderTrait;
+import software.amazon.smithy.model.traits.EventPayloadTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public class EventStreamGenerator {
+    public void generateEventStreamSerializers(
+        GenerationContext context,
+        ServiceShape service,
+        String documentContentType,
+        BiFunction<String, MemberShape, String> getEventHeaderInputValue,
+        BiFunction<String, MemberShape, String> getEventPayloadInputValue,
+        Consumer<GenerationContext> serializeInputEventDocumentPayload
+    ) {
+        Model model = context.getModel();
+
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
+        EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
+        TreeSet<StructureShape> eventShapesToMarshall = new TreeSet<>();
+        TreeSet<StructureShape> eventShapesToUnmarshall = new TreeSet<>();
+        for (OperationShape operation : operations) {
+            if (eventStreamIndex.getInputInfo(operation).isPresent()) {
+                EventStreamInfo eventStreamInfo = eventStreamIndex.getInputInfo(operation).get();
+                UnionShape eventsUnion = eventStreamInfo.getEventStreamTarget().asUnionShape().get();
+                generateEventStreamSerializer(context, eventsUnion);
+                Set<StructureShape> eventShapes = eventsUnion.members().stream()
+                        .map(member -> model.expectShape(member.getTarget()).asStructureShape().get())
+                        .collect(Collectors.toSet());
+                eventShapes.forEach(eventShapesToMarshall::add);
+            } else if (eventStreamIndex.getOutputInfo(operation).isPresent()) {
+                EventStreamInfo eventStreamInfo = eventStreamIndex.getOutputInfo(operation).get();
+                UnionShape eventsUnion = eventStreamInfo.getEventStreamTarget().asUnionShape().get();
+                // generateEventStreamSerializer(context, eventsUnion);
+                Set<StructureShape> eventShapes = eventsUnion.members().stream()
+                        .map(member -> model.expectShape(member.getTarget()).asStructureShape().get())
+                        .collect(Collectors.toSet());
+                eventShapes.forEach(eventShapesToUnmarshall::add);
+            }
+        }
+
+        eventShapesToMarshall.forEach(event -> {
+            generateEventMarshaller(
+                context,
+                event,
+                documentContentType,
+                getEventHeaderInputValue,
+                getEventPayloadInputValue,
+                serializeInputEventDocumentPayload);
+        });
+        eventShapesToUnmarshall.forEach(event -> {
+            //PASS
+        });
+    }
+
+    private void generateEventStreamSerializer(GenerationContext context, UnionShape eventsUnion) {
+        String methodName = getEventStreamFunctionName(context, eventsUnion);
+        Symbol eventsUnionSymbol = getSymbol(context, eventsUnion);
+        TypeScriptWriter writer = context.getWriter();
+        Model model = context.getModel();
+        writer.addImport("Message", "__Message", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.openBlock("const $L = (\n"
+                + "  input: any,\n"
+                + "  context: __SerdeContext\n"
+                + "): any => {", "}", methodName, () -> {
+            writer.openBlock("const eventMarshallingVisitor = (event: any): __Message => $T.visit(event, {", "});",
+                    eventsUnionSymbol, () -> {
+                        eventsUnion.getAllMembers().forEach((memberName, memberShape) -> {
+                            StructureShape target = model.expectShape(memberShape.getTarget(), StructureShape.class);
+                            String eventSerMethodName = getEventStreamFunctionName(context, target);
+                            writer.write("$L: value => $L(value, context)", memberName, eventSerMethodName);
+                        });
+                        writer.write("_: value => value as any");
+                    });
+            writer.write("return context.eventStreamMarshaller.serialize(input, eventMarshallingVisitor);");
+        });
+    }
+
+    public String getEventStreamFunctionName(GenerationContext context, Shape shape) {
+        Symbol symbol = getSymbol(context, shape);
+        String protocolName = context.getProtocolName();
+        return ProtocolGenerator.getSerFunctionName(symbol, protocolName) + "_event";
+    }
+
+    private Symbol getSymbol(GenerationContext context, Shape shape) {
+        SymbolProvider symbolProvider = context.getSymbolProvider();
+        return symbolProvider.toSymbol(shape);
+    }
+
+    public void generateEventMarshaller(
+        GenerationContext context,
+        StructureShape event,
+        String documentContentType,
+        BiFunction<String, MemberShape, String> getEventHeaderInputValue,
+        BiFunction<String, MemberShape, String> getEventPayloadInputValue,
+        Consumer<GenerationContext> serializeInputEventDocumentPayload
+    ) {
+        String methodName = getEventStreamFunctionName(context, event);
+        Symbol symbol = getSymbol(context, event);
+        TypeScriptWriter writer = context.getWriter();
+        writer.addImport("MessageHeaders", "__MessageHeaders", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.openBlock("const $L = (\n"
+                + "  input: $T,\n"
+                + "  context: __SerdeContext\n"
+                + "): __Message => {", "}", methodName, symbol, () -> {
+            writer.openBlock("const headers: __MessageHeaders = {", "}", () -> {
+                //fix headers required by event stream
+                writer.write("\":event-type\": { type: \"string\", value: $S },", symbol.getName());
+                writer.write("\":message-type\": { type: \"string\", value: \"event\" },");
+                writeEventContentTypeHeader(context, event, documentContentType);
+            });
+            writeEventHeaders(context, event, getEventHeaderInputValue);
+            writeEventBody(context, event, getEventPayloadInputValue, serializeInputEventDocumentPayload);
+            writer.openBlock("return { headers, body };");
+        });
+    }
+
+    private void writeEventContentTypeHeader(
+        GenerationContext context,
+        StructureShape event,
+        String documentContentType
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape payloadShape = getEventPayloadShape(context, event);
+        if (payloadShape instanceof BlobShape) {
+            writer.write("\":content-type\": { type: \"string\", value: \"application/octet-stream\" },");
+        } else if (payloadShape instanceof StringShape) {
+            writer.write("\":content-type\": { type: \"string\", value: \"text/plain\" },");
+        } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
+            writer.write("\":content-type\": { type: \"string\", value: $S },", documentContentType);
+        } else {
+            throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
+                    payloadShape.getType()));
+        }
+    }
+
+    private Shape getEventPayloadShape(GenerationContext context, StructureShape event) {
+        Model model = context.getModel();
+        List<MemberShape> payloadMembers = event.getAllMembers().values().stream()
+                .filter(member -> member.hasTrait(EventPayloadTrait.class))
+                .collect(Collectors.toList());
+        return payloadMembers.isEmpty()
+                        ? event // implicit payload
+                        : model.expectShape(payloadMembers.get(0).getTarget());
+    }
+
+    private void writeEventHeaders(
+        GenerationContext context,
+        StructureShape event,
+        BiFunction<String, MemberShape, String> getEventHeaderInputValue
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        Model model = context.getModel();
+        List<MemberShape> headerMembers = event.getAllMembers().values().stream()
+                .filter(member -> member.hasTrait(EventHeaderTrait.class)).collect(Collectors.toList());
+        for (MemberShape headerMember : headerMembers) {
+            String memberName = headerMember.getMemberName();
+            Shape target = model.expectShape(headerMember.getTarget());
+            writer.openBlock("if (input.$L) {", "}", memberName, () -> {
+                writer.write("headers[$S] = { type: $S, value: $L }", memberName,
+                        getEventHeaderType(headerMember),
+                        getEventHeaderInputValue.apply("input." + memberName, headerMember));
+            });
+        }
+    }
+
+    /**
+     * The value of event header 'type' property of given shape.
+     */
+    private String getEventHeaderType(Shape shape) {
+        switch (shape.getType()) {
+            case BOOLEAN:
+            case BYTE:
+            case SHORT:
+            case INTEGER:
+            case LONG:
+            case STRING:
+            case TIMESTAMP:
+                return shape.getType().toString();
+            case BLOB:
+                return "binary";
+            default:
+                return "binary";
+        }
+    }
+
+    private void writeEventBody(
+        GenerationContext context,
+        StructureShape event,
+        BiFunction<String, MemberShape, String> getEventPayloadInputValue,
+        Consumer<GenerationContext> serializeInputEventDocumentPayload
+    ) {
+        TypeScriptWriter writer = context.getWriter();
+        Shape payloadShape = getEventPayloadShape(context, event);
+        if (payloadShape instanceof BlobShape || payloadShape instanceof StringShape) {
+            // Since event itself must be a structure shape, so string or blob payload member must has eventPayload
+            // trait explicitly.
+            MemberShape payloadMember = event.getAllMembers().values().stream()
+                    .filter(member -> member.hasTrait(EventPayloadTrait.class))
+                    .collect(Collectors.toList()).get(0);
+            String payloadMemberName = payloadMember.getMemberName();
+            writer.write("message.body = $L || message.body;",
+                    getEventPayloadInputValue.apply("input." + payloadMemberName, payloadMember));
+        } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
+            // handle implicit event payload by removing members with eventHeader trait.
+            for (MemberShape memberShape : event.members()) {
+                if (memberShape.hasTrait(EventHeaderTrait.class)) {
+                    writer.write("delete input[$S]", memberShape.getMemberName());
+                }
+            }
+            SymbolProvider symbolProvider = context.getSymbolProvider();
+            Symbol symbol = symbolProvider.toSymbol(payloadShape);
+            String serFunctionName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
+            writer.write("const body = $L(input, context);", serFunctionName);
+            serializeInputEventDocumentPayload.accept(context);
+        } else {
+            throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
+                    payloadShape.getType()));
+        }
+    }
+
+    private void generateEventStreamDeserializer(GenerationContext context, UnionShape eventsUnion) {
+
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -360,26 +360,12 @@ public class EventStreamGenerator {
             writer.openBlock("return context.eventStreamMarshaller.deserialize(", ");", () -> {
                 writer.write("output,");
                 writer.openBlock("async event => {", "}", () -> {
-                    writer.write("const eventName = Object.keys(event)[0];");
-                    writer.openBlock(
-                                "const eventHeaders = Object.entries(event[eventName].headers).reduce(", ");", () -> {
-                        writer.write(
-                            "(headers, [header, {value}]) => {headers[header] = value; return headers; },");
-                        writer.write("{} as Record<string, any>");
-                    });
-                    writer.openBlock("const eventMessage = {", "};", () -> {
-                        writer.write("headers: eventHeaders,");
-                        writer.write("body: event[eventName].body");
-                    });
-                    writer.openBlock("const parsedEvent = {", "};", () -> {
-                        writer.write("[eventName]: eventMessage");
-                    });
                     eventsUnion.getAllMembers().forEach((name, member) -> {
                         StructureShape event = model.expectShape(member.getTarget(), StructureShape.class);
-                        writer.openBlock("if (parsedEvent[$S] != null) {", "}", name, () -> {
+                        writer.openBlock("if (event[$S] != null) {", "}", name, () -> {
                             writer.openBlock("return {", "};", () -> {
                                 String eventDeserMethodName = getEventDeserFunctionName(context, event);
-                                writer.write("$1L: await $2L(parsedEvent[$1S], context),", name, eventDeserMethodName);
+                                writer.write("$1L: await $2L(event[$1S], context),", name, eventDeserMethodName);
                             });
                         });
                     });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -148,22 +148,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     public void generateSharedComponents(GenerationContext context) {
         deserializingErrorShapes.forEach(error -> generateErrorDeserializer(context, error));
         serializingErrorShapes.forEach(error -> generateErrorSerializer(context, error));
-        Model model = context.getModel();
         ServiceShape service = context.getService();
         eventStreamGenerator.generateEventStreamSerializers(
             context,
             service,
             getDocumentContentType(),
-            (dataSource, member) -> {
-                Shape target = model.expectShape(member.getTarget());
-                return getInputValue(context, Location.HEADER, dataSource, member, target);
-            },
-            (dataSource, member) -> {
-                Shape target = model.expectShape(member.getTarget());
-                return getInputValue(context, Location.PAYLOAD, dataSource, member, target);
-            },
-            (ctxt) -> {
-                this.serializeInputEventDocumentPayload(ctxt);
+            () -> {
+                this.serializeInputEventDocumentPayload(context);
             },
             serializingDocumentShapes
         );
@@ -174,11 +165,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             service,
             errorEventShapes,
             deserializingDocumentShapes,
-            isErrorCodeInBody,
-            (dataSource, member) -> {
-                Shape target = model.expectShape(member.getTarget());
-                return getOutputValue(context, Location.HEADER, dataSource, member, target);
-            }
+            isErrorCodeInBody
         );
         errorEventShapes.removeIf(deserializingErrorShapes::contains);
         errorEventShapes.forEach(error -> generateErrorDeserializer(context, error));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -164,7 +164,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             },
             (ctxt) -> {
                 this.serializeInputEventDocumentPayload(ctxt);
-            }
+            },
+            serializingDocumentShapes
         );
         // Error shapes that only referred in the error event of an eventstream
         Set<StructureShape> errorEventShapes = new TreeSet<>();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -50,6 +50,7 @@ import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.NumberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -57,8 +58,6 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EndpointTrait;
 import software.amazon.smithy.model.traits.ErrorTrait;
-// import software.amazon.smithy.model.traits.EventHeaderTrait;
-// import software.amazon.smithy.model.traits.EventPayloadTrait;
 import software.amazon.smithy.model.traits.HostLabelTrait;
 import software.amazon.smithy.model.traits.HttpErrorTrait;
 import software.amazon.smithy.model.traits.HttpQueryTrait;
@@ -91,10 +90,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private final Set<Shape> deserializingDocumentShapes = new TreeSet<>();
     private final Set<StructureShape> serializingErrorShapes = new TreeSet<>();
     private final Set<StructureShape> deserializingErrorShapes = new TreeSet<>();
-    // private final Set<StructureShape> serializeEventShapes = new TreeSet<>();
-    // private final Set<StructureShape> deserializingEventShapes = new TreeSet<>();
-    // private final Set<UnionShape> serializeEventUnions = new TreeSet<>();
-    // private final Set<UnionShape> deserializeEventUnions = new TreeSet<>();
     private final boolean isErrorCodeInBody;
     private final EventStreamGenerator eventStreamGenerator = new EventStreamGenerator();
 
@@ -151,20 +146,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
     @Override
     public void generateSharedComponents(GenerationContext context) {
-        // serializeEventUnions.forEach(eventUnion -> generateSerializingEventUnion(context, eventUnion));
-        // deserializeEventUnions.forEach(eventUnion -> generateDeserializingEventUnion(context, eventUnion));
-        // serializeEventShapes.forEach(event -> generateEventSerializer(context, event));
-        // deserializingEventShapes.forEach(event -> generateEventDeserializer(context, event));
-        serializingErrorShapes.forEach(error -> generateErrorSerializer(context, error));
-        generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
-        HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
-        HttpProtocolGeneratorUtils.generateCollectBody(context);
-        HttpProtocolGeneratorUtils.generateCollectBodyString(context);
-        HttpProtocolGeneratorUtils.generateHttpBindingUtils(context);
         Model model = context.getModel();
+        ServiceShape service = context.getService();
         eventStreamGenerator.generateEventStreamSerializers(
             context,
-            context.getService(),
+            service,
             getDocumentContentType(),
             (dataSource, member) -> {
                 Shape target = model.expectShape(member.getTarget());
@@ -176,20 +162,36 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             },
             (ctxt) -> {
                 this.serializeInputEventDocumentPayload(ctxt);
-            });
+            }
+        );
+        // Error shapes that only referred in the error event of an eventstream
+        Set<StructureShape> errorEventShapes = new TreeSet<>();
+        // Shapes referred by the eventstream's events' document payload, behaves similar to normal response document.
+        Set<Shape> eventDocumentPayloadShapes = new TreeSet<>();
         eventStreamGenerator.generateEventStreamDeserializers(
             context,
-            context.getService(),
-            deserializingErrorShapes,
-            deserializingDocumentShapes,
+            service,
+            errorEventShapes,
+            eventDocumentPayloadShapes,
             isErrorCodeInBody,
             (dataSource, member) -> {
                 Shape target = model.expectShape(member.getTarget());
                 return getOutputValue(context, Location.HEADER, dataSource, member, target);
             }
         );
+
         deserializingErrorShapes.forEach(error -> generateErrorDeserializer(context, error));
+        errorEventShapes.removeIf(deserializingErrorShapes::contains);
+        errorEventShapes.forEach(error -> generateErrorDeserializer(context, error));
+        serializingErrorShapes.forEach(error -> generateErrorSerializer(context, error));
+        generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
         generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
+        eventDocumentPayloadShapes.removeIf(deserializingDocumentShapes::contains);
+        generateDocumentBodyShapeDeserializers(context, eventDocumentPayloadShapes);
+        HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
+        HttpProtocolGeneratorUtils.generateCollectBody(context);
+        HttpProtocolGeneratorUtils.generateCollectBodyString(context);
+        HttpProtocolGeneratorUtils.generateHttpBindingUtils(context);
     }
 
     @Override
@@ -1201,15 +1203,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         switch (bindingType) {
             case PAYLOAD:
-                // if (target.isUnionShape() && target.hasTrait(StreamingTrait.class)) {
-                //     this.serializeEventUnions.add(target.asUnionShape().get());
-                //     Symbol targetSymbol = context.getSymbolProvider().toSymbol(target);
-                //     String eventSerializer = ProtocolGenerator.getSerFunctionName(targetSymbol,
-                //             context.getProtocolName());
-                //     return "context.eventStreamMarshaller.serialize(" + dataSource
-                //             + ", event => " + eventSerializer + "_event(event, context))";
-                // }
-                // Redirect to a serialization function.
                 Symbol symbol = context.getSymbolProvider().toSymbol(target);
                 return ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName())
                         + "(" + dataSource + ", context)";
@@ -1561,160 +1554,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             }
         });
     }
-
-    // // Writes a function used to dispatch event to corresponding event serializer if given event stream is
-    // // a multi-event event stream.
-    // private void generateSerializingEventUnion(
-    //         GenerationContext context,
-    //         UnionShape events
-    // ) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     SymbolProvider symbolProvider = context.getSymbolProvider();
-    //     Symbol symbol = symbolProvider.toSymbol(events);
-    //     String protocolName = context.getProtocolName();
-    //     String methodName = ProtocolGenerator.getSerFunctionName(symbol, protocolName) + "_event";
-    //     Model model = context.getModel();
-    //     writer.addImport("Message", "__Message", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-    //     writer.openBlock("const $L = (\n"
-    //             + "  input: any,\n"
-    //             + "  context: __SerdeContext\n"
-    //             + "): __Message => {", "}", methodName, () -> {
-    //         // Visit over the union type, then get the right serialization for the member.
-    //         writer.openBlock("return $T.visit(input, {", "});", symbol, () -> {
-    //             events.getAllMembers().forEach((memberName, memberShape) -> {
-    //                 StructureShape target = model.expectShape(memberShape.getTarget(), StructureShape.class);
-    //                 // Prepare event shapes to generate event serializers.
-    //                 serializeEventShapes.add(target);
-    //                 // Dispatch to special event deserialize function
-    //                 Symbol eventSymbol = symbolProvider.toSymbol(target);
-    //                 String eventSerMethodName =
-    //                         ProtocolGenerator.getSerFunctionName(eventSymbol, protocolName) + "_event";
-    //                 writer.write("$L: value => $L(value, context),", memberName, eventSerMethodName);
-    //             });
-
-    //             // Handle the unknown property.
-    //             writer.write("_: value => value as any");
-    //         });
-    //     });
-    // }
-
-    // // Writes a function serializing event input into event messages.
-    // private void generateEventSerializer(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     SymbolProvider symbolProvider = context.getSymbolProvider();
-    //     Symbol symbol = symbolProvider.toSymbol(event);
-    //     String methodName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName()) + "_event";
-    //     writer.openBlock("const $L = (\n"
-    //                    + "  input: $L,\n"
-    //                    + "  context: __SerdeContext\n"
-    //                    + "): __Message => {", "}", methodName, symbol.getName(), () -> {
-    //         writer.openBlock("const message: __Message = {", "}", () -> {
-    //             writer.openBlock("headers: {", "},", () -> {
-    //                 //fix headers required by event stream
-    //                 writer.write("\":event-type\": { type: \"string\", value: $S },", symbol.getName());
-    //                 writer.write("\":message-type\": { type: \"string\", value: \"event\" },");
-    //                 writeEventContentTypeHeader(context, event);
-    //             });
-    //             writer.write("body: new Uint8Array()");
-    //         });
-    //         writeEventHeaders(context, event);
-    //         writeEventBody(context, event);
-    //         writer.write("return message;");
-    //     });
-    // }
-
-    // private void writeEventContentTypeHeader(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     Shape payloadShape = getEventPayloadShape(context, event);
-    //     if (payloadShape instanceof BlobShape) {
-    //         writer.write("\":content-type\": { type: \"string\", value: \"application/octet-stream\" },");
-    //     } else if (payloadShape instanceof StringShape) {
-    //         writer.write("\":content-type\": { type: \"string\", value: \"text/plain\" },");
-    //     } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
-    //         writer.write("\":content-type\": { type: \"string\", value: $S },", getDocumentContentType());
-    //     } else {
-    //         throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
-    //                 payloadShape.getType()));
-    //     }
-    // }
-
-    // private Shape getEventPayloadShape(GenerationContext context, StructureShape event) {
-    //     Model model = context.getModel();
-    //     List<MemberShape> payloadMembers = event.getAllMembers().values().stream()
-    //             .filter(member -> member.hasTrait(EventPayloadTrait.class))
-    //             .collect(Collectors.toList());
-    //     return payloadMembers.isEmpty()
-    //                     ? event // implicit payload
-    //                     : model.expectShape(payloadMembers.get(0).getTarget());
-    // }
-
-    // private void writeEventHeaders(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     Model model = context.getModel();
-    //     List<MemberShape> headerMembers = event.getAllMembers().values().stream()
-    //             .filter(member -> member.hasTrait(EventHeaderTrait.class)).collect(Collectors.toList());
-    //     for (MemberShape headerMember : headerMembers) {
-    //         String memberName = headerMember.getMemberName();
-    //         Shape target = model.expectShape(headerMember.getTarget());
-    //         writer.openBlock("if (input.$L) {", "}", memberName, () -> {
-    //             writer.write("message.headers[$S] = { type: $S, value: $L }", memberName,
-    //                     getEventHeaderType(headerMember),
-    //                     getOutputValue(context, Location.HEADER, "input." + memberName, headerMember, target));
-    //         });
-    //     }
-    // }
-
-    // /**
-    //  * The value of event header 'type' property of given shape.
-    //  */
-    // private String getEventHeaderType(Shape shape) {
-    //     switch (shape.getType()) {
-    //         case BOOLEAN:
-    //         case BYTE:
-    //         case SHORT:
-    //         case INTEGER:
-    //         case LONG:
-    //         case STRING:
-    //         case TIMESTAMP:
-    //             return shape.getType().toString();
-    //         case BLOB:
-    //             return "binary";
-    //         default:
-    //             return "binary";
-    //     }
-    // }
-
-    // private void writeEventBody(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     Model model = context.getModel();
-    //     Shape payloadShape = getEventPayloadShape(context, event);
-    //     if (payloadShape instanceof BlobShape || payloadShape instanceof StringShape) {
-    //         // Since event itself must be a structure shape, so string or blob payload member must has eventPayload
-    //         // trait explicitly.
-    //         MemberShape payloadMember = event.getAllMembers().values().stream()
-    //                 .filter(member -> member.hasTrait(EventPayloadTrait.class))
-    //                 .collect(Collectors.toList()).get(0);
-    //         String payloadMemberName = payloadMember.getMemberName();
-    //         writer.write("message.body = $L || message.body;",
-    //                 getInputValue(context, Location.PAYLOAD, "input." + payloadMemberName, payloadMember,
-    //                         model.expectShape(payloadMember.getTarget())));
-    //     } else if (payloadShape instanceof StructureShape || payloadShape instanceof UnionShape) {
-    //         // handle implicit event payload by removing members with eventHeader trait.
-    //         for (MemberShape memberShape : event.members()) {
-    //             if (memberShape.hasTrait(EventHeaderTrait.class)) {
-    //                 writer.write("delete input[$S]", memberShape.getMemberName());
-    //             }
-    //         }
-    //         SymbolProvider symbolProvider = context.getSymbolProvider();
-    //         Symbol symbol = symbolProvider.toSymbol(payloadShape);
-    //         String serFunctionName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
-    //         writer.write("const body = $L(input, context);", serFunctionName);
-    //         serializeInputEventDocumentPayload(context);
-    //     } else {
-    //         throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
-    //                 payloadShape.getType()));
-    //     }
-    // }
 
     private void generateOperationRequestDeserializer(
             GenerationContext context,
@@ -2478,196 +2317,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         return readPayload(context, binding);
     }
-
-    // // Writes a function deserializing response payload to stream of event messages
-    // private void generateEventStreamDeserializer(GenerationContext context, MemberShape member, Shape target) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     writer.openBlock("const data: any = context.eventStreamMarshaller.deserialize(", ");", () -> {
-    //         writer.write("output.body,");
-    //         writer.openBlock("async event => {", "}", () -> {
-    //             writer.write("const eventName = Object.keys(event)[0];");
-    //         writer.openBlock("const eventHeaders = Object.entries(event[eventName].headers).reduce(", ");", () -> {
-    //                 writer.write(
-    //                     "(accummulator, curr) => {accummulator[curr[0]] = curr[1].value; return accummulator; },");
-    //                 writer.write("{} as Record<string, any>");
-    //             });
-    //             writer.openBlock("const eventMessage = {", "};", () -> {
-    //                 writer.write("headers: eventHeaders,");
-    //                 writer.write("body: event[eventName].body");
-    //             });
-    //             writer.openBlock("const parsedEvent = {", "};", () -> {
-    //                 writer.write("[eventName]: eventMessage");
-    //             });
-    //             Symbol targetSymbol = context.getSymbolProvider().toSymbol(target);
-    //             StringBuilder deserFunctionBuilder = new StringBuilder(ProtocolGenerator.getDeserFunctionName(
-    //                     targetSymbol, context.getProtocolName())).append("_event");
-    //             if (target instanceof StructureShape) {
-    //                 // Single-event stream. Save the structure and generate event-specific deser later.
-    //                 this.deserializingEventShapes.add(target.asStructureShape().get());
-    //                 // For single-event stream, supply event message to corresponding event structure deser.
-    //                 deserFunctionBuilder.append("(eventMessage, context)");
-    //             } else if (target instanceof UnionShape) {
-    //                 // Multi-event stream. Save the union and generate dispatcher later.
-    //                 this.deserializeEventUnions.add(target.asUnionShape().get());
-    //                 // For multi-event stream, supply event name to event pairs to the events union deser.
-    //                 deserFunctionBuilder.append("(parsedEvent, context)");
-    //             } else {
-    //                 throw new CodegenException(String.format("Unexpected shape targeted by eventstream: `%s`",
-    //                         target.getType()));
-    //             }
-    //             writer.write("return await $L;", deserFunctionBuilder.toString());
-
-    //         });
-    //     });
-    // }
-
-    // /**
-    //  * Writes a function used to dispatch event to corresponding event deserializers if given
-    //  * event stream is a multi-event event stream.
-    //  */
-    // private void generateDeserializingEventUnion(
-    //         GenerationContext context,
-    //         UnionShape events
-    // ) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     SymbolProvider symbolProvider = context.getSymbolProvider();
-    //     Symbol symbol = symbolProvider.toSymbol(events);
-    //     String protocolName = context.getProtocolName();
-    //     String methodName = ProtocolGenerator.getDeserFunctionName(symbol, protocolName) + "_event";
-    //     Model model = context.getModel();
-    //     writer.openBlock("const $L = async (\n"
-    //                    + "  output: any,\n"
-    //                    + "  context: __SerdeContext\n"
-    //                    + "): Promise<$T> => {", "}", methodName, symbol, () -> {
-    //         events.getAllMembers().forEach((name, member) -> {
-    //             StructureShape target = model.expectShape(member.getTarget(), StructureShape.class);
-    //             // Prepare event for generating event deserializers.
-    //             deserializingEventShapes.add(target);
-    //             writer.openBlock("if (output[$S] !== undefined) {", "}", name, () -> {
-    //                 writer.openBlock("return {", "};", () -> {
-    //                     // Dispatch to special event deserialize function
-    //                     Symbol eventSymbol = symbolProvider.toSymbol(target);
-    //                     String eventDeserMethodName =
-    //                             ProtocolGenerator.getDeserFunctionName(eventSymbol, protocolName) + "_event";
-    //                     writer.write("$1L: await $2L(output[$1S], context)", name, eventDeserMethodName);
-    //                 });
-    //             });
-    //         });
-    //         writer.write("return {$$unknown: output};");
-    //     });
-    // }
-
-    // // Writes a function deserializing event message to event output.
-    // private void generateEventDeserializer(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     SymbolProvider symbolProvider = context.getSymbolProvider();
-    //     Symbol symbol = symbolProvider.toSymbol(event);
-    //     String methodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()) + "_event";
-    //     // Handle the general response.
-    //     writer.openBlock("const $L = async (\n"
-    //                    + "  output: any,\n"
-    //                    + "  context: __SerdeContext\n"
-    //                    + "): Promise<$T> => {", "}", methodName, symbol, () -> {
-    //         if (event.hasTrait(ErrorTrait.class)) {
-    //             generateErrorEventDeserializer(context, event);
-    //         } else {
-    //             writer.write("let contents: $L = {} as any;", symbol.getName());
-    //             readEventHeaders(context, event);
-    //             readEventBody(context, event);
-    //             writer.write("return contents;");
-    //         }
-    //     });
-    // }
-
-    // // Writes function content that deserialize error event with error deserializer
-    // private void generateErrorEventDeserializer(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     SymbolProvider symbolProvider = context.getSymbolProvider();
-    //     // If this is an error event, we need to generate the error deserializer.
-    //     deserializingErrorShapes.add(event);
-    //     Symbol errorSymbol = symbolProvider.toSymbol(event);
-    //     String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
-    //             context.getProtocolName()) + "Response";
-    //     if (isErrorCodeInBody) {
-    //         // If error code is in body, parseBody() won't be called inside error deser. So we parse body here.
-    //         // It's ok to parse body here because body won't be streaming if 'isErrorCodeInBody' is set.
-    //         writer.openBlock("const parsedOutput: any = {", "};",
-    //                 () -> {
-    //                     writer.write("...output,");
-    //                     writer.write("body: await parseBody(output.body, context)");
-    //                 });
-    //         writer.write("return $L(parsedOutput, context);", errorDeserMethodName);
-    //     } else {
-    //         writer.write("return $L(output, context);", errorDeserMethodName);
-    //     }
-    // }
-
-    // // Parse members from event headers.
-    // private void readEventHeaders(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     Model model = context.getModel();
-    //     List<MemberShape> headerMembers = event.getAllMembers().values().stream()
-    //             .filter(member -> member.hasTrait(EventHeaderTrait.class)).collect(Collectors.toList());
-    //     for (MemberShape headerMember : headerMembers) {
-    //         String memberName = headerMember.getMemberName();
-    //         writer.openBlock("if (output.headers[$S] !== undefined) {", "}", memberName, () -> {
-    //             Shape target = model.expectShape(headerMember.getTarget());
-    //             String headerValue = getOutputValue(context, Location.HEADER,
-    //                     "output.headers['" + memberName + "']", headerMember, target);
-    //             writer.write("contents.$L = $L;", memberName, headerValue);
-    //         });
-    //     }
-    // }
-
-    // private void readEventBody(GenerationContext context, StructureShape event) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     // Parse members from event payload.
-    //     List<MemberShape> payloadMembers = event.getAllMembers().values().stream()
-    //             .filter(member -> member.hasTrait(EventPayloadTrait.class)).collect(Collectors.toList());
-    //     List<MemberShape> documentMembers = event.getAllMembers().values().stream()
-    //             .filter(member -> !member.hasTrait(EventHeaderTrait.class)
-    //                     && !member.hasTrait(EventPayloadTrait.class))
-    //             .collect(Collectors.toList());
-    //     if (!payloadMembers.isEmpty()) {
-    //         //There's only one event payload member
-    //         MemberShape payloadMember = payloadMembers.get(0);
-    //         readEventPayload(context, payloadMember);
-    //     } else if (!documentMembers.isEmpty()) {
-    //         // Parse member from event body using original event structure deser.
-    //         SymbolProvider symbolProvider = context.getSymbolProvider();
-    //         Symbol symbol = symbolProvider.toSymbol(event);
-    //         // If response has document binding, the body can be parsed to JavaScript object.
-    //         writer.write("const data: any = await parseBody(output.body, context);");
-    //         // Deser the event document with the original event(structure) shape deser function
-    //         writer.openBlock("contents = {", "} as any;", () -> {
-    //             writer.write("...contents,");
-    //             writer.write("...$L(data, context)",
-    //                     ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()));
-    //         });
-    //         //need original structure shape deserializer to deserialize event body.
-    //         deserializingDocumentShapes.add(event);
-    //     }
-    // }
-
-    // private void readEventPayload(GenerationContext context, MemberShape payloadMember) {
-    //     TypeScriptWriter writer = context.getWriter();
-    //     Model model = context.getModel();
-    //     Shape payloadTarget = model.expectShape(payloadMember.getTarget());
-    //     String memberName = payloadMember.getMemberName();
-    //     if (payloadTarget instanceof BlobShape) {
-    //         // If event payload is a blob, only need to collect stream to binary data(Uint8Array).
-    //         writer.write("contents.$L = output.body;", memberName);
-    //     } else if (payloadTarget instanceof StructureShape || payloadTarget instanceof UnionShape) {
-    //         // If body is Structure or Union, they we need to parse the string into JavaScript object.
-    //         writer.write("contents.$L = await parseBody(output.body, context);", memberName);
-    //     } else if (payloadTarget instanceof StringShape) {
-    //         // If payload is string, we need to collect body and encode binary to string.
-    //         writer.write("contents.$L = await collectBodyString(output.body, context);", memberName);
-    //     } else {
-    //         throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
-    //                 payloadTarget.getType()));
-    //     }
-    // }
 
     /**
      * Given context and a source of data, generate an output value provider for the

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1370,21 +1370,20 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Writes the code needed to serialize an event payload as a protocol-specific document.
      *
-     * <p>Implementations of this method are expected to set a value to the ${@code message.body} property.
-     * The value set is expected to by a JavaScript ${@code Uint8Array} type and is to be encoded as the
+     * <p>Implementations of this method are expected to set a value to the instantiated ${@code body} variable.
+     * The value set is expected to be a JavaScript ${@code Uint8Array} type and is to be encoded as the
      * event payload.
      *
      * <p>Three parameters will be available in scope:
      * <ul>
      *   <li>{@code body}: The serialized event payload object that needs to be transformed to binary data</li>
-     *   <li>{@code message: <T>}: The partially constructed event message.</li>
      *   <li>{@code context: SerdeContext}: a TypeScript type containing context and tools for type serde.</li>
      * </ul>
      *
      * <p>For example:
      *
      * <pre>{@code
-     * message.body = context.utf8Decoder(JSON.stringify(body));
+     * body = context.utf8Decoder(JSON.stringify(body));
      * }</pre>
      * @param context The generation context.
      */
@@ -2220,13 +2219,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Handle streaming shapes differently.
         if (target.hasTrait(StreamingTrait.class)) {
-            // if (target instanceof UnionShape) {
-            //     // If payload is a event stream, return it after calling event stream deser function.
-            //     generateEventStreamDeserializer(context, binding.getMember(), target);
-            //     writer.write("contents.$L = data;", binding.getMemberName());
-            //     // Don't generate non-eventstream payload shape again.
-            //     return null;
-            // }
             // If payload is streaming, return raw low-level stream directly.
             writer.write("const data: any = output.body;");
         } else if (target instanceof BlobShape) {


### PR DESCRIPTION
*Issue #, if available:*
Associated with https://github.com/aws/aws-sdk-js-v3/pull/3805

*Description of changes:*
Move all the event stream related utilities to the `EventStreamGenerator` class from the bloat `HttpBindingProtocolGenerator`. Make it ready to be used in the RPC protocol generators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
