### PR TITLE
Ignore deprecated traits for shapes in the prelude

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -265,7 +265,7 @@ public final class TypeScriptWriter extends CodeWriter {
         return member.getMemberTrait(model, DocumentationTrait.class)
                 .map(DocumentationTrait::getValue)
                 .map(docs -> {
-                    if (member.getMemberTrait(model, DeprecatedTrait.class).isPresent()) {
+                    if (member.getTrait(DeprecatedTrait.class).isPresent()) {
                         docs = "@deprecated\n\n" + docs;
                     }
                     writeDocs(docs);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change is to avoid adding `@deprecated` annotations when the target shape is in the prelude. This will make the transition to IDL-2.0 smoother as the primitive types have been deprecated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
