### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @awslabs/aws-sdk-js-team
-* @awslabs/smithy
+* @awslabs/aws-sdk-js-team @awslabs/smithy


### PR DESCRIPTION
The CODEOWNERS file gives precedence to the farthest-down match. Previously, with the Smithy team on the line after the JS team, the Smithy team would be reviewers, skipping over the JS team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
