### PR TITLE
Fix broken reference to `fail()` after jest-upgrade

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -643,7 +643,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  r = await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  fail('Expected a valid response to be returned, got err.');\n"
+                       + "  fail('Expected a valid response to be returned, got:\n\n `${err}`');\n"
                        + "  return;\n"
                        + "}");
             writeResponseAssertions(operation, testCase);

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -139,3 +139,11 @@ const clientParams = {
   region: "us-west-2",
   credentials: { accessKeyId: "key", secretAccessKey: "secret" }
 }
+
+/**
+ * A wrapper function that shadows `fail` from jest-jasmine2
+ * (jasmine2 was replaced with circus in > v27 as the default test runner)
+ */
+const fail = (error?: any): never => {
+    throw new Error(error);
+}


### PR DESCRIPTION
*Description of changes:*

Jest versions >= 27 replace jest-jasmine2 with jest-circus, which does not have an implementation for the `fail()` method, but still has the method stub defined in the Jest type-defs. This change implements the `fail()` method in protocol test suites, and adjusts the thrown message to actually state the error, instead of just `err`.

For more information, see [DefinitelyTyped maintainer discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55803)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the 
terms of your choice.



*Testing*
Run the protocol test suite after making changes and running the codegen

Before changes:
```ts
  ● Ec2QueryDateTimeWithNegativeOffset:Response

    ReferenceError: fail is not defined

      184 |     r = await client.send(command);
      185 |   } catch (err) {
    > 186 |     fail("Expected a valid response to be returned, got err.");
          |     ^
      187 |     return;
      188 |   }
      189 |   expect(r["$metadata"].httpStatusCode).toBe(200);

      at test/functional/ec2query.spec.ts:186:5
          at Generator.throw (<anonymous>)
      at rejected (../../node_modules/tslib/tslib.js:115:69)
```


After changes:
```ts
  ● Ec2QueryDateTimeWithNegativeOffset:Response

    Expected a valid response to be returned, got err:

    TypeError: Invalid RFC-3339 date-time value

      162 |  */
      163 | function fail(error?: any): never {
    > 164 |   throw new Error(error);
          |         ^
      165 | }
      166 |
      167 | /**

      at fail (test/functional/ec2query.spec.ts:164:9)
      at test/functional/ec2query.spec.ts:194:5
          at Generator.throw (<anonymous>)
      at rejected (../../node_modules/tslib/tslib.js:115:69)
```