### PR TITLE
Add util-retry dependency

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -49,6 +49,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", true),
     MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", true),
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
+    UTIL_RETRY("dependencies", "@aws-sdk/util-retry", true),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
     MIDDLEWARE_ENDPOINTS_V2("dependencies", "@aws-sdk/middleware-endpoint", false),
     AWS_SDK_UTIL_ENDPOINTS("dependencies", "@aws-sdk/util-endpoints", false),


### PR DESCRIPTION
This PR adds the `util-retry` added in https://github.com/aws/aws-sdk-js-v3/pull/4224 as a dependency so that it can be used by updated clients in a forthcoming PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
