### PR TITLE
fix: add idempotencyToken generation if member is queryParam

### DIFF
--- a/smithy-typescript-codegen/build.gradle.kts
+++ b/smithy-typescript-codegen/build.gradle.kts
@@ -32,6 +32,7 @@ buildscript {
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
+    api("software.amazon.smithy:smithy-model:$smithyVersion")
     api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -856,18 +856,19 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         }
         boolean isRequired = binding.getMember().isRequired();
         String idempotencyComponent = (isIdempotencyToken && !isRequired) ? " ?? generateIdempotencyToken()" : "";
+        String memberAssertionComponent = (idempotencyComponent.isEmpty() ? "!" : "");
 
         String queryValue = getInputValue(
             context,
             binding.getLocation(),
-            "input." + memberName + "!",
+            "input." + memberName + memberAssertionComponent,
             binding.getMember(),
             target
         );
 
         writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
 
-        if (Objects.equals("input." + memberName + "!", queryValue)) {
+        if (Objects.equals("input." + memberName + memberAssertionComponent, queryValue)) {
             String value = isRequired ? "__expectNonNull($L, `" + memberName + "`)" : "$L";
             // simple undefined check
             writer.write(


### PR DESCRIPTION
internal P75309097

Currently we provide a default idempotency token (uuid v4) if a request structure member has the smithy trait.
We do not provide one if the member is a query parameter. 

- This PR adds the idempotency default token (`uuid.v4()`) for query parameters. 

from https://smithy.io/1.0/spec/core/behavior-traits.html#idempotencytoken-trait

> A unique identifier (typically a [UUID](https://tools.ietf.org/html/rfc4122)) SHOULD be used by the client when providing the value for the request token member. When the request token is present, the service MUST ensure that the request is not replayed within a service-defined period of time. This allows the client to safely retry operation invocations, including operations that are not read-only, that fail due to networking issues or internal server errors. The service uses the provided request token to identify and discard duplicate requests.

> Client implementations MAY automatically provide a value for a request token member if and only if the member is not explicitly provided.

merge together:
https://github.com/awslabs/smithy-typescript/pull/655
https://github.com/aws/aws-sdk-js-v3/pull/4272