### PR TITLE
fix: trailing comma not allowed in ruleset

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -189,7 +189,7 @@ public final class EndpointsV2Generator implements Runnable {
                 writer.addImport("RuleSetObject", null, "@aws-sdk/util-endpoints");
                 writer.openBlock(
                     "export const ruleSet: RuleSetObject = ",
-                    "",
+                    ";",
                     () -> {
                         new RuleSetSerializer(
                             endpointRuleSetTrait.getRuleSet(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetSerializer.java
@@ -33,7 +33,17 @@ public class RuleSetSerializer {
      * Write the ruleset as a TS object.
      */
     public void generate() {
-        traverse(ruleSet);
+        ObjectNode objectNode = ruleSet.expectObjectNode();
+        writer.openBlock(
+            "{",
+            "}",
+            () -> {
+                objectNode.getMembers().forEach((k, v) -> {
+                    writer.writeInline("\"" + k + "\": ");
+                    traverse(v);
+                });
+            }
+        );
     }
 
     private void traverse(Node node) {


### PR DESCRIPTION
*Issue #, if available:*
#633 

*Description of changes:*

This will generate a valid TypeScript file for `src/endpoint/ruleset.ts`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
