### PR TITLE
fix(endpoints): move AWS name map to JSv3, additional fixes for all-service endpoint compilation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -235,9 +235,6 @@ final class CommandGenerator implements Runnable {
             // Add serialization and deserialization plugin.
             writer.write("this.middlewareStack.use($T(configuration, this.serialize, this.deserialize));", serde);
 
-            // Add customizations.
-            addCommandSpecificPlugins();
-
             // EndpointsV2
             if (service.hasTrait(EndpointRuleSetTrait.class)) {
                 writer.addImport(
@@ -253,6 +250,9 @@ final class CommandGenerator implements Runnable {
                     }
                 );
             }
+
+            // Add customizations.
+            addCommandSpecificPlugins();
 
             // Resolve the middleware stack.
             writer.write("\nconst stack = clientStack.concat(this.middlewareStack);\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsParamNameMap.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsParamNameMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,25 +15,27 @@
 
 package software.amazon.smithy.typescript.codegen.endpointsV2;
 
+import java.util.HashMap;
 import java.util.Map;
-import software.amazon.smithy.utils.MapUtils;
 
-
+/**
+ * Map of EndpointsV2 canonical ruleset param name to generated code param names.
+ * This allows continuity for parameter names that were decided prior to EndpointsV2
+ * and differ from their EndpointsV2 name.
+ */
 public final class EndpointsParamNameMap {
-    /**
-     * Map of EndpointsV2 ruleset param name to existing JSv3 config param names.
-     */
-    private static final Map<String, String> MAPPING = MapUtils.of(
-        "Region", "region",
-        "UseFIPS", "useFipsEndpoint",
-        "UseDualStack", "useDualstackEndpoint",
-        "ForcePathStyle", "forcePathStyle",
-        "Accelerate", "useAccelerateEndpoint",
-        "DisableMRAP", "disableMultiregionAccessPoints",
-        "UseArnRegion", "useArnRegion"
-    );
+    private static final Map<String, String> MAPPING = new HashMap<>();
 
     private EndpointsParamNameMap() {}
+
+    public static void setNameMapping(Map<String, String> parameterNameMap) {
+        EndpointsParamNameMap.MAPPING.clear();
+        MAPPING.putAll(parameterNameMap);
+    }
+
+    public static void addNameMapping(Map<String, String> parameterNameMap) {
+        MAPPING.putAll(parameterNameMap);
+    }
 
     public static String getLocalName(String endpointsV2ParamName) {
         return MAPPING.getOrDefault(endpointsV2ParamName, endpointsV2ParamName);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public final class EndpointsV2Generator implements Runnable {
         TypeScriptWriter writer = new TypeScriptWriter("");
 
         writer.addImport("EndpointParameters", "__EndpointParameters", "@aws-sdk/types");
+        writer.addImport("Provider", null, "@aws-sdk/types");
 
         writer.openBlock(
             "export interface ClientInputEndpointParameters {",
@@ -81,7 +82,9 @@ public final class EndpointsV2Generator implements Runnable {
             }
         );
 
+        writer.write("");
         writer.write("export type ClientResolvedEndpointParameters = ClientInputEndpointParameters;");
+        writer.write("");
 
         writer.openBlock(
             "export const resolveClientEndpointParameters = "
@@ -99,6 +102,7 @@ public final class EndpointsV2Generator implements Runnable {
             }
         );
 
+        writer.write("");
         writer.openBlock(
             "export interface EndpointParameters extends __EndpointParameters {",
             "}",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/ParameterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/ParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -102,14 +102,18 @@ public class ParameterGenerator {
     /**
      * Used to generate interface line for EndpointParameters.ts.
      */
-    public String toCodeString() {
+    public String toCodeString(boolean isClientContextParam) {
         String buffer = "";
         buffer += parameterName;
-        if (!required || hasDefault()) {
+        if (!required || hasDefault() || isClientContextParam) {
             buffer += "?";
         }
         buffer += ": ";
-        buffer += tsParamType + ";";
+        if (isClientContextParam) {
+            buffer += (tsParamType + "|" + "Provider<" + tsParamType + ">") + ";";
+        } else {
+            buffer += tsParamType + ";";
+        }
         return buffer;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -69,7 +69,8 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
                     writer.write(parameterGenerator.defaultAsCodeString());
                 }
             } else if (clientContextParams.isEmpty() || clientContextParams.containsKey(key)) {
-                writer.write(parameterGenerator.toCodeString());
+                boolean isClientContextParams = !clientContextParams.isEmpty();
+                writer.write(parameterGenerator.toCodeString(isClientContextParams));
             }
         }
         return null;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.


### PR DESCRIPTION
- takes the endpoints-2.0 branch for all service models in aws-models repo and tests codegen + compilation
- fixes resulting TS compilation errors 