### PR TITLE
chore: remove aws trait dependency

### DIFF
--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -33,7 +33,6 @@ buildscript {
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
-    api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -62,6 +62,7 @@ public final class TypeScriptSettings {
     private ShapeId service;
     private ObjectNode pluginSettings = Node.objectNode();
     private ShapeId protocol;
+    private String defaultSigningName = "";
     private boolean isPrivate;
     private ArtifactType artifactType = ArtifactType.CLIENT;
     private boolean disableDefaultValidation = false;
@@ -373,6 +374,20 @@ public final class TypeScriptSettings {
      */
     public void setProtocol(ShapeId protocol) {
         this.protocol = Objects.requireNonNull(protocol);
+    }
+
+    /**
+     * @param name - used as the signing service name when no explicit value from endpoints AuthScheme is present.
+     */
+    public void setDefaultSigningName(String name) {
+        defaultSigningName = name;
+    }
+
+    /**
+     * @return signing service name when no explicit value from endpoints AuthScheme is present.
+     */
+    public String getDefaultSigningName() {
+        return defaultSigningName;
     }
 
     /**


### PR DESCRIPTION
internal JS-3641

pair with https://github.com/aws/aws-sdk-js-v3/pull/4259

make defaultSigningName configurable externally. AWS codegen will set this value instead of Smithy-TS.
