### PR TITLE
Bump typescript to ~4.9.5

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -17,7 +17,7 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/base-package.json
@@ -25,7 +25,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "^3.0.0",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
*Issue #, if available:*
Bumping TypeScript is unblocked as typedoc is updated https://github.com/awslabs/smithy-typescript/pull/699

*Description of changes:*
Bump typescript to ~4.9.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
