### PR TITLE
pagination: omit aggregated client in paginators

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -117,13 +117,11 @@ final class PaginationGenerator implements Runnable {
             TypeScriptWriter writer
     ) {
         writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@aws-sdk/types");
-        String aggregatedClientLocation = service.getNamespace().replace(service.getName(), aggregatedClientName);
-        writer.addImport(aggregatedClientName, aggregatedClientName, aggregatedClientLocation);
         writer.addImport(service.getName(), service.getName(), service.getNamespace());
 
         writer.openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
                 "}", aggregatedClientName, () -> {
-            writer.write("client: $L | $L;", aggregatedClientName, service.getName());
+            writer.write("client: $L;", service.getName());
         });
     }
 


### PR DESCRIPTION
for https://github.com/aws/aws-sdk-js-v3/issues/3093

Current paginators use a method based request if the client that is provided by the user is the aggregated client type. 
This is not necessary because the aggregated client extends the barebones client and can still make Command-based requests with `.send()`. 

Inclusion of the aggregated client is detrimental because it imports all commands (and thus protocols/models) in a given service, increasing bundle size.  