### PR TITLE
Use requiredMemberMode default on codegen-test

### DIFF
--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -8,8 +8,7 @@
             "packageVersion": "0.0.1",
             "packageJson": {
                 "license": "Apache-2.0"
-            },
-            "requiredMemberMode": "strict"
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/awslabs/smithy-typescript/pull/566 introduced the `requiredMemberMode` codegen option.

This PR removes this setting from being set in smithy-typescript-codegen-test, resulting in the default `nullable` mode being used. It is being removed to avoid confusion as the `strict` mode should only be used under special cases and in lieu of other documentation, the smithy-typescript-codegen-test may serve as an example for other codegen implementations. 

The `strict` mode deserves better testing and documentation. A future PR will add additional testing and documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
