### PR TITLE
feat(codegen): general data mapping function

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -348,28 +348,13 @@ public final class HttpProtocolGeneratorUtils {
 
             // Error responses must be at least BaseException interface
             SymbolReference baseExceptionReference = getClientBaseException(context);
-            writer.write("let response: $T;", baseExceptionReference);
             errorCodeGenerator.accept(context);
-            writer.openBlock("switch (errorCode) {", "}", () -> {
-                // Generate the case statement for each error, invoking the specific deserializer.
-                new TreeSet<>(operationIndex.getErrors(operation, context.getService())).forEach(error -> {
-                    final ShapeId errorId = error.getId();
-                    // Track errors bound to the operation so their deserializers may be generated.
-                    errorShapes.add(error);
-                    Symbol errorSymbol = symbolProvider.toSymbol(error);
-                    String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
-                            context.getProtocolName()) + "Response";
-                     // Dispatch to the error deserialization function.
-                    String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
-                    writer.write("case $S:", errorId.getName());
-                    writer.write("case $S:", errorId.toString());
-                    writer.indent()
-                            .write("throw await $L($L, context);", errorDeserMethodName, outputParam)
-                            .dedent();
-                });
 
-                // Build a generic error the best we can for ones we don't know about.
-                writer.write("default:").indent();
+            TreeSet<StructureShape> structureShapes = new TreeSet<>(
+                operationIndex.getErrors(operation, context.getService())
+            );
+
+            Runnable defaultErrorHandler = () -> {
                 if (shouldParseErrorBody) {
                     // Body is already parsed above
                     writer.write("const parsedBody = parsedOutput.body;");
@@ -378,21 +363,49 @@ public final class HttpProtocolGeneratorUtils {
                     writer.write("const parsedBody = await parseBody(output.body, context);");
                 }
 
+                writer.addImport("throwDefaultError", "throwDefaultError", "@aws-sdk/smithy-client");
+
                 // Get the protocol specific error location for retrieving contents.
                 String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                writer.write("const $$metadata = deserializeMetadata(output);");
-                writer.write("const statusCode = $$metadata.httpStatusCode ? $$metadata.httpStatusCode"
-                        + " + '' : undefined;");
-                writer.openBlock("response = new $T({", "});", baseExceptionReference, () -> {
-                    writer.write("name: $1L.code || $1L.Code || errorCode || statusCode || 'UnknowError',",
-                            errorLocation);
-                    writer.write("$$fault: \"client\",");
-                    writer.write("$$metadata");
+                writer.openBlock("throwDefaultError({", "})", () -> {
+                    writer.write("output,");
+                    if (errorLocation.equals("parsedBody")) {
+                        writer.write("parsedBody,");
+                    } else {
+                        writer.write("parsedBody: $L,", errorLocation);
+                    }
+                    writer.write("exceptionCtor: $T,", baseExceptionReference);
+                    writer.write("errorCode");
                 });
-                writer.addImport("decorateServiceException", "__decorateServiceException",
-                        TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-                writer.write("throw __decorateServiceException(response, $L);", errorLocation);
-            });
+            };
+
+            if (!structureShapes.isEmpty()) {
+                writer.openBlock("switch (errorCode) {", "}", () -> {
+                    // Generate the case statement for each error, invoking the specific deserializer.
+
+                    structureShapes.forEach(error -> {
+                        final ShapeId errorId = error.getId();
+                        // Track errors bound to the operation so their deserializers may be generated.
+                        errorShapes.add(error);
+                        Symbol errorSymbol = symbolProvider.toSymbol(error);
+                        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
+                            context.getProtocolName()) + "Response";
+                        // Dispatch to the error deserialization function.
+                        String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
+                        writer.write("case $S:", errorId.getName());
+                        writer.write("case $S:", errorId.toString());
+                        writer.indent()
+                            .write("throw await $L($L, context);", errorDeserMethodName, outputParam)
+                            .dedent();
+                    });
+
+                    // Build a generic error the best we can for ones we don't know about.
+                    writer.write("default:").indent();
+                    defaultErrorHandler.run();
+                });
+            } else {
+                defaultErrorHandler.run();
+            }
         });
         writer.write("");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -370,28 +370,28 @@ public final class HttpProtocolGeneratorUtils {
 
                 // Build a generic error the best we can for ones we don't know about.
                 writer.write("default:").indent();
-                        if (shouldParseErrorBody) {
-                            // Body is already parsed above
-                            writer.write("const parsedBody = parsedOutput.body;");
-                        } else {
-                            // Body is not parsed above, so parse it here
-                            writer.write("const parsedBody = await parseBody(output.body, context);");
-                        }
+                if (shouldParseErrorBody) {
+                    // Body is already parsed above
+                    writer.write("const parsedBody = parsedOutput.body;");
+                } else {
+                    // Body is not parsed above, so parse it here
+                    writer.write("const parsedBody = await parseBody(output.body, context);");
+                }
 
-                        // Get the protocol specific error location for retrieving contents.
-                        String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                        writer.write("const $$metadata = deserializeMetadata(output);");
-                        writer.write("const statusCode = $$metadata.httpStatusCode ? $$metadata.httpStatusCode"
-                                + " + '' : undefined;");
-                        writer.openBlock("response = new $T({", "});", baseExceptionReference, () -> {
-                            writer.write("name: $1L.code || $1L.Code || errorCode || statusCode || 'UnknowError',",
-                                    errorLocation);
-                            writer.write("$$fault: \"client\",");
-                            writer.write("$$metadata");
-                        });
-                        writer.addImport("decorateServiceException", "__decorateServiceException",
-                                TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-                        writer.write("throw __decorateServiceException(response, $L);", errorLocation);
+                // Get the protocol specific error location for retrieving contents.
+                String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
+                writer.write("const $$metadata = deserializeMetadata(output);");
+                writer.write("const statusCode = $$metadata.httpStatusCode ? $$metadata.httpStatusCode"
+                        + " + '' : undefined;");
+                writer.openBlock("response = new $T({", "});", baseExceptionReference, () -> {
+                    writer.write("name: $1L.code || $1L.Code || errorCode || statusCode || 'UnknowError',",
+                            errorLocation);
+                    writer.write("$$fault: \"client\",");
+                    writer.write("$$metadata");
+                });
+                writer.addImport("decorateServiceException", "__decorateServiceException",
+                        TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                writer.write("throw __decorateServiceException(response, $L);", errorLocation);
             });
         });
         writer.write("");


### PR DESCRIPTION
### Problem:
Object field names are often repeated multiple times per line in code that is only transferring fields from one object to another (mapping), with repetitive checks.

#### Examples
Request headers
```typescript
const headers = {
    "content-type": "application/xml",
    ...(isSerializableHeaderValue(input.ChecksumCRC32) && { "x-amz-checksum-crc32": input.ChecksumCRC32 }),
    ...(isSerializableHeaderValue(input.ChecksumCRC32C) && { "x-amz-checksum-crc32c": input.ChecksumCRC32C }),
    ...(isSerializableHeaderValue(input.ChecksumSHA1) && { "x-amz-checksum-sha1": input.ChecksumSHA1 }),
    ...(isSerializableHeaderValue(input.ChecksumSHA256) && { "x-amz-checksum-sha256": input.ChecksumSHA256 }),
    ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer }),
    ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
        "x-amz-expected-bucket-owner": input.ExpectedBucketOwner,
    }),
    ...(isSerializableHeaderValue(input.SSECustomerAlgorithm) && {
        "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm,
    }),
    ...(isSerializableHeaderValue(input.SSECustomerKey) && {
        "x-amz-server-side-encryption-customer-key": input.SSECustomerKey,
    }),
    ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
        "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5,
    }),
};
```

Response headers
```typescript
if (output.headers["x-amz-expiration"] !== undefined) {
    contents.Expiration = output.headers["x-amz-expiration"];
}
if (output.headers["etag"] !== undefined) {
    contents.ETag = output.headers["etag"];
}
if (output.headers["x-amz-checksum-crc32"] !== undefined) {
    contents.ChecksumCRC32 = output.headers["x-amz-checksum-crc32"];
}
if (output.headers["x-amz-checksum-crc32c"] !== undefined) {
    contents.ChecksumCRC32C = output.headers["x-amz-checksum-crc32c"];
}
if (output.headers["x-amz-checksum-sha1"] !== undefined) {
    contents.ChecksumSHA1 = output.headers["x-amz-checksum-sha1"];
}
```

Body deserialization
```typescript
if (data["Bucket"] !== undefined) {
    contents.Bucket = __expectString(data["Bucket"]);
  }
  if (data["ChecksumCRC32"] !== undefined) {
    contents.ChecksumCRC32 = __expectString(data["ChecksumCRC32"]);
  }
  if (data["ChecksumCRC32C"] !== undefined) {
    contents.ChecksumCRC32C = __expectString(data["ChecksumCRC32C"]);
  }
  if (data["ChecksumSHA1"] !== undefined) {
    contents.ChecksumSHA1 = __expectString(data["ChecksumSHA1"]);
  }
  if (data["ChecksumSHA256"] !== undefined) {
    contents.ChecksumSHA256 = __expectString(data["ChecksumSHA256"]);
  }
  if (data["ETag"] !== undefined) {
    contents.ETag = __expectString(data["ETag"]);
  }
  if (data["Key"] !== undefined) {
    contents.Key = __expectString(data["Key"]);
  }
  if (data["Location"] !== undefined) {
    contents.Location = __expectString(data["Location"]);
  }
```

... and more.

### Proposed solution:

A general purpose data mapping function. It accepts transfer instructions in a brevity form:

```typescript
{
    key: value, // unfiltered form
    key: [filter, value], // immediate filtered form
    key: [(value) => boolean, () => value] // lazy form
}
```
Where the key's value in the target object is created with a combination of the filter and the value, both of which can be value expressions or lazy functional providers. 

source: https://github.com/aws/aws-sdk-js-v3/blob/800e8e97ea1f184111e2a85208b07d68fb7297b2/packages/smithy-client/src/object-mapping.ts

Also targeted were the following repeated patterns:

Resolved path construction, XML node creation, and default error deserialization. These were turned into helper functions.

### Effects

The change for S3 in for example dist-cjs and dist-es:
dist-cjs/protocols -> 568kb to 440kb
dist-es/protocols -> 692kb to 556kb

overall reduction is approximately 0.1mb out of 1.2 to 1.3mb.