### PR TITLE
Fix codegen windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Java ${{ matrix.java }}
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
         java: [8, 11]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -458,7 +458,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 return visitedModels.get(shape);
             }
             // Add models into buckets no bigger than chunk size.
-            String path = Paths.get(".", SHAPE_NAMESPACE_PREFIX, "models_" + bucketCount).toString();
+            String path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_" + bucketCount);
             visitedModels.put(shape, path);
             currentBucketSize++;
             if (currentBucketSize == chunkSize) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/smithy-typescript/issues/568
*Description of changes:*
The use of `Paths.get` when creating an import/export path, ie. `import { Foo } from ./path`, caused tests to fail on Windows because the tests expect unix-like paths. For portability and consistency, the places where import/export paths are created in `SymbolVisitor` and `ImportDeclarations` were refactored to always create unix-like path separators regardless of OS.

Additionally, CI was added for Windows (and MacOS since it wasn't there already).

*Testing details:*
- Ran `./gradlew clean build` successfully on Windows and Mac

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
