### PR TITLE
fix(server-protocol-tests): fix codegen for server-protocol-tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -1662,15 +1661,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             handleContentType(context, operation, bindingIndex);
             handleAccept(context, operation, bindingIndex);
             // Start deserializing the response.
-            writer.openBlock("const contents: $T = {", "};", inputType, () -> {
-                // Only set a type and the members if we have output.
-                operation.getInput().ifPresent(shapeId -> {
-                    // Set all the members to undefined to meet type constraints.
-                    StructureShape target = model.expectShape(shapeId).asStructureShape().get();
-                    new TreeMap<>(target.getAllMembers())
-                            .forEach((memberName, memberShape) -> writer.write(
-                                    "$L: undefined,", memberName));
-                });
+            writer.openBlock("const contents: any = map({", "});", () -> {
                 readRequestHeaders(context, operation, bindingIndex, "output");
             });
             readQueryString(context, operation, bindingIndex);


### PR DESCRIPTION
Fix for aws-sdk-js-v3 `yarn generate-clients -s && yarn test:server-protocols`
