### PR TITLE
chore(codegen): match lib and target declarations

### DIFF
--- a/smithy-typescript-ssdk-libs/tsconfig.json
+++ b/smithy-typescript-ssdk-libs/tsconfig.json
@@ -15,7 +15,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES2018",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2018", "dom"],
     "baseUrl": ".",
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
`lib` declarations targeting standards newer than the `target` are useful when one polyfills missing features.

`lib` declarations targeting _older_ standards are constraining in a strange way: we emit code relying on newer features, but types prevent us from using them

Since were are already emitting `es2018` code, we can target that standard for the types as well.

This is a spin-off of @eduardomourar's awslabs/smithy-typescript#667

Co-authored-by: Eduardo Rodrigues <eduardomourar@users.noreply.github.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
