### PR TITLE
Call parseErrorBody when parsing error structures

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -342,7 +342,7 @@ public final class HttpProtocolGeneratorUtils {
                 writer.openBlock("const parsedOutput: any = {", "};",
                         () -> {
                             writer.write("...output,");
-                            writer.write("body: await parseBody(output.body, context)");
+                            writer.write("body: await parseErrorBody(output.body, context)");
                         });
             }
 


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3034

*Description of changes:*
Calls parseErrorBody when parsing error structures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
