### PR TITLE
fix: missing dom type in tsconfig

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "downlevelIteration": true,
     "importHelpers": true,
     "incremental": true,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-js-v3/issues/2896

*Description of changes:*

After PR #625, the DOM type has been removed from the default tsconfig.json file (before the value for lib included the DOM). This causes the following error during compilation:
> src/models/models_0.ts(1162,67): error TS2304: Cannot find name 'Blob'.

This is change will allow compiling any recent generated Smithy project without modifying the tsconfig (as being done in the AWS SDK JS v3 repo [here](https://github.com/aws/aws-sdk-js-v3/blob/7ac3f19ee0f6e16b825fe4a22177d5e8a4af8b2a/tsconfig.json#L7)). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
