### PR TITLE
Remove unconditional adding of util-base64 node and browser modules

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -59,8 +59,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", true),
 
-    AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", true),
-    AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", true),
+    @Deprecated AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", false),
+    @Deprecated AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", false),
     AWS_SDK_UTIL_BASE64("dependencies", "@aws-sdk/util-base64", true),
 
     AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", true),


### PR DESCRIPTION
*Issue #, if available:*
The util additions of dependencies util-base64-node and util-base64-browser were manually replaced to that of util-base64 in https://github.com/aws/aws-sdk-js-v3/pull/4140
However, they were re-added by codegen while updating clients endpoints from 2022-11-04 in https://github.com/aws/aws-sdk-js-v3/commit/7471107c0881b5d9e474447a660dd3354a50b195

*Description of changes:*
Remove unconditional adding of util-base64 node and browser modules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
