### PR TITLE
Import from util-utf8 on server and tests

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -540,7 +540,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         if (isClientTest) {
             writer.write("const utf8Encoder = client.config.utf8Encoder;");
         } else {
-            writer.addImport("toUtf8", "__utf8Encoder", "@aws-sdk/util-utf8-node");
+            writer.addImport("toUtf8", "__utf8Encoder", "@aws-sdk/util-utf8");
             writer.write("const utf8Encoder = __utf8Encoder;");
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -276,8 +276,8 @@ final class ServerGenerator {
         writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
         writer.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
         writer.addImport("toBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
-        writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8-node");
-        writer.addImport("toUtf8", null, "@aws-sdk/util-utf8-node");
+        writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8");
+        writer.addImport("toUtf8", null, "@aws-sdk/util-utf8");
 
         writer.openBlock("const serdeContextBase = {", "};", () -> {
             writer.write("base64Encoder: toBase64,");


### PR DESCRIPTION
This updates server and protocol tests to import `fromUtf8` and `toUtf8` from `@aws-sdk/util-utf8`.

See https://github.com/awslabs/smithy-typescript/pull/672 for equivalent client changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
