### PR TITLE
feat(codegen): pass settings to get clients plugins

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -91,7 +91,7 @@ final class DirectedTypeScriptCodegen
         List<RuntimeClientPlugin> runtimePlugins = new ArrayList<>();
         directive.integrations().forEach(integration -> {
             LOGGER.info(() -> "Adding TypeScriptIntegration: " + integration.getClass().getName());
-            integration.getClientPlugins().forEach(runtimePlugin -> {
+            integration.getClientPlugins(directive.settings()).forEach(runtimePlugin -> {
                 LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
                 runtimePlugins.add(runtimePlugin);
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
@@ -113,7 +113,7 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
     }
 
     @Override
-    public List<RuntimeClientPlugin> getClientPlugins() {
+    public List<RuntimeClientPlugin> getClientPlugins(TypeScriptSettings settings) {
         return ListUtils.of(
             RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.BODY_CHECKSUM.dependency, "ApplyMd5BodyChecksum",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -41,7 +41,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class AddEventStreamDependency implements TypeScriptIntegration {
 
     @Override
-    public List<RuntimeClientPlugin> getClientPlugins() {
+    public List<RuntimeClientPlugin> getClientPlugins(TypeScriptSettings settings) {
         return ListUtils.of(
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER.dependency,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -60,7 +60,7 @@ public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
      * query parameter, that query parameter will be used.
      */
     @Override
-    public List<RuntimeClientPlugin> getClientPlugins() {
+    public List<RuntimeClientPlugin> getClientPlugins(TypeScriptSettings settings) {
         return ListUtils.of(
             // Add the config if the service uses HTTP API key authorization.
             RuntimeClientPlugin.builder()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
@@ -41,11 +42,21 @@ public interface TypeScriptIntegration
         extends SmithyIntegration<TypeScriptSettings, TypeScriptWriter, TypeScriptCodegenContext> {
 
     /**
+     * Use {@link #getClientPlugins(TypeScriptSettings settings)} instead.
+     */
+    @Deprecated
+    default List<RuntimeClientPlugin> getClientPlugins() {
+        throw new CodegenException("The method `getClientPlugins(TypeScriptSettings settings)`"
+                + " should be used instead of getClientPlugins().");
+    }
+
+    /**
      * Gets a list of plugins to apply to the generated client.
      *
+     * @param settings Settings used to generate.
      * @return Returns the list of RuntimePlugins to apply to the client.
      */
-    default List<RuntimeClientPlugin> getClientPlugins() {
+    default List<RuntimeClientPlugin> getClientPlugins(TypeScriptSettings settings) {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

In order to allow customization of plugins during initialization (e.g. boolean property was enabled in the plugin settings), we need to pass the Smithy build settings.

BREAKING CHANGE: Codegen users must migrate from `TypeScriptIntegration.getClientPlugins()` to `getClientPlugins(TypeScriptSettings settings)`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
