### PR TITLE
temporary: publish one more es5 version

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.es.json
@@ -1,10 +1,17 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.symbol.wellknown"
+    ],
     "outDir": "dist-es"
   }
 }


### PR DESCRIPTION
requested by Amplify

temporarily reverts https://github.com/awslabs/smithy-typescript/pull/603 and https://github.com/aws/aws-sdk-js-v3/pull/4006