### PR TITLE
Fix missing underscore prefix in DefaultsMode Provider

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
@@ -41,6 +41,6 @@ public class AddDefaultsModeDependency implements TypeScriptIntegration {
         writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.writeDocs("The {@link __DefaultsMode} that will be used to determine how certain default configuration "
                 + "options are resolved in the SDK.");
-        writer.write("defaultsMode?: __DefaultsMode | __Provider<_DefaultsMode>;\n");
+        writer.write("defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;\n");
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Missed in https://github.com/awslabs/smithy-typescript/pull/670

*Description of changes:*
Fix missing underscore prefix in DefaultsMode Provider

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
