### PR TITLE
chore(types): set @types/node version to 14

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -44,7 +44,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", true),
     CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", true),
-    TYPES_NODE("devDependencies", "@types/node", "^12.7.5", true),
+    TYPES_NODE("devDependencies", "@types/node", "^14.14.31", true),
 
     MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", true),
     MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", true),


### PR DESCRIPTION
Node.js 12 has reached EOL. This updates the usage of types to 14 and higher. 