### PR TITLE
Use FileWriter from TypeScript Delegator to write EndpointV2 files 

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -307,7 +307,7 @@ final class DirectedTypeScriptCodegen
             return;
         }
 
-        new EndpointsV2Generator(directive.settings(), directive.model(), directive.fileManifest()).run();
+        new EndpointsV2Generator(directive.context().writerDelegator(), directive.settings(), directive.model()).run();
     }
 
     private void generateServiceInterface(GenerateServiceDirective<TypeScriptCodegenContext,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -51,6 +51,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
     MIDDLEWARE_ENDPOINTS_V2("dependencies", "@aws-sdk/middleware-endpoint", false),
+    AWS_SDK_UTIL_ENDPOINTS("dependencies", "@aws-sdk/util-endpoints", false),
 
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "2.0.0", true),
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "2.0.0", true),


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4053

*Description of changes:*
Uses FileWriter from TypeScript Delegator to write EndpointV2 files, and add `@aws-sdk/util-endpoints` dependency in return.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
