### PR TITLE
validate required input query params

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -856,17 +856,21 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             target
         );
 
+        boolean isRequired = binding.getMember().isRequired();
+        writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
+        String value = isRequired ? "__expectNonNull($L, `" + memberName + "`)" : "$L";
+
         if (Objects.equals("input." + memberName + "!", queryValue)) {
             // simple undefined check
             writer.write(
-                "$S: [,$L],",
+                "$S: [," + value + "],",
                 binding.getLocationName(),
                 queryValue
             );
         } else {
             // undefined check with lazy eval
             writer.write(
-                "$S: [() => input.$L !== void 0, () => $L],",
+                "$S: [() => input.$L !== void 0, () => " + value + "],",
                 binding.getLocationName(),
                 memberName,
                 queryValue


### PR DESCRIPTION
internal JS-3645

`expectNonNull` is a throwing assertion function from smithy-client. 
This PR adds this assertion to input shape members that have the `required` trait.

Example:
```js
s3.abortMultiPartUpload({ /* missing uploadid */ });
// TypeError: Expected a non-null value for UploadId
```