### PR TITLE
Remove internal enum values from validation message

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -35,7 +35,7 @@ describe("sensitive validation", () => {
 
   describe("strips the failure value from the resultant validation failure", () => {
     it("with enums", () => {
-      expect(sensitize(new EnumValidator(["apple", "banana", "orange"]), "pear").failureValue).toBeNull();
+      expect(sensitize(new EnumValidator(["apple", "banana", "orange"], ["apple"]), "pear").failureValue).toBeNull();
     });
     it("with integer enums", () => {
       expect(sensitize(new IntegerEnumValidator([1, 2, 3]), 0).failureValue).toBeNull();
@@ -53,7 +53,7 @@ describe("sensitive validation", () => {
 });
 
 describe("enum validation", () => {
-  const enumValidator = new EnumValidator(["apple", "banana", "orange"]);
+  const enumValidator = new EnumValidator(["apple", "banana", "orange"], ["apple", "banana"]);
 
   it("does not fail when the enum value is found", () => {
     expect(enumValidator.validate("apple", "fruit")).toBeNull();
@@ -62,7 +62,7 @@ describe("enum validation", () => {
   it("fails when the enum value is not found", () => {
     expect(enumValidator.validate("kiwi", "fruit")).toEqual({
       constraintType: "enum",
-      constraintValues: ["apple", "banana", "orange"],
+      constraintValues: ["apple", "banana"],
       path: "fruit",
       failureValue: "kiwi",
     });

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -153,9 +153,11 @@ export interface SingleConstraintValidator<T, F> {
 
 export class EnumValidator implements SingleConstraintValidator<string, EnumValidationFailure> {
   private readonly allowedValues: string[];
+  private readonly nonInternalValues: string[];
 
-  constructor(allowedValues: readonly string[]) {
+  constructor(allowedValues: readonly string[], nonInternalValues: readonly string[]) {
     this.allowedValues = allowedValues.slice();
+    this.nonInternalValues = nonInternalValues.slice();
   }
 
   validate(input: string | undefined | null, path: string): EnumValidationFailure | null {
@@ -166,7 +168,7 @@ export class EnumValidator implements SingleConstraintValidator<string, EnumVali
     if (this.allowedValues.indexOf(input) < 0) {
       return {
         constraintType: "enum",
-        constraintValues: this.allowedValues.slice(),
+        constraintValues: this.nonInternalValues.slice(),
         path: path,
         failureValue: input,
       };


### PR DESCRIPTION
The enum validation protocol tests were updated in https://github.com/awslabs/smithy/pull/1658 to remove enum values with the `@internal` trait, or which have been tagged with `internal`.

For example:
```
enum Fruit {
    APPLE
    BANANA
    
    @internal
    DURIAN

   @tags(["internal"])
   PAPAYA
}
```

Validation for the above `Fruit` enum will check that input is any of the four enum values, but the validation message returned will only include the non-internal values, `apple` and `banana`.

When https://github.com/aws/aws-sdk-js-v3 updates to use the smithy release that contains https://github.com/awslabs/smithy/pull/1658, a PR will be cut to update the generated validation tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
