### PR TITLE
Add intEnum support, tests for enum generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.25.0,1.26.0[
+smithyVersion=[1.26.0,1.27.0[
 smithyGradleVersion=0.6.0

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.codegen.core.directed.CustomizeDirective;
 import software.amazon.smithy.codegen.core.directed.DirectedCodegen;
 import software.amazon.smithy.codegen.core.directed.GenerateEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
@@ -369,6 +370,18 @@ final class DirectedTypeScriptCodegen
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
             EnumGenerator generator = new EnumGenerator(
                     directive.shape().asStringShape().get(),
+                    directive.symbolProvider().toSymbol(directive.shape()),
+                    writer
+            );
+            generator.run();
+        });
+    }
+
+    @Override
+    public void generateIntEnumShape(GenerateIntEnumDirective<TypeScriptCodegenContext, TypeScriptSettings> directive) {
+        directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
+            IntEnumGenerator generator = new IntEnumGenerator(
+                    directive.shape().asIntEnumShape().get(),
                     directive.symbolProvider().toSymbol(directive.shape()),
                     writer
             );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IntEnumGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IntEnumGenerator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.util.Comparator;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Generates an appropriate TypeScript type from a Smithy intEnum shape.
+ *
+ * <p>For example, given the following Smithy model:</p>
+ *
+ * <pre>{@code
+ * intEnum FaceCard {
+ *     JACK = 1
+ *     QUEEN = 2
+ *     KING = 3
+ * }
+ * }</pre>
+ *
+ * <p>We will generate the following:
+ *
+ * <pre>{@code
+ * export enum FaceCard {
+ *   JACK = 1,
+ *   QUEEN = 2,
+ *   KING = 3,
+ * }
+ * }</pre>
+ *
+ * <p>Shapes that refer to this intEnum as a member will use the following
+ * generated code:
+ *
+ * <pre>{@code
+ * import { FaceCard } from "./FaceCard";
+ *
+ * interface MyStructure {
+ *   "facecard": FaceCard | number;
+ * }
+ * }</pre>
+ */
+@SmithyInternalApi
+final class IntEnumGenerator implements Runnable {
+
+    private final Symbol symbol;
+    private final IntEnumShape shape;
+    private final TypeScriptWriter writer;
+
+    IntEnumGenerator(IntEnumShape shape, Symbol symbol, TypeScriptWriter writer) {
+        this.shape = shape;
+        this.symbol = symbol;
+        this.writer = writer;
+    }
+
+    @Override
+    public void run() {
+        generateIntEnum();
+    }
+
+    private void generateIntEnum() {
+        writer.openBlock("export enum $L {", "}", symbol.getName(), () -> {
+            // Sort by the values to ensure a stable order and sane diffs.
+            shape.getEnumValues().entrySet()
+                    .stream()
+                    .sorted(Comparator.comparing(e -> e.getValue()))
+                    .forEach(this::writeIntEnumEntry);
+        });
+    }
+
+    private void writeIntEnumEntry(Map.Entry<String, Integer> entry) {
+        writer.write("$L = $L,", TypeScriptUtils.sanitizePropertyName(entry.getKey()), entry.getValue());
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/EnumGeneratorTest.java
@@ -2,6 +2,7 @@ package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -33,8 +34,7 @@ public class EnumGeneratorTest {
         new EnumGenerator(shape, symbol, writer).run();
 
         assertThat(writer.toString(), containsString("export enum Baz {"));
-        assertThat(writer.toString(), containsString("FOO = \"FOO\""));
-        assertThat(writer.toString(), containsString("BAR = \"BAR\","));
+        assertThat(writer.toString(), stringContainsInOrder("BAR = \"BAR\",", "FOO = \"FOO\""));
     }
 
     @Test

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IntEnumGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IntEnumGeneratorTest.java
@@ -1,0 +1,37 @@
+package software.amazon.smithy.typescript.codegen;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+
+public class IntEnumGeneratorTest {
+    @Test
+    public void generatesIntEnums() {
+        IntEnumShape shape = IntEnumShape.builder()
+                .id("com.foo#Foo")
+                .addMember("BAR", 5)
+                .addMember("BAZ", 2)
+                .build();
+        TypeScriptWriter writer = new TypeScriptWriter("foo");
+        Model model = Model.assembler()
+                .addShape(shape)
+                .addImport(getClass().getResource("simple-service.smithy"))
+                .assemble()
+                .unwrap();
+        TypeScriptSettings settings = TypeScriptSettings.from(model, Node.objectNodeBuilder()
+                .withMember("package", Node.from("example"))
+                .withMember("packageVersion", Node.from("1.0.0"))
+                .build());
+        Symbol symbol = new SymbolVisitor(model, settings).toSymbol(shape);
+        new IntEnumGenerator(shape, symbol, writer).run();
+
+        assertThat(writer.toString(), containsString("export enum Foo {"));
+        assertThat(writer.toString(), stringContainsInOrder("BAZ = 2,", "BAR = 5,"));
+    }
+}


### PR DESCRIPTION
PR adds support for `intEnum` shapes added with Smithy IDLv2. It relies DirectedCodegen changes added in Smithy 1.26.0 and updates to use 1.26.x.

Given this Smithy model:
```
structure MyStruct {
    myIntEnum: MyIntEnum
}

intEnum MyIntEnum {
    BAR = 3
    FOO = 1
    BAZ = 2
}
```

The following types will be generated:
```
export enum MyIntEnum {
  FOO = 1,
  BAZ = 2,
  BAR = 3,
}

export interface MyStruct {
  myIntEnum?: MyIntEnum | number;
}
```

This PR also adds and updates tests and documentation for `enum` shape generation, including the `| string` behavior in the `SymbolVisitor`, and ordering applied to members in `EnumGenerator`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
