### PR TITLE
Add mavenCentral as plugin repository

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(":smithy-typescript-codegen-test")
 pluginManagement {
     repositories {
         mavenLocal()
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3822

*Description of changes:*

CI build are failing with:
```console
A problem occurred configuring project ':smithy-typescript-codegen-test'.
> Could not resolve all artifacts for configuration ':smithy-typescript-codegen-test:classpath'.
   > Could not resolve software.amazon.smithy:smithy-cli:[1.26.0,1.27.0[.
     Required by:
         project :smithy-typescript-codegen-test
      > Failed to list versions for software.amazon.smithy:smithy-cli.
         > Unable to load Maven meta-data from https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml.
            > Could not get resource 'https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
               > Could not GET 'https://jcenter.bintray.com/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
                  > Read timed out
   > Could not resolve software.amazon.smithy:smithy-gradle-plugin:0.6.0.
     Required by:
         project :smithy-typescript-codegen-test > software.amazon.smithy:software.amazon.smithy.gradle.plugin:0.6.0
      > Skipped due to earlier error
```

This is happening due to jCenter being [shutdown](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

The mavenCentral was added as plugin repository in other places in smithy-typescript, and in smithy project in https://github.com/awslabs/smithy/pull/1189. This PR adds mavenCentral for smithy-typescript.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
