### PR TITLE
model bucketing: special case for smithy.api#Unit

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -67,6 +67,7 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.model.traits.UnitTypeTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -459,7 +460,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
             }
             // Add models into buckets no bigger than chunk size.
             String path;
-            if (shape.getId().toString().equals("smithy.api#Unit")) {
+            if (shape.getId().equals(UnitTypeTrait.UNIT)) {
                 // Unit should only be put in the zero bucket, since it does not
                 // generate anything. It also does not contribute to bucket size.
                 path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_0");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -458,13 +458,20 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
                 return visitedModels.get(shape);
             }
             // Add models into buckets no bigger than chunk size.
-            String path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_" + bucketCount);
-            visitedModels.put(shape, path);
-            currentBucketSize++;
-            if (currentBucketSize == chunkSize) {
-                bucketCount++;
-                currentBucketSize = 0;
+            String path;
+            if (shape.getId().toString().equals("smithy.api#Unit")) {
+                // Unit should only be put in the zero bucket, since it does not
+                // generate anything. It also does not contribute to bucket size.
+                path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_0");
+            } else {
+                path = String.join("/", ".", SHAPE_NAMESPACE_PREFIX, "models_" + bucketCount);
+                currentBucketSize++;
+                if (currentBucketSize == chunkSize) {
+                    bucketCount++;
+                    currentBucketSize = 0;
+                }
             }
+            visitedModels.put(shape, path);
             return path;
         }
 


### PR DESCRIPTION
In an edge case, the only model assigned to the last bucket may be `smithy.api#Unit`. 

This causes the code generator to think that `models_N` exists, but in fact only `models_(N-1)` exists because `Unit` does not generate anything. This causes a compilation error in the generated models index.

```ts
// smithy-typescript generated code
export * from "./models_0";
export * from "./models_1"; // file doesn't exist
```

This proposed fix is to ignore `smithy.api#Unit` when incrementing the bucketing counter.

## testing
tested code generation against the edge case unreleased feature