### PR TITLE
chore: remove unsupported version deprecation warning

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -2,13 +2,11 @@ import { ${clientConfigName} } from "${clientModuleName}";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
 import { loadConfigsForDefaultMode } from "@aws-sdk/smithy-client";
 import { resolveDefaultsModeConfig } from "@aws-sdk/util-defaults-mode-node";
-import { emitWarningIfUnsupportedVersion } from "@aws-sdk/smithy-client";
 
 /**
  * @internal
  */
 export const getRuntimeConfig = (config: ${clientConfigName}) => {
-  emitWarningIfUnsupportedVersion(process.version);
   const defaultsMode = resolveDefaultsModeConfig(config);
   const defaultConfigProvider = () => defaultsMode().then(loadConfigsForDefaultMode);
   const clientSharedValues = getSharedRuntimeConfig(config);


### PR DESCRIPTION
*Issue #, if available:*
No longer needed, as we've ending support for Node.js 12.x in https://github.com/awslabs/smithy-typescript/pull/623

*Description of changes:*
Removes call to unsupported version deprecation warning in runtimeConfig

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
