### PR TITLE
feat(endpoint): expose static endpoint param instructions provider

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -183,7 +183,7 @@ final class CommandGenerator implements Runnable {
         }
         writer.addImport("EndpointParameterInstructions", null, "@aws-sdk/middleware-endpoint");
         writer.openBlock(
-            "public static instructions(): EndpointParameterInstructions {", "}",
+            "public static getEndpointParameterInstructions(): EndpointParameterInstructions {", "}",
             () -> {
                 writer.openBlock(
                     "return {", "};",
@@ -246,7 +246,7 @@ final class CommandGenerator implements Runnable {
                     "this.middlewareStack.use(getEndpointPlugin(configuration, ",
                     "));",
                     () -> {
-                        writer.write("$L.instructions()", symbol.getName());
+                        writer.write("$L.getEndpointParameterInstructions()", symbol.getName());
                     }
                 );
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -119,26 +119,31 @@ final class CommandGenerator implements Runnable {
         String name = symbol.getName();
         writer.writeShapeDocs(operation, shapeDoc -> shapeDoc + "\n" + getCommandExample(serviceSymbol.getName(),
                 configType, name, inputType.getName(), outputType.getName()));
-        writer.openBlock("export class $L extends $$Command<$T, $T, $L> {", "}", name, inputType, outputType,
-                configType, () -> {
+        writer.openBlock(
+            "export class $L extends $$Command<$T, $T, $L> {", "}",
+            name, inputType, outputType,
+            configType, () -> {
 
-            // Section for adding custom command properties.
-            writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
-            writer.pushState(COMMAND_PROPERTIES_SECTION).popState();
-            writer.write("// End section: $L", COMMAND_PROPERTIES_SECTION);
-            writer.write("");
+                // Section for adding custom command properties.
+                writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
+                writer.pushState(COMMAND_PROPERTIES_SECTION).popState();
+                writer.write("// End section: $L", COMMAND_PROPERTIES_SECTION);
+                writer.write("");
+                generateEndpointParameterInstructionProvider();
+                writer.write("");
 
-            generateCommandConstructor();
-            writer.write("");
-            generateCommandMiddlewareResolver(configType);
-            writeSerde();
+                generateCommandConstructor();
+                writer.write("");
+                generateCommandMiddlewareResolver(configType);
+                writeSerde();
 
-            // Hook for adding more methods to the command.
-            writer.write("// Start section: $L", COMMAND_BODY_EXTRA_SECTION)
+                // Hook for adding more methods to the command.
+                writer.write("// Start section: $L", COMMAND_BODY_EXTRA_SECTION)
                     .pushState(COMMAND_BODY_EXTRA_SECTION)
                     .popState()
                     .write("// End section: $L", COMMAND_BODY_EXTRA_SECTION);
-        });
+            }
+        );
     }
 
     private String getCommandExample(String serviceName, String configName, String commandName, String commandInput,
@@ -172,32 +177,16 @@ final class CommandGenerator implements Runnable {
         });
     }
 
-    private void generateCommandMiddlewareResolver(String configType) {
-        Symbol serde = TypeScriptDependency.MIDDLEWARE_SERDE.createSymbol("getSerdePlugin");
-        writer.writeDocs("@internal");
-        writer.write("resolveMiddleware(")
-                .indent()
-                .write("clientStack: MiddlewareStack<$L, $L>,", "ServiceInputTypes", "ServiceOutputTypes")
-                .write("configuration: $L,", configType)
-                .write("options?: $T", applicationProtocol.getOptionsType())
-                .dedent();
-        writer.openBlock("): Handler<$T, $T> {", "}", inputType, outputType, () -> {
-            // Add serialization and deserialization plugin.
-            writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
-
-            // Add customizations.
-            addCommandSpecificPlugins();
-
-            // EndpointsV2
-            if (service.hasTrait(EndpointRuleSetTrait.class)) {
-                writer.addImport(
-                    "getEndpointPlugin",
-                    "getEndpointPlugin",
-                    "@aws-sdk/middleware-endpoint"
-                );
+    private void generateEndpointParameterInstructionProvider() {
+        if (!service.hasTrait(EndpointRuleSetTrait.class)) {
+            return;
+        }
+        writer.addImport("EndpointParameterInstructions", null, "@aws-sdk/middleware-endpoint");
+        writer.openBlock(
+            "public static instructions(): EndpointParameterInstructions {", "}",
+            () -> {
                 writer.openBlock(
-                    "this.middlewareStack.use(getEndpointPlugin(configuration, {",
-                    "}));",
+                    "return {", "};",
                     () -> {
                         RuleSetParameterFinder parameterFinder = new RuleSetParameterFinder(service);
                         parameterFinder.getBuiltInParams().forEach((name, type) -> {
@@ -224,6 +213,40 @@ final class CommandGenerator implements Runnable {
                                 name, EndpointsParamNameMap.getLocalName(name)
                             );
                         });
+                    }
+                );
+            }
+        );
+    }
+
+    private void generateCommandMiddlewareResolver(String configType) {
+        Symbol serde = TypeScriptDependency.MIDDLEWARE_SERDE.createSymbol("getSerdePlugin");
+        writer.writeDocs("@internal");
+        writer.write("resolveMiddleware(")
+                .indent()
+                .write("clientStack: MiddlewareStack<$L, $L>,", "ServiceInputTypes", "ServiceOutputTypes")
+                .write("configuration: $L,", configType)
+                .write("options?: $T", applicationProtocol.getOptionsType())
+                .dedent();
+        writer.openBlock("): Handler<$T, $T> {", "}", inputType, outputType, () -> {
+            // Add serialization and deserialization plugin.
+            writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
+
+            // Add customizations.
+            addCommandSpecificPlugins();
+
+            // EndpointsV2
+            if (service.hasTrait(EndpointRuleSetTrait.class)) {
+                writer.addImport(
+                    "getEndpointPlugin",
+                    "getEndpointPlugin",
+                    "@aws-sdk/middleware-endpoint"
+                );
+                writer.openBlock(
+                    "this.middlewareStack.use(getEndpointPlugin(configuration, ",
+                    "));",
+                    () -> {
+                        writer.write("$L.instructions()", symbol.getName());
                     }
                 );
             }


### PR DESCRIPTION
This exposes the static instructions object for each command so that it can be used by other internal packages like s3 presigner and lib-upload that need to resolve the v2 endpoint of e.g. `PutObjectCommand` without necessarily `send`ing an instance of that command.

before:
```js
public resolveMiddleware() {
    this.middlewareStack.use(getEndpointPlugin(configuration, { /* instructions literal object */ })  
}
```

after:
```js
public static instructions(): EndpointParameterInstructions {
    return { /* instructions literal object */ };
}

public resolveMiddleware() {
    this.middlewareStack.use(getEndpointPlugin(configuration, Command.instructions())  
}
```

Since the instructions are not tied to individual Command instances, the function can be static.