### PR TITLE
Bump tsconfig.es.json target to ES2020

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
@@ -1,17 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": [
-      "dom",
-      "es5",
-      "es2015.promise",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2015.symbol.wellknown"
-    ],
+    "lib": ["dom"],
     "outDir": "dist-es"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3616
Blog post: [Announcing the end of support for Internet Explorer 11 in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-internet-explorer-11-in-the-aws-sdk-for-javascript-v3/)

This PR will be rebased and made ready after v3.182.0 release on Sep 30th.

*Description of changes:*
Bumps tsconfig.es.json target to ES2020

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
