### PR TITLE
Add smithy as codeowners for the whole repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,2 @@
-# The JS team owns everything by default
 * @awslabs/aws-sdk-js-team
-
-# These libraries are only intended for use with the SSDK.
-smithy-typescript-ssdk-libs/* @awslabs/smithy
-
-# These integs tests are mostly for the SSDK integrations
-smithy-typescript-integ-tests/* @awslabs/smithy
-
-# These are all specific to SSDK functionality.
-smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java @awslabs/smithy
-smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java @awslabs/smithy
-smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java @awslabs/smithy
+* @awslabs/smithy


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Makes Smithy codeowners on the entire repo, rather than just the ssdk stuff. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
