### PR TITLE
Use util-base64 in ServerGenerator

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -274,8 +274,8 @@ final class ServerGenerator {
         writer.addImport("ServerSerdeContext", "__ServerSerdeContext", "@aws-smithy/server-common");
         writer.addImport("NodeHttpHandler", null, "@aws-sdk/node-http-handler");
         writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
-        writer.addImport("fromBase64", null, "@aws-sdk/util-base64-node");
-        writer.addImport("toBase64", null, "@aws-sdk/util-base64-node");
+        writer.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
+        writer.addImport("toBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
         writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8-node");
         writer.addImport("toUtf8", null, "@aws-sdk/util-utf8-node");
 


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-3705

*Description of changes:*
Use util-base64 in ServerGenerator.

In AWS SDK for JavaScript (v3) clients, the change was done in https://github.com/aws/aws-sdk-js-v3/pull/4140

*Testing:*

Verified that tests pass for server artifacts:

```console
$ aws-sdk-js-v3> yarn generate-clients --server-artifacts

$ aws-sdk-js-v3> yarn test:server-protocols
...
lerna success run Ran npm script 'test' in 2 packages in 15.2s:
lerna success - @aws-sdk/aws-restjson-server
lerna success - @aws-sdk/aws-restjson-validation-server
Done in 49.06s.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
