### PR TITLE
Add Gradle Wrapper Validation Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Gradle Wrapper Validation Action, based on https://blog.gradle.org/gradle-wrapper-checksum-verification-github-action.

This PR is a replacement for https://github.com/awslabs/smithy-typescript/pull/255.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
