### PR TITLE
Update default package description based on artifact type

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
@@ -30,6 +30,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 final class PackageJsonGenerator {
 
+    public static final String PACKAGE_JSON_FILENAME = "package.json";
+
     private PackageJsonGenerator() {}
 
     static void writePackageJson(
@@ -74,6 +76,6 @@ final class PackageJsonGenerator {
         template = template.replace("${packageDescription}", settings.getPackageDescription());
         template = template.replace("${packageVersion}", settings.getPackageVersion());
         template = template.replace("${packageManager}", settings.getPackageManager().getCommand());
-        manifest.writeFile("package.json", template);
+        manifest.writeFile(PACKAGE_JSON_FILENAME, template);
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -93,7 +93,7 @@ public final class TypeScriptSettings {
         settings.setPackageName(config.expectStringMember(PACKAGE).getValue());
         settings.setPackageVersion(config.expectStringMember(PACKAGE_VERSION).getValue());
         settings.setPackageDescription(config.getStringMemberOrDefault(
-                PACKAGE_DESCRIPTION, settings.getPackageName() + " client"));
+                PACKAGE_DESCRIPTION, settings.getDefaultDescription()));
         settings.packageJson = config.getObjectMember(PACKAGE_JSON).orElse(Node.objectNode());
         config.getStringMember(PROTOCOL).map(StringNode::getValue).map(ShapeId::from).ifPresent(settings::setProtocol);
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
@@ -108,6 +108,20 @@ public final class TypeScriptSettings {
 
         settings.setPluginSettings(config);
         return settings;
+    }
+
+    private String getDefaultDescription() {
+        String description = getPackageName();
+        switch (artifactType) {
+            case CLIENT:
+                description += " client";
+                break;
+            case SSDK:
+                description += " server";
+                break;
+            default:
+        }
+        return description;
     }
 
     // TODO: this seems reusable across generators.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/PackageJsonGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/PackageJsonGeneratorTest.java
@@ -1,0 +1,52 @@
+package software.amazon.smithy.typescript.codegen;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.build.MockManifest;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PackageJsonGeneratorTest {
+    @ParameterizedTest
+    @MethodSource("providePackageDescriptionTestCases")
+    void expectPackageDescriptionUpdatedByArtifactType(TypeScriptSettings.ArtifactType artifactType, String expectedDescription) {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
+
+        MockManifest manifest = new MockManifest();
+
+        ObjectNode settings = Node.objectNodeBuilder()
+                .withMember("service", Node.from("smithy.example#Example"))
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build();
+
+        final TypeScriptSettings typeScriptSettings = TypeScriptSettings.from(model, settings, artifactType);
+
+        PackageJsonGenerator.writePackageJson(typeScriptSettings, manifest, new HashMap<>());
+
+        assertTrue(manifest.getFileString(PackageJsonGenerator.PACKAGE_JSON_FILENAME).isPresent());
+
+        String packageJson = manifest.getFileString(PackageJsonGenerator.PACKAGE_JSON_FILENAME).get();
+
+        assertThat(packageJson, containsString(String.format("\"description\": \"%s\"", expectedDescription)));
+    }
+
+    private static Stream<Arguments> providePackageDescriptionTestCases() {
+        return Stream.of(
+            Arguments.of(TypeScriptSettings.ArtifactType.SSDK, "example server"),
+            Arguments.of(TypeScriptSettings.ArtifactType.CLIENT, "example client")
+        );
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptSettingsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptSettingsTest.java
@@ -1,13 +1,19 @@
 package software.amazon.smithy.typescript.codegen;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+import java.util.stream.Stream;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.Test;
-import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.ShapeId;
 
 public class TypeScriptSettingsTest {
 
@@ -52,6 +58,33 @@ public class TypeScriptSettingsTest {
                 .build());
 
         assertEquals(TypeScriptSettings.PackageManager.NPM, settings.getPackageManager());
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("providePackageDescriptionTestCases")
+    void expectPackageDescriptionUpdatedByArtifactType(TypeScriptSettings.ArtifactType artifactType, String expectedDescription) {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
+
+        ObjectNode settings = Node.objectNodeBuilder()
+                .withMember("service", Node.from("smithy.example#Example"))
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build();
+
+        final TypeScriptSettings typeScriptSettings = TypeScriptSettings.from(model, settings, artifactType);
+
+        assertEquals(typeScriptSettings.getPackageDescription(), expectedDescription);
+    }
+
+    private static Stream<Arguments> providePackageDescriptionTestCases() {
+        return Stream.of(
+                Arguments.of(TypeScriptSettings.ArtifactType.SSDK, "example server"),
+                Arguments.of(TypeScriptSettings.ArtifactType.CLIENT, "example client")
+        );
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Update default `package.json` description based on artifact type

For example if the package name is `ExamplePackage`, the following package description can be:
* Client -> `ExamplePackage client`
* SSDK -> `ExamplePackage server`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
