### PR TITLE
feat(smithy-typescript-codegen): allow deferred resolution for api key config

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -84,6 +84,9 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", false),
     AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", false),
 
+    // Conditionally added when setting the auth middleware.
+    AWS_SDK_UTIL_MIDDLEWARE("dependencies", "@aws-sdk/util-middleware", false),
+
     // Conditionally added if a event stream shape is found anywhere in the model
     AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
             false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
 import software.amazon.smithy.model.traits.OptionalAuthTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.IoUtils;
@@ -134,6 +135,7 @@ public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
         writerFactory.accept(
                 Paths.get(CodegenUtils.SOURCE_FOLDER, "middleware", INTEGRATION_NAME, "index.ts").toString(),
                 writer -> {
+                        writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_MIDDLEWARE);
                         String source = IoUtils.readUtf8Resource(getClass(), "http-api-key-auth.ts");
                         writer.write("$L$L", noTouchNoticePrefix, "http-api-key-auth.ts");
                         writer.write("$L", source);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

In order to defer resolving the API Key configuration to when we actually make the API call, we need to allow a function to be passed in the `apiKey` property. Now that we are importing the library `@aws-sdk/util-middleware` as part of the API Key middleware, we included it explicitly as a dependency to our generated project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
