### PR TITLE
chore: be consistent with type aliases

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
@@ -37,10 +37,10 @@ public class AddDefaultsModeDependency implements TypeScriptIntegration {
         // Dependencies used in the default runtime config template.
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER);
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_NODE);
-        writer.addImport("DefaultsMode", "DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-        writer.addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.writeDocs("The {@link DefaultsMode} that will be used to determine how certain default configuration "
+        writer.addImport("DefaultsMode", "__DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.writeDocs("The {@link __DefaultsMode} that will be used to determine how certain default configuration "
                 + "options are resolved in the SDK.");
-        writer.write("defaultsMode?: DefaultsMode | Provider<DefaultsMode>;\n");
+        writer.write("defaultsMode?: __DefaultsMode | __Provider<_DefaultsMode>;\n");
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Ensure import type aliases are consistent to avoid the same import appearing twice (for example as [here](https://github.com/aws/aws-sdk-js-v3/blob/3844108f9adcd8282f66189427bad8cb309d2746/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts#L45-L46)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
