### PR TITLE
fix(endpoint): quote-wrap keys in generated ruleset ts file

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
@@ -45,7 +45,7 @@ public class RuleSetSerializer {
                 "},",
                 () -> {
                     objectNode.getMembers().forEach((k, v) -> {
-                        writer.writeInline(k + ": ");
+                        writer.writeInline("\"" + k + "\": ");
                         traverse(v);
                     });
                 }


### PR DESCRIPTION
Wrap quotes on object keys in the ruleset object.

ruleset might have a key like `"x-amz-account-id":`