### PR TITLE
feat: use re2 test method instead of match

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -300,7 +300,7 @@ export class PatternValidator implements SingleConstraintValidator<string, Patte
       return null;
     }
 
-    if (!this.pattern.match(input)) {
+    if (!this.pattern.test(input)) {
       return {
         constraintType: "pattern",
         constraintValues: this.inputPattern,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Pulling change from PR #667 where we use the `test` method instead of `match` from re2-wasm library.  Since we only care about the success/failure of the match, `test` is enough, potentially faster, and matches Javascript native's RegExp
interface. Also, that will be useful for consumers that want to swap the regular expression implementation (e.g. with NPM overrides).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
