### PR TITLE
Add smithy-rs-typescript-server as codeowners for SSDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
 * @awslabs/aws-sdk-js-team @awslabs/smithy
+
+# These libraries are only intended for use with the SSDK.
+smithy-typescript-ssdk-libs/* @awslabs/smithy-rs-typescript-server
+
+# These are all specific to SSDK functionality.
+smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java @awslabs/smithy-rs-typescript-server
+smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java @awslabs/smithy-rs-typescript-server
+smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerSymbolVisitor.java @awslabs/smithy-rs-typescript-server


### PR DESCRIPTION
Add the CF team focused on TypeScript server. Similar to https://github.com/awslabs/smithy-typescript/blob/6366593165b8e51a80d84414ceac41dfacae5ce4/.github/CODEOWNERS but with the new team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
