### PR TITLE
fix(endpoint): do not modify context param names

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -204,7 +204,7 @@ final class CommandGenerator implements Runnable {
                         parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
                             writer.write(
                                 "$L: { type: \"contextParams\", name: \"$L\" },",
-                                name, EndpointsParamNameMap.getLocalName(name)
+                                name, name
                             );
                         });
                         parameterFinder.getClientContextParams().forEach((name, type) -> {


### PR DESCRIPTION
don't rename context params like `Bucket` to `bucket`.