### PR TITLE
Fix Error printout for protocol-response tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -643,7 +643,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  r = await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  fail('Expected a valid response to be returned, got err.');\n"
+                       + "  fail('Expected a valid response to be returned, got:\n\n `${err}`');\n"
                        + "  return;\n"
                        + "}");
             writeResponseAssertions(operation, testCase);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -643,7 +643,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             writer.write("try {\n"
                        + "  r = await client.send(command);\n"
                        + "} catch (err) {\n"
-                       + "  fail('Expected a valid response to be returned, got:\n\n `${err}`');\n"
+                       + "  fail(\"Expected a valid response to be returned, got \" + err);\n"
                        + "  return;\n"
                        + "}");
             writeResponseAssertions(operation, testCase);

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -139,3 +139,11 @@ const clientParams = {
   region: "us-west-2",
   credentials: { accessKeyId: "key", secretAccessKey: "secret" }
 }
+
+/**
+ * A wrapper function that shadows `fail` from jest-jasmine2
+ * (jasmine2 was replaced with circus in > v27 as the default test runner)
+ */
+const fail = (error?: any): never => {
+    throw new Error(error);
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes an issue brought in through https://github.com/awslabs/smithy-typescript/pull/645


*Testing*
- built smithy-typescript and published to local maven
- ran client-generation in JS SDK, verified no build errors
- ran protocol-test generation and ran tests, verified no build errors
- verified code-gen:

```ts
  let r: any;
  try {
    r = await client.send(command);
  } catch (err) {
    fail("Expected a valid response to be returned, got " + err);
    return;
  }
```

- verified test output for a forced-to-fail test:

```
  ● Ec2QueryDateTimeWithPositiveOffset:Response

    Expected a valid response to be returned, got TypeError: Invalid RFC-3339 date-time value
```
(NOTE: I intentionally made this test fail)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.