### PR TITLE
feat: replace back re2 with regexp

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "^3.127.0",
     "@aws-sdk/types": "^3.127.0",
-    "tslib": "^1.8.0",
-    "re2-wasm": "^1.0.2"
+    "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -13,8 +13,6 @@
  *  permissions and limitations under the License.
  */
 
-import { RE2 } from "re2-wasm";
-
 import { findDuplicates } from "../unique";
 import {
   EnumValidationFailure,
@@ -288,11 +286,11 @@ export class RangeValidator implements SingleConstraintValidator<number, RangeVa
 
 export class PatternValidator implements SingleConstraintValidator<string, PatternValidationFailure> {
   private readonly inputPattern: string;
-  private readonly pattern: RE2;
+  private readonly pattern: RegExp;
 
   constructor(pattern: string) {
     this.inputPattern = pattern;
-    this.pattern = new RE2(pattern, "u");
+    this.pattern = new RegExp(pattern, "u");
   }
 
   validate(input: string | undefined | null, path: string): PatternValidationFailure | null {
@@ -300,7 +298,7 @@ export class PatternValidator implements SingleConstraintValidator<string, Patte
       return null;
     }
 
-    if (!this.pattern.match(input)) {
+    if (!this.pattern.test(input)) {
       return {
         constraintType: "pattern",
         constraintValues: this.inputPattern,

--- a/smithy-typescript-ssdk-libs/tsconfig.json
+++ b/smithy-typescript-ssdk-libs/tsconfig.json
@@ -15,7 +15,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES2018",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2018", "dom"],
     "baseUrl": ".",
     "strict": true,
     "declaration": true,

--- a/smithy-typescript-ssdk-libs/yarn.lock
+++ b/smithy-typescript-ssdk-libs/yarn.lock
@@ -3276,11 +3276,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-re2-wasm@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/re2-wasm/-/re2-wasm-1.0.2.tgz#78c09dc651b8962aa814b55ae7fe5e472ec15bbb"
-  integrity sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA==
-
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This reverts the re2/re2-wasm change (related to #451 and #467) and puts back the default RegExp implementation. Here are the reasons:

* re2: these regular expressions are provided by the teams that designed the API and its Smithy model, so it would make more sense to move the check for vulnerable regular expressions during the Smithy build phase.

* re2-wasm: it adds an extra step during compilation which makes the server deployment more complex (as shown in the AWS sample [here](https://github.com/aws-samples/smithy-server-generator-typescript-sample/blob/7e751f0bef5bf29d08175fb4ff0a35c07eebc327/server/lib/cdk-stack.ts#L38-L40)).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
