### PR TITLE
Pin smithy-cli version to 1.26.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.26.0,1.27.0[
+smithyVersion=1.26.1
 smithyGradleVersion=0.6.0


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3822

*Description of changes:*
Pin smithy-cli version to 1.26.1 to temporally handle issues with gradle dependencies.
Previous attempt in https://github.com/awslabs/smithy-typescript/pull/629

<details>
<summary>Before</summary>

```console
$ rm -rf ~/.gradle/*                 
zsh: sure you want to delete all 6 files in /home/trivikr/.gradle [yn]? y

$ ./gradlew clean publishToMavenLocal
...
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':smithy-typescript-codegen-test'.
> Could not resolve all artifacts for configuration ':smithy-typescript-codegen-test:classpath'.
   > Could not resolve software.amazon.smithy:smithy-cli:[1.26.0,1.27.0[.
     Required by:
         project :smithy-typescript-codegen-test
      > Failed to list versions for software.amazon.smithy:smithy-cli.
         > Unable to load Maven meta-data from https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml.
            > Could not get resource 'https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
               > Could not GET 'https://jcenter.bintray.com/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
                  > Read timed out
```

</details>

<details>
<summary>After</summary>

```console
$ rm -rf ~/.gradle/*                 
zsh: sure you want to delete all 6 files in /home/trivikr/.gradle [yn]? y

$ ./gradlew clean publishToMavenLocal
...
BUILD SUCCESSFUL in 35s
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
