### PR TITLE
Add ReadmeGenerator

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -235,6 +235,10 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
             protocolGenerator.generateProtocolTests(context);
         }
 
+        if (settings.getEnableDefaultReadme()) {
+            ReadmeGenerator.generateDefault(settings, model, writers::checkoutFileWriter);
+        }
+
         // Write each pending writer.
         LOGGER.fine("Flushing TypeScript writers");
         List<SymbolDependency> dependencies = writers.getDependencies();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ReadmeGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ReadmeGenerator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.utils.IoUtils;
+import software.amazon.smithy.utils.StringUtils;
+
+public final class ReadmeGenerator {
+
+    public static final String README_FILENAME = "README.md";
+    private static final String DEFAULT_CLIENT_README_TEMPLATE = "default_readme_client.md.template";
+    private static final String DEFAULT_SERVER_README_TEMPLATE = "default_readme_server.md.template";
+
+    private ReadmeGenerator() {}
+
+    public static void generateDefault(
+        TypeScriptSettings settings,
+        Model model,
+        Function<String, TypeScriptWriter> writerFactory
+    ) {
+        String template = settings.generateClient() ? DEFAULT_CLIENT_README_TEMPLATE : DEFAULT_SERVER_README_TEMPLATE;
+
+        TypeScriptWriter writer = writerFactory.apply(README_FILENAME);
+
+        String resource =  IoUtils.readUtf8Resource(ReadmeGenerator.class, template);
+
+        resource = resource.replaceAll(Pattern.quote("${packageName}"), settings.getPackageName());
+
+        ServiceShape service = settings.getService(model);
+
+        String serviceId = service.getId().getName();
+
+        resource = resource.replaceAll(Pattern.quote("${serviceId}"), serviceId);
+
+        String rawDocumentation = service.getTrait(DocumentationTrait.class)
+                .map(DocumentationTrait::getValue)
+                .orElse("");
+
+        String documentation = Arrays.asList(rawDocumentation.split("\n")).stream()
+                .map(StringUtils::trim)
+                .collect(Collectors.joining("\n"));
+        resource = resource.replaceAll(Pattern.quote("${documentation}"), Matcher.quoteReplacement(documentation));
+
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        OperationShape firstOperation = topDownIndex.getContainedOperations(service).iterator().next();
+        String operationName = firstOperation.getId().getName(service);
+        resource = resource.replaceAll(Pattern.quote("${commandName}"), operationName);
+        resource = resource.replaceAll(Pattern.quote("${operationName}"),
+                operationName.substring(0, 1).toLowerCase() + operationName.substring(1));
+        resource = resource.replaceAll(Pattern.quote("$"), Matcher.quoteReplacement("$$"));
+
+        writer.write(resource);
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -54,6 +54,7 @@ public final class TypeScriptSettings {
     private static final String PROTOCOL = "protocol";
     private static final String PRIVATE = "private";
     private static final String PACKAGE_MANAGER = "packageManager";
+    private static final String ENABLE_DEFAULT_README = "enableDefaultReadme";
 
     private String packageName;
     private String packageDescription = "";
@@ -66,6 +67,7 @@ public final class TypeScriptSettings {
     private ArtifactType artifactType = ArtifactType.CLIENT;
     private boolean disableDefaultValidation = false;
     private PackageManager packageManager = PackageManager.YARN;
+    private boolean enableDefaultReadme;
 
     @Deprecated
     public static TypeScriptSettings from(Model model, ObjectNode config) {
@@ -97,6 +99,8 @@ public final class TypeScriptSettings {
         settings.packageJson = config.getObjectMember(PACKAGE_JSON).orElse(Node.objectNode());
         config.getStringMember(PROTOCOL).map(StringNode::getValue).map(ShapeId::from).ifPresent(settings::setProtocol);
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
+        settings.setEnableDefaultReadme(
+                config.getBooleanMember(ENABLE_DEFAULT_README).map(BooleanNode::getValue).orElse(false));
         settings.setPackageManager(
                 config.getStringMember(PACKAGE_MANAGER)
                     .map(s -> PackageManager.fromString(s.getValue()))
@@ -251,6 +255,14 @@ public final class TypeScriptSettings {
         this.isPrivate = isPrivate;
     }
 
+    public boolean getEnableDefaultReadme() {
+        return enableDefaultReadme;
+    }
+
+    public void setEnableDefaultReadme(boolean enableDefaultReadme) {
+        this.enableDefaultReadme = enableDefaultReadme;
+    }
+
     /**
      * Returns if the generated package will be a client.
      *
@@ -381,10 +393,11 @@ public final class TypeScriptSettings {
     public enum ArtifactType {
         CLIENT(SymbolVisitor::new,
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
-                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE)),
+                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, ENABLE_DEFAULT_README)),
         SSDK((m, s) -> new ServerSymbolVisitor(m, new SymbolVisitor(m, s)),
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
-                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, DISABLE_DEFAULT_VALIDATION));
+                              SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, DISABLE_DEFAULT_VALIDATION,
+                              ENABLE_DEFAULT_README));
 
         private final BiFunction<Model, TypeScriptSettings, SymbolProvider> symbolProviderFactory;
         private final List<String> configProperties;

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/default_readme_client.md.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/default_readme_client.md.template
@@ -1,0 +1,184 @@
+<!-- generated file, do not edit directly -->
+
+# ${packageName}
+
+[![NPM version](https://img.shields.io/npm/v/${packageName}/latest.svg)](https://www.npmjs.com/package/${packageName})
+[![NPM downloads](https://img.shields.io/npm/dm/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
+
+## Description
+
+SDK for JavaScript ${serviceId} Client for Node.js, Browser and React Native.
+
+${documentation}
+
+## Installing
+To install this package, simply type add or install ${packageName}
+using your favorite package manager:
+- `npm install ${packageName}`
+- `yarn add ${packageName}`
+- `pnpm add ${packageName}`
+
+## Getting Started
+
+### Import
+
+The SDK is modulized by clients and commands.
+To send a request, you only need to import the `${serviceId}Client` and
+the commands you need, for example `${commandName}Command`:
+
+```js
+// ES5 example
+const { ${serviceId}Client, ${commandName}Command } = require("${packageName}");
+```
+
+```ts
+// ES6+ example
+import { ${serviceId}Client, ${commandName}Command } from "${packageName}";
+```
+
+### Usage
+
+To send a request, you:
+
+- Initiate client with configuration (e.g. credentials, region).
+- Initiate command with input parameters.
+- Call `send` operation on client with command object as input.
+- If you are using a custom http handler, you may call `destroy()` to close open connections.
+
+```js
+// a client can be shared by different commands.
+const client = new ${serviceId}Client({ region: "REGION" });
+
+const params = { /** input parameters */ };
+const command = new ${commandName}Command(params);
+```
+
+#### Async/await
+
+We recommend using [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+operator to wait for the promise returned by send operation as follows:
+
+```js
+// async/await.
+try {
+  const data = await client.send(command);
+  // process data.
+} catch (error) {
+  // error handling.
+} finally {
+  // finally.
+}
+```
+
+Async-await is clean, concise, intuitive, easy to debug and has better error handling
+as compared to using Promise chains or callbacks.
+
+#### Promises
+
+You can also use [Promise chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining)
+to execute send operation.
+
+```js
+client.send(command).then(
+  (data) => {
+    // process data.
+  },
+  (error) => {
+    // error handling.
+  }
+);
+```
+
+Promises can also be called using `.catch()` and `.finally()` as follows:
+
+```js
+client
+  .send(command)
+  .then((data) => {
+    // process data.
+  })
+  .catch((error) => {
+    // error handling.
+  })
+  .finally(() => {
+    // finally.
+  });
+```
+
+#### Callbacks
+
+We do not recommend using callbacks because of [callback hell](http://callbackhell.com/),
+but they are supported by the send operation.
+
+```js
+// callbacks.
+client.send(command, (err, data) => {
+  // process err and data.
+});
+```
+
+#### v2 compatible style
+
+The client can also send requests using v2 compatible style.
+However, it results in a bigger bundle size and may be dropped in next major version. More details in the blog post
+on [modular packages in AWS SDK for JavaScript](https://aws.amazon.com/blogs/developer/modular-packages-in-aws-sdk-for-javascript/)
+
+```ts
+import * as AWS from "${packageName}";
+const client = new AWS.${serviceId}({ region: "REGION" });
+
+// async/await.
+try {
+  const data = await client.${operationName}(params);
+  // process data.
+} catch (error) {
+  // error handling.
+}
+
+// Promises.
+client
+  .${operationName}(params)
+  .then((data) => {
+    // process data.
+  })
+  .catch((error) => {
+    // error handling.
+  });
+
+// callbacks.
+client.${operationName}(params, (err, data) => {
+  // process err and data.
+});
+```
+
+### Troubleshooting
+
+When the service returns an exception, the error will include the exception information,
+as well as response metadata (e.g. request id).
+
+```js
+try {
+  const data = await client.send(command);
+  // process data.
+} catch (error) {
+  const { requestId, cfId, extendedRequestId } = error.$$metadata;
+  console.log({ requestId, cfId, extendedRequestId });
+  /**
+   * The keys within exceptions are also parsed.
+   * You can access them by specifying exception names:
+   * if (error.name === 'SomeServiceException') {
+   *     const value = error.specialKeyInException;
+   * }
+   */
+}
+```
+
+## Contributing
+
+This client code is generated automatically. Any modifications will be overwritten the next time the `${packageName}` package is updated.
+
+## License
+
+This SDK is distributed under the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0),
+see LICENSE for more information.

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/default_readme_server.md.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/default_readme_server.md.template
@@ -1,0 +1,45 @@
+<!-- generated file, do not edit directly -->
+
+# ${packageName}
+
+[![NPM version](https://img.shields.io/npm/v/${packageName}/latest.svg)](https://www.npmjs.com/package/${packageName})
+[![NPM downloads](https://img.shields.io/npm/dm/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
+
+## Description
+
+SDK for JavaScript ${serviceId} Server
+
+${documentation}
+
+## Installing
+To install this package, simply type add or install ${packageName}
+using your favorite package manager:
+- `npm install ${packageName}`
+- `yarn add ${packageName}`
+- `pnpm add ${packageName}`
+
+## Getting Started
+
+Below is an example service handler created for the ${commandName} operation.
+
+```ts
+
+import {ServiceHandler} from "@aws-smithy/server-common";
+import {${commandName}ServerInput, ${commandName}ServerOutput} from "${packageName}";
+import {convertEvent, convertVersion1Response} from "@aws-smithy/server-apigateway";
+
+const ${commandName}Operation: Operation<${commandName}ServerInput, ${commandName}ServerOutput> = async (input, _) => {
+  // Populate your business logic
+};
+
+const serviceHandler: ServiceHandler<HandlerContext> = get${commandName}Handler(${commandName}Operation);
+```
+
+## Contributing
+
+This client code is generated automatically. Any modifications will be overwritten the next time the `${packageName}` package is updated.
+## License
+
+This SDK is distributed under the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0),
+see LICENSE for more information.

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/DefaultReadmeGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/DefaultReadmeGeneratorTest.java
@@ -1,0 +1,51 @@
+package software.amazon.smithy.typescript.codegen;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static software.amazon.smithy.typescript.codegen.ReadmeGenerator.README_FILENAME;
+
+class DefaultReadmeGeneratorTest {
+
+    private TypeScriptWriter writer;
+    private TypeScriptSettings settings;
+    private final Model model = Model.assembler()
+            .addImport(getClass().getResource("simple-service-with-operation.smithy"))
+            .assemble()
+            .unwrap();
+
+
+    @BeforeEach
+    void setup() {
+        writer = new TypeScriptWriter(README_FILENAME);
+        settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("service", Node.from("smithy.example#Example"))
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .withMember("enableDefaultReadme", Node.from(true))
+                .build());
+    }
+
+    @Test
+    void expectDefaultFileWrittenForClientSDK() {
+        ReadmeGenerator.generateDefault(settings, model, this::writerFactory);
+
+        assertThat(writer.toString(), containsString("SDK for JavaScript Example Client"));
+    }
+
+    @Test
+    void expectDefaultFileWrittenForServerSDK() {
+        settings.setArtifactType(TypeScriptSettings.ArtifactType.SSDK);
+
+        ReadmeGenerator.generateDefault(settings, model, this::writerFactory);
+
+        assertThat(writer.toString(), containsString("SDK for JavaScript Example Server"));
+    }
+
+    private TypeScriptWriter writerFactory(String filename) {
+        return writer;
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* Added ReadmeGenerator
* Added `enableDefaultReadme` in TypeScriptSettings (defaults to `false`)
* This allows default README.md to be generated if set to true in `smithy-build.json`.
* Updated `aws-sdk-js-v3` repo to generate AWS SDK or default README.md depending on settings (See [commit](https://github.com/AndrewFossAWS/aws-sdk-js-v3/commit/c21b61b925d934e4d774f1d67e1a5d4fc7c7aee7))
* Manually validated both AWS SDK or default README.md via using `smithy-typescript-ssdk-demo` repo
* TODO: Add additional markdown utility functions to assist client with README generations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
