### PR TITLE
Update uniqueItems validation message

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -162,7 +162,7 @@ describe("message formatting", () => {
         path: "/test",
       };
       expect(generateValidationMessage(failure)).toEqual(
-        "Value with repeated values at '/test' failed to satisfy constraint: Member must have unique values"
+        "Value at '/test' failed to satisfy constraint: Member must have unique values"
       );
     });
   });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -152,7 +152,6 @@ export const generateValidationMessage = (failure: ValidationFailure): string =>
       break;
     }
     case "uniqueItems": {
-      prefix = prefix + " with repeated values";
       suffix = "must have unique values";
     }
   }


### PR DESCRIPTION
This updates the validation message for uniqueItems to match the protocol test change from https://github.com/awslabs/smithy/pull/1639.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
