### PR TITLE
Fix restXml protocol test for timestampFormat targets

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1413,8 +1413,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 throw new CodegenException("Unexpected named member shape binding location `" + bindingType + "`");
         }
 
-        String baseParam = HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, member, format);
-        return baseParam + ".toString()";
+        return HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, member, format);
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -82,7 +82,7 @@ public final class HttpProtocolGeneratorUtils {
                 // Use the split to not serialize milliseconds.
                 return "(" + dataSource + ".toISOString().split('.')[0]+\"Z\")";
             case EPOCH_SECONDS:
-                return "Math.round(" + dataSource + ".getTime() / 1000)";
+                return "Math.round(" + dataSource + ".getTime() / 1000).toString()";
             case HTTP_DATE:
                 context.getWriter().addImport("dateToUtcString", "__dateToUtcString", "@aws-sdk/smithy-client");
                 return "__dateToUtcString(" + dataSource + ")";

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -30,7 +30,7 @@ public class HttpProtocolGeneratorUtilsTest {
 
         assertThat("(" + DATA_SOURCE + ".toISOString().split('.')[0]+\"Z\")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.DATE_TIME)));
-        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
+        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000).toString()",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
         assertThat("__dateToUtcString(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.HTTP_DATE)));


### PR DESCRIPTION
Currently, protocol tests generated and run against Smithy 1.26.3 or later result in the following error:
```
src/protocols/Aws_restXml.ts(2199,27): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
```
This is due to the protocol test addition in https://github.com/awslabs/smithy/pull/1440.

This PR updates the DocumentMememberSerVisitor to append `.toString()` so that generated input parameter serializers are converted to strings where necessary for restXml protocols.

To test, these smithy-typescript changes were published locally with `./gradlew clean build pTML` before Smithy dependencies were updated in https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/gradle.properties#L1 to `1.26.4` and the following was successfully run: `yarn generate-clients && yarn test:protocols` from the aws-sdk-js-v3 repository which updated the generated `Aws_restXml.ts` file and allowed the protocol tests to succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
