### PR TITLE
Bump actions/setup-node to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     name: TypeScript Lint
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
     name: TypeScript Test
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
     name: Ensure TypeScript is formatted
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Install dependencies


### PR DESCRIPTION
*Issue #, if available:*
Bumps default runtime to node16 https://github.com/actions/setup-node/pull/414
Removed deprecation notice printed under https://github.com/awslabs/smithy-typescript/actions/runs/3491161866

*Description of changes:*
Bump actions/setup-node to v3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
