### PR TITLE
docs: add thrown exceptions to command documentation

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -124,7 +124,7 @@ final class CommandGenerator implements Runnable {
 
         String name = symbol.getName();
         writer.writeShapeDocs(
-            operation, 
+            operation,
             shapeDoc -> shapeDoc + "\n"
             + getCommandExample(serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName())
             + "\n"
@@ -186,10 +186,10 @@ final class CommandGenerator implements Runnable {
             ErrorTrait errorTrait = errorShape.getTrait(ErrorTrait.class).get();
 
             if (doc.isPresent()) {
-                buffer.append(String.format("@throws {@link %s} (%s fault) %s\n", 
+                buffer.append(String.format("@throws {@link %s} (%s fault) %s%n",
                     error.getName(), errorTrait.getValue(), doc.get().getValue()));
             } else {
-                buffer.append(String.format("@throws {@link %s} (%s fault)\n", 
+                buffer.append(String.format("@throws {@link %s} (%s fault)%n",
                     error.getName(), errorTrait.getValue()));
             }
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -37,7 +37,10 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.endpointsV2.EndpointsParamNameMap;
 import software.amazon.smithy.typescript.codegen.endpointsV2.RuleSetParameterFinder;
@@ -120,8 +123,13 @@ final class CommandGenerator implements Runnable {
         writer.addImport("MiddlewareStack", "MiddlewareStack", "@aws-sdk/types");
 
         String name = symbol.getName();
-        writer.writeShapeDocs(operation, shapeDoc -> shapeDoc + "\n" + getCommandExample(serviceSymbol.getName(),
-                configType, name, inputType.getName(), outputType.getName()));
+        writer.writeShapeDocs(
+            operation, 
+            shapeDoc -> shapeDoc + "\n"
+            + getCommandExample(serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName())
+            + "\n"
+            + getThrownExceptions()
+        );
         writer.openBlock(
             "export class $L extends $$Command<$T, $T, $L> {", "}",
             name, inputType, outputType,
@@ -167,6 +175,25 @@ final class CommandGenerator implements Runnable {
             + String.format("@see {@link %s} for command's `input` shape.%n", commandInput)
             + String.format("@see {@link %s} for command's `response` shape.%n", commandOutput)
             + String.format("@see {@link %s | config} for %s's `config` shape.%n", configName, serviceName);
+    }
+
+    private String getThrownExceptions() {
+        List<ShapeId> errors = operation.getErrors();
+        StringBuilder buffer = new StringBuilder();
+        for (ShapeId error : errors) {
+            Shape errorShape = model.getShape(error).get();
+            Optional<DocumentationTrait> doc = errorShape.getTrait(DocumentationTrait.class);
+            ErrorTrait errorTrait = errorShape.getTrait(ErrorTrait.class).get();
+
+            if (doc.isPresent()) {
+                buffer.append(String.format("@throws {@link %s} (%s fault) %s\n", 
+                    error.getName(), errorTrait.getValue(), doc.get().getValue()));
+            } else {
+                buffer.append(String.format("@throws {@link %s} (%s fault)\n", 
+                    error.getName(), errorTrait.getValue()));
+            }
+        }
+        return buffer.toString();
     }
 
     private void generateCommandConstructor() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -123,13 +123,20 @@ final class CommandGenerator implements Runnable {
         writer.addImport("MiddlewareStack", "MiddlewareStack", "@aws-sdk/types");
 
         String name = symbol.getName();
+
+        StringBuilder additionalDocs = new StringBuilder()
+            .append("\n")
+            .append(getCommandExample(
+                serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName()
+            ))
+            .append("\n")
+            .append(getThrownExceptions());
+
         writer.writeShapeDocs(
             operation,
-            shapeDoc -> shapeDoc + "\n"
-            + getCommandExample(serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName())
-            + "\n"
-            + getThrownExceptions()
+            shapeDoc -> shapeDoc + additionalDocs
         );
+
         writer.openBlock(
             "export class $L extends $$Command<$T, $T, $L> {", "}",
             name, inputType, outputType,
@@ -186,12 +193,13 @@ final class CommandGenerator implements Runnable {
             ErrorTrait errorTrait = errorShape.getTrait(ErrorTrait.class).get();
 
             if (doc.isPresent()) {
-                buffer.append(String.format("@throws {@link %s} (%s fault) %s%n",
+                buffer.append(String.format("@throws {@link %s} (%s fault) %s",
                     error.getName(), errorTrait.getValue(), doc.get().getValue()));
             } else {
-                buffer.append(String.format("@throws {@link %s} (%s fault)%n",
+                buffer.append(String.format("@throws {@link %s} (%s fault)",
                     error.getName(), errorTrait.getValue()));
             }
+            buffer.append("\n");
         }
         return buffer.toString();
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -193,13 +193,13 @@ final class CommandGenerator implements Runnable {
             ErrorTrait errorTrait = errorShape.getTrait(ErrorTrait.class).get();
 
             if (doc.isPresent()) {
-                buffer.append(String.format("@throws {@link %s} (%s fault) %s",
+                buffer.append(String.format("@throws {@link %s} (%s fault)%n %s",
                     error.getName(), errorTrait.getValue(), doc.get().getValue()));
             } else {
                 buffer.append(String.format("@throws {@link %s} (%s fault)",
                     error.getName(), errorTrait.getValue()));
             }
-            buffer.append("\n");
+            buffer.append("\n\n");
         }
         return buffer.toString();
     }


### PR DESCRIPTION
This adds the modeled errors of each operation to the JSDoc block of the corresponding command.

This will generate useful links in API documentation. The `@throws` entries appear directly after the existing links to the command input, output, and client config. 

The current documentation makes it impossible to find which exceptions are modeled with an operation without consulting the Smithy model declaration file. This will help API documentation readers or source code readers write their error handling switch cases.

Example:

```js
/**
 * <p>Returns the content of the specified pronunciation lexicon stored
 *       in an Amazon Web Services Region. For more information, see <a href="https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html">Managing Lexicons</a>.</p>
 * @example
 * Use a bare-bones client and the command you need to make an API call.
 * ```javascript
 * import { PollyClient, GetLexiconCommand } from "@aws-sdk/client-polly"; // ES Modules import
 * // const { PollyClient, GetLexiconCommand } = require("@aws-sdk/client-polly"); // CommonJS import
 * const client = new PollyClient(config);
 * const command = new GetLexiconCommand(input);
 * const response = await client.send(command);
 * ```
 *
 * @see {@link GetLexiconCommandInput} for command's `input` shape.
 * @see {@link GetLexiconCommandOutput} for command's `response` shape.
 * @see {@link PollyClientResolvedConfig | config} for PollyClient's `config` shape.
 *
 * @throws {@link LexiconNotFoundException} (client) <p>Amazon Polly can't find the specified lexicon. This could be caused by a
 *       lexicon that is missing, its name is misspelled or specifying a lexicon
 *       that is in a different region.</p>
 *          <p>Verify that the lexicon exists, is in the region (see <a>ListLexicons</a>) and that you spelled its name is spelled
 *       correctly. Then try again.</p>
 * @throws {@link ServiceFailureException} (server) <p>An unknown condition has caused a service failure.</p>
 *
```

- [x] a JSv3 codegen change (TBD) will be committed alongside this if approved.