### PR TITLE
Clients parse datetime offsets

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -241,7 +241,8 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
                 Location.DOCUMENT,
                 shape,
                 format,
-                requiresNumericEpochSecondsInPayload());
+                requiresNumericEpochSecondsInPayload(),
+                context.getSettings().generateClient());
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2484,7 +2484,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             Format format = httpIndex.determineTimestampFormat(member, bindingType, getDocumentTimestampFormat());
             return HttpProtocolGeneratorUtils.getTimestampOutputParam(
                     context.getWriter(), dataSource, bindingType, member, format,
-                    requiresNumericEpochSecondsInPayload());
+                    requiresNumericEpochSecondsInPayload(), context.getSettings().generateClient());
         } else if (target instanceof BlobShape) {
             return getBlobOutputParam(bindingType, dataSource);
         } else if (target instanceof CollectionShape) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -37,7 +37,9 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.ArtifactType;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -46,12 +48,16 @@ public class DocumentMemberDeserVisitorTest {
     private static final String PROTOCOL = "TestProtocol";
     private static final Format FORMAT = Format.EPOCH_SECONDS;
     private static GenerationContext mockContext;
+    private static TypeScriptSettings mockSettings;
 
     static {
         mockContext = new GenerationContext();
+        mockSettings = new TypeScriptSettings();
         mockContext.setProtocolName(PROTOCOL);
         mockContext.setSymbolProvider(new MockProvider());
         mockContext.setWriter(new TypeScriptWriter("foo"));
+        mockSettings.setArtifactType(ArtifactType.SSDK);
+        mockContext.setSettings(mockSettings);
     }
 
     @ParameterizedTest

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtilsTest.java
@@ -41,14 +41,16 @@ public class HttpProtocolGeneratorUtilsTest {
         TimestampShape shape = TimestampShape.builder().id("com.smithy.example#Foo").build();
         TypeScriptWriter writer = new TypeScriptWriter("foo");
 
+        assertThat("__expectNonNull(__parseRfc3339DateTimeWithOffset(" + DATA_SOURCE + "))",
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME, false, true)));
         assertThat("__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME, false)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.DATE_TIME, false, false)));
         assertThat("__expectNonNull(__parseEpochTimestamp(__expectNumber(" + DATA_SOURCE + ")))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, true)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, true, false)));
         assertThat("__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, false)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.EPOCH_SECONDS, false, false)));
         assertThat("__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
-                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE, false)));
+                equalTo(HttpProtocolGeneratorUtils.getTimestampOutputParam(writer, DATA_SOURCE, Location.DOCUMENT, shape, Format.HTTP_DATE, false, false)));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/pull/4379 adds a new datetime parsing function, parseRfc3339DateTimeWithOffset.

This PR updates clients to use the added parsing function to gracefully handle offsets, normalizing them to zero offset.

Servers will continue to use the existing `parseRfc3339DateTime` function.

This PR should not be merged until https://github.com/aws/aws-sdk-js-v3/pull/4379 has been reviewed and merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
