### PR TITLE
Remove reflected values from validation message

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -158,12 +158,12 @@ describe("message formatting", () => {
     it("with unique items", () => {
       const failure: UniqueItemsValidationFailure = {
         constraintType: "uniqueItems",
-        failureValue: [5,9],
-        path:"/test",
+        failureValue: [5, 9],
+        path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
         "Value with repeated values at '/test' failed to satisfy constraint: Member must have unique values"
       );
-    })
+    });
   });
 });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -32,8 +32,7 @@ describe("message formatting", () => {
       path: "/test",
     };
     expect(generateValidationMessage(failure)).toEqual(
-      "Value zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz... " +
-        "(truncated) at '/test' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-c]$"
+      "Value at '/test' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-c]$"
     );
   });
   it("omits null values", () => {
@@ -50,7 +49,7 @@ describe("message formatting", () => {
   it("formats required failures", () => {
     const failure = new RequiredValidationFailure("/test");
     expect(generateValidationMessage(failure)).toEqual(
-      "Value null at '/test' failed to satisfy constraint: Member must not be null"
+      "Value at '/test' failed to satisfy constraint: Member must not be null"
     );
   });
   it("formats enum failures", () => {
@@ -61,7 +60,7 @@ describe("message formatting", () => {
       path: "/test",
     };
     expect(generateValidationMessage(failure)).toEqual(
-      "Value pear at '/test' failed to satisfy constraint: Member must satisfy enum value set: [apple, banana]"
+      "Value at '/test' failed to satisfy constraint: Member must satisfy enum value set: [apple, banana]"
     );
   });
   it("formats integer enum failures", () => {
@@ -72,7 +71,7 @@ describe("message formatting", () => {
       path: "/test",
     };
     expect(generateValidationMessage(failure)).toEqual(
-      "Value 3 at '/test' failed to satisfy constraint: Member must satisfy enum value set: [1, 2]"
+      "Value at '/test' failed to satisfy constraint: Member must satisfy enum value set: [1, 2]"
     );
   });
   describe("formats length failures", () => {
@@ -84,7 +83,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value with length 3 at '/test' failed to satisfy constraint: Member must have length greater than or equal to 7"
+        "Value at '/test' failed to satisfy constraint: Member must have length greater than or equal to 7"
       );
     });
     it("with only max values", () => {
@@ -95,7 +94,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value with length 3 at '/test' failed to satisfy constraint: Member must have length less than or equal to 2"
+        "Value at '/test' failed to satisfy constraint: Member must have length less than or equal to 2"
       );
     });
     it("with min and max values", () => {
@@ -106,7 +105,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value with length 2 at '/test' failed to satisfy constraint: Member must have length between 3 and 7, inclusive"
+        "Value at '/test' failed to satisfy constraint: Member must have length between 3 and 7, inclusive"
       );
     });
   });
@@ -118,7 +117,7 @@ describe("message formatting", () => {
       path: "/test",
     };
     expect(generateValidationMessage(failure)).toEqual(
-      "Value xyz at '/test' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-c]$"
+      "Value at '/test' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-c]$"
     );
   });
   describe("formats range failures", () => {
@@ -130,7 +129,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value 3 at '/test' failed to satisfy constraint: Member must be greater than or equal to 7"
+        "Value at '/test' failed to satisfy constraint: Member must be greater than or equal to 7"
       );
     });
     it("with only max values", () => {
@@ -141,7 +140,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value 3 at '/test' failed to satisfy constraint: Member must be less than or equal to 2"
+        "Value at '/test' failed to satisfy constraint: Member must be less than or equal to 2"
       );
     });
     it("with min and max values", () => {
@@ -152,7 +151,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value 2 at '/test' failed to satisfy constraint: Member must be between 3 and 7, inclusive"
+        "Value at '/test' failed to satisfy constraint: Member must be between 3 and 7, inclusive"
       );
     });
   });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -21,6 +21,7 @@ import {
   PatternValidationFailure,
   RangeValidationFailure,
   RequiredValidationFailure,
+  UniqueItemsValidationFailure,
 } from "./index";
 
 describe("message formatting", () => {
@@ -83,7 +84,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value at '/test' failed to satisfy constraint: Member must have length greater than or equal to 7"
+        "Value with length 3 at '/test' failed to satisfy constraint: Member must have length greater than or equal to 7"
       );
     });
     it("with only max values", () => {
@@ -94,7 +95,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value at '/test' failed to satisfy constraint: Member must have length less than or equal to 2"
+        "Value with length 3 at '/test' failed to satisfy constraint: Member must have length less than or equal to 2"
       );
     });
     it("with min and max values", () => {
@@ -105,7 +106,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value at '/test' failed to satisfy constraint: Member must have length between 3 and 7, inclusive"
+        "Value with length 2 at '/test' failed to satisfy constraint: Member must have length between 3 and 7, inclusive"
       );
     });
   });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -155,5 +155,15 @@ describe("message formatting", () => {
         "Value at '/test' failed to satisfy constraint: Member must be between 3 and 7, inclusive"
       );
     });
+    it("with unique items", () => {
+      const failure: UniqueItemsValidationFailure = {
+        constraintType: "uniqueItems",
+        failureValue: [5,9],
+        path:"/test",
+      };
+      expect(generateValidationMessage(failure)).toEqual(
+        "Value with repeated values at '/test' failed to satisfy constraint: Member must have unique values"
+      );
+    })
   });
 });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -103,20 +103,6 @@ export const generateValidationSummary = (failures: readonly ValidationFailure[]
 };
 
 export const generateValidationMessage = (failure: ValidationFailure): string => {
-  let failureValue;
-  if (failure.constraintType === "required") {
-    failureValue = "null ";
-  } else if (failure.failureValue === null) {
-    failureValue = "";
-  } else {
-    const rawFailureValue = failure.failureValue.toString();
-    if (rawFailureValue.length > 64) {
-      failureValue = rawFailureValue.substr(0, 49) + "... (truncated) ";
-    } else {
-      failureValue = rawFailureValue + " ";
-    }
-  }
-
   let prefix = "Value";
   let suffix: string;
   switch (failure.constraintType) {
@@ -135,9 +121,6 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       break;
     }
     case "length": {
-      if (failure.failureValue !== null) {
-        prefix = prefix + " with length";
-      }
       const min = failure.constraintValues[0];
       const max = failure.constraintValues[1];
       if (min === undefined) {
@@ -170,5 +153,5 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       suffix = "must have unique values";
     }
   }
-  return `${prefix} ${failureValue}at '${failure.path}' failed to satisfy constraint: Member ${suffix}`;
+  return `${prefix} at '${failure.path}' failed to satisfy constraint: Member ${suffix}`;
 };

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -121,6 +121,9 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       break;
     }
     case "length": {
+      if (failure.failureValue !== null) {
+        prefix = prefix + " with length " + failure.failureValue;
+      }
       const min = failure.constraintValues[0];
       const max = failure.constraintValues[1];
       if (min === undefined) {


### PR DESCRIPTION
This PR updates the `generateValidationMessage` to not return the input value in the validation message.

This change will be paired with updated protocol tests: https://github.com/awslabs/smithy/pull/1622

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
