### PR TITLE
fix(endpoint): add default signing name

### DIFF
--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -33,6 +33,7 @@ buildscript {
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
+    api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -327,6 +327,14 @@ final class ServiceBareBonesClientGenerator implements Runnable {
             writer.write("let $L = __getRuntimeConfig(configuration);",
                     generateConfigVariable(configVariable));
 
+            if (service.hasTrait(EndpointRuleSetTrait.class)) {
+                configVariable++;
+                writer.write("let $L = $L($L);",
+                    generateConfigVariable(configVariable),
+                    "resolveClientEndpointParameters",
+                    generateConfigVariable(configVariable - 1));
+            }
+
             // Add runtime plugin "resolve" method calls. These are invoked one
             // after the other until all of the runtime plugins have been called.
             // Only plugins that have configuration are called. Each time the
@@ -348,14 +356,6 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                                  generateConfigVariable(configVariable - 1),
                                  additionalParamsString);
                 }
-            }
-
-            if (service.hasTrait(EndpointRuleSetTrait.class)) {
-                configVariable++;
-                writer.write("let $L = $L($L);",
-                    generateConfigVariable(configVariable),
-                    "resolveClientEndpointParameters",
-                    generateConfigVariable(configVariable - 1));
             }
 
             writer.write("super($L);", generateConfigVariable(configVariable));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -17,6 +17,8 @@ package software.amazon.smithy.typescript.codegen.endpointsV2;
 
 import java.nio.file.Paths;
 import java.util.Map;
+import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.aws.traits.auth.SigV4Trait;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -83,7 +85,13 @@ public final class EndpointsV2Generator implements Runnable {
         );
 
         writer.write("");
-        writer.write("export type ClientResolvedEndpointParameters = ClientInputEndpointParameters;");
+        writer.openBlock(
+            "export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {",
+            "};",
+            () -> {
+                writer.write("defaultSigningName: string;");
+            }
+        );
         writer.write("");
 
         writer.openBlock(
@@ -98,6 +106,12 @@ public final class EndpointsV2Generator implements Runnable {
                     ruleSet.getObjectMember("parameters").ifPresent(parameters -> {
                         parameters.accept(new RuleSetParametersVisitor(writer, true));
                     });
+                    ServiceTrait serviceTrait = service.getTrait(ServiceTrait.class).get();
+                    writer.write(
+                        "defaultSigningName: \"$L\",",
+                        service.getTrait(SigV4Trait.class).map(SigV4Trait::getName)
+                            .orElse(serviceTrait.getArnNamespace())
+                    );
                 });
             }
         );


### PR DESCRIPTION
add default signing name for endpoints 2.0 based on the sigv4 trait or the service arn namespace, because it will not have the region info provider and not all endpoints resolve with an authScheme containing a signing service name.

This PR is for: https://github.com/aws/aws-sdk-js-v3/pull/4044