### PR TITLE
Fix the handling `intEnum` shapes when generating output value

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2677,6 +2677,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         context.getWriter().addImport(
                                 "strictParseLong", "__strictParseLong", "@aws-sdk/smithy-client");
                         return "__strictParseLong(" + dataSource + ")";
+                    case INT_ENUM:
                     case INTEGER:
                         context.getWriter().addImport(
                                 "strictParseInt32", "__strictParseInt32", "@aws-sdk/smithy-client");


### PR DESCRIPTION
`intEnum` shapes aren't handled correctly when generating output value provider. This one-line change fixes this issue.

*Issue #, if available:*
N/A

*Description of changes:*
When running protocol test generation, `intEnum` shapes aren't handled correctly in the output-value provider generation step of `HttpBindingProtocolGenerator`. This change address the following error:

```
Projection aws-protocoltests-restjson failed: software.amazon.smithy.codegen.core.CodegenException: Unexpected number shape `intEnum`
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
