### PR TITLE
Update to smithy 1.25.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
     version = "0.11.0"
 }
 
-extra["smithyVersion"] = "[1.23.0,1.24.0["
+extra["smithyVersion"] = "[1.25.0,1.26.0["
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false


### PR DESCRIPTION
*Issue #, if available:*
Internal P71712427

*Description of changes:*
Bumps smithy to 1.25.x to attempt to remediate preview build failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
