### PR TITLE
Revert "Fix restXml protocol test for timestampFormat targets"

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1413,7 +1413,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 throw new CodegenException("Unexpected named member shape binding location `" + bindingType + "`");
         }
 
-        return HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, member, format);
+        String baseParam = HttpProtocolGeneratorUtils.getTimestampInputParam(context, dataSource, member, format);
+        return baseParam + ".toString()";
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -82,7 +82,7 @@ public final class HttpProtocolGeneratorUtils {
                 // Use the split to not serialize milliseconds.
                 return "(" + dataSource + ".toISOString().split('.')[0]+\"Z\")";
             case EPOCH_SECONDS:
-                return "Math.round(" + dataSource + ".getTime() / 1000).toString()";
+                return "Math.round(" + dataSource + ".getTime() / 1000)";
             case HTTP_DATE:
                 context.getWriter().addImport("dateToUtcString", "__dateToUtcString", "@aws-sdk/smithy-client");
                 return "__dateToUtcString(" + dataSource + ")";

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -30,7 +30,7 @@ public class HttpProtocolGeneratorUtilsTest {
 
         assertThat("(" + DATA_SOURCE + ".toISOString().split('.')[0]+\"Z\")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.DATE_TIME)));
-        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000).toString()",
+        assertThat("Math.round(" + DATA_SOURCE + ".getTime() / 1000)",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.EPOCH_SECONDS)));
         assertThat("__dateToUtcString(" + DATA_SOURCE + ")",
                 equalTo(HttpProtocolGeneratorUtils.getTimestampInputParam(mockContext, DATA_SOURCE, shape, Format.HTTP_DATE)));


### PR DESCRIPTION
This reverts commit f42c5d0f171e9b6ebb2f1c9092c6a59f74b48c30.

This PR reverts the changes to timestampFormat targets.

The changes to the serialization caused an issue with serializing milliseconds since epoch for EventStream: https://github.com/aws/aws-sdk-js-v3/issues/4343


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
