### PR TITLE
Fix generated imports for BigDecimal support

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -237,7 +237,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     }
 
     private Symbol createBigJsSymbol(Shape shape) {
-        return createSymbolBuilder(shape, "Big", TypeScriptDependency.TYPES_BIG_JS.packageName)
+        return createSymbolBuilder(shape, "Big", TypeScriptDependency.BIG_JS.packageName)
                 .addDependency(TypeScriptDependency.TYPES_BIG_JS)
                 .addDependency(TypeScriptDependency.BIG_JS)
                 .build();


### PR DESCRIPTION
Issue: https://github.com/awslabs/smithy-typescript/issues/700

Change big.js import from "@types/big.js" to just "big.js" to avoid a TypeScript compilation error:
```
error TS6137: Cannot import type declaration files. Consider importing 'big.js' instead of '@types/big.js'.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
