### PR TITLE
chore: support delegation of determining errors for an operation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2060,7 +2060,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation);
+                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -17,18 +17,21 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.knowledge.HttpBinding.Location;
-import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -313,6 +316,7 @@ public final class HttpProtocolGeneratorUtils {
      * @param errorCodeGenerator A consumer
      * @param shouldParseErrorBody Flag indicating whether need to parse response body in this dispatcher function
      * @param bodyErrorLocationModifier A function that returns the location of an error in a body given a data source.
+     * @param operationErrorsToShapes A map of error names to their {@link ShapeId}.
      * @return A set of all error structure shapes for the operation that were dispatched to.
      */
     static Set<StructureShape> generateErrorDispatcher(
@@ -321,11 +325,11 @@ public final class HttpProtocolGeneratorUtils {
             SymbolReference responseType,
             Consumer<GenerationContext> errorCodeGenerator,
             boolean shouldParseErrorBody,
-            BiFunction<GenerationContext, String, String> bodyErrorLocationModifier
+            BiFunction<GenerationContext, String, String> bodyErrorLocationModifier,
+            BiFunction<GenerationContext, OperationShape, Map<String, ShapeId>> operationErrorsToShapes
     ) {
         TypeScriptWriter writer = context.getWriter();
         SymbolProvider symbolProvider = context.getSymbolProvider();
-        OperationIndex operationIndex = OperationIndex.of(context.getModel());
         Set<StructureShape> errorShapes = new TreeSet<>();
 
         Symbol symbol = symbolProvider.toSymbol(operation);
@@ -349,10 +353,6 @@ public final class HttpProtocolGeneratorUtils {
             // Error responses must be at least BaseException interface
             SymbolReference baseExceptionReference = getClientBaseException(context);
             errorCodeGenerator.accept(context);
-
-            TreeSet<StructureShape> structureShapes = new TreeSet<>(
-                operationIndex.getErrors(operation, context.getService())
-            );
 
             Runnable defaultErrorHandler = () -> {
                 if (shouldParseErrorBody) {
@@ -379,12 +379,13 @@ public final class HttpProtocolGeneratorUtils {
                 });
             };
 
-            if (!structureShapes.isEmpty()) {
+            Map<String, ShapeId> operationNamesToShapes = operationErrorsToShapes.apply(context, operation);
+            if (!operationNamesToShapes.isEmpty()) {
                 writer.openBlock("switch (errorCode) {", "}", () -> {
                     // Generate the case statement for each error, invoking the specific deserializer.
 
-                    structureShapes.forEach(error -> {
-                        final ShapeId errorId = error.getId();
+                    operationNamesToShapes.forEach((name, errorId) -> {
+                        StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
                         // Track errors bound to the operation so their deserializers may be generated.
                         errorShapes.add(error);
                         Symbol errorSymbol = symbolProvider.toSymbol(error);
@@ -392,7 +393,7 @@ public final class HttpProtocolGeneratorUtils {
                             context.getProtocolName()) + "Response";
                         // Dispatch to the error deserialization function.
                         String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
-                        writer.write("case $S:", errorId.getName());
+                        writer.write("case $S:", name);
                         writer.write("case $S:", errorId.toString());
                         writer.indent()
                             .write("throw await $L($L, context);", errorDeserMethodName, outputParam)
@@ -467,5 +468,25 @@ public final class HttpProtocolGeneratorUtils {
                 .alias("__BaseException")
                 .symbol(serviceExceptionSymbol)
                 .build();
+    }
+
+    /**
+     * Returns a map of error names to their {@link ShapeId}.
+     *
+     * @param context   the generation context
+     * @param operation the operation shape to retrieve errors for
+     * @return map of error names to {@link ShapeId}
+     */
+    public static Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
+        return operation.getErrors().stream()
+            .collect(Collectors.toMap(
+                shapeId -> shapeId.getName(context.getService()),
+                Function.identity(),
+                (x, y) -> {
+                    if (!x.equals(y)) {
+                        throw new CodegenException(String.format("conflicting error shape ids: %s, %s", x, y));
+                    }
+                    return x;
+                }, TreeMap::new));
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -412,7 +412,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
                 context, operation, responseType, this::writeErrorCodeParser,
-                isErrorCodeInBody, this::getErrorBodyLocation);
+                isErrorCodeInBody, this::getErrorBodyLocation, this::getOperationErrors);
         deserializingErrorShapes.addAll(errorShapes);
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -261,6 +262,17 @@ public interface ProtocolGenerator {
             default:
                 return symbol.getName();
         }
+    }
+
+    /**
+     * Returns a map of error names to their {@link ShapeId}.
+     *
+     * @param context the generation context
+     * @param operation the operation shape to retrieve errors for
+     * @return map of error names to {@link ShapeId}
+     */
+    default Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
+        return HttpProtocolGeneratorUtils.getOperationErrors(context, operation);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2681
Re-post of https://github.com/awslabs/smithy-typescript/pull/489

*Description of changes:*
Supports delegation of determining errors for an operation, needed to support [awsQueryError](https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#aws-protocols-awsqueryerror-trait) trait

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
