### PR TITLE
Use HttpResponse constructor in protocol tests

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -57,11 +57,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
         options?: HttpHandlerOptions
     ): Promise<{ response: HttpResponse }> {
         return Promise.resolve({
-            response: {
+            response: new HttpResponse({
                 statusCode: this.code,
                 headers: this.headers,
                 body: Readable.from([this.body])
-            }
+            })
         });
     }
 }


### PR DESCRIPTION
*Description of changes:*
Updates the TS protocol test stub to construct HttpResponse objects using the class constructor, instead of with object syntax. The constructor has optional parameters, so when updating the HttpResponse implementation we can continue to pass old properties. Without using the constructor, we have to change the HttpResponse interface and protocol test codegen simulataneously to avoid breaking changes.

Tested via js v3 sdk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
