### PR TITLE
Revert "Fix broken reference to `fail()` after jest-upgrade"

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -643,7 +643,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  r = await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  fail('Expected a valid response to be returned, got:\n\n `${err}`');\n"
+                       + "  fail('Expected a valid response to be returned, got err.');\n"
                        + "  return;\n"
                        + "}");
             writeResponseAssertions(operation, testCase);

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -139,11 +139,3 @@ const clientParams = {
   region: "us-west-2",
   credentials: { accessKeyId: "key", secretAccessKey: "secret" }
 }
-
-/**
- * A wrapper function that shadows `fail` from jest-jasmine2
- * (jasmine2 was replaced with circus in > v27 as the default test runner)
- */
-const fail = (error?: any): never => {
-    throw new Error(error);
-}


### PR DESCRIPTION
This reverts commit 4b16dc57d7bb1bddcaa4e9596fcd1bff5f23fc17.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
