### PR TITLE
Skip code generation of data filter functions for shapes that do not contain sensitive fields (recursive)

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -74,7 +74,7 @@ final class CommandGenerator implements Runnable {
     private final Symbol outputType;
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
-    private final SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder();
+    private final SensitiveDataFinder sensitiveDataFinder;
 
     CommandGenerator(
             TypeScriptSettings settings,
@@ -84,8 +84,7 @@ final class CommandGenerator implements Runnable {
             TypeScriptWriter writer,
             List<RuntimeClientPlugin> runtimePlugins,
             ProtocolGenerator protocolGenerator,
-            ApplicationProtocol applicationProtocol
-    ) {
+            ApplicationProtocol applicationProtocol) {
         this.settings = settings;
         this.model = model;
         this.service = settings.getService(model);
@@ -97,6 +96,7 @@ final class CommandGenerator implements Runnable {
                 .collect(Collectors.toList());
         this.protocolGenerator = protocolGenerator;
         this.applicationProtocol = applicationProtocol;
+        sensitiveDataFinder = new SensitiveDataFinder(model);
 
         symbol = symbolProvider.toSymbol(operation);
         operationIndex = OperationIndex.of(model);
@@ -127,65 +127,62 @@ final class CommandGenerator implements Runnable {
         String name = symbol.getName();
 
         StringBuilder additionalDocs = new StringBuilder()
-            .append("\n")
-            .append(getCommandExample(
-                serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName()
-            ))
-            .append("\n")
-            .append(getThrownExceptions());
+                .append("\n")
+                .append(getCommandExample(
+                        serviceSymbol.getName(), configType, name, inputType.getName(), outputType.getName()))
+                .append("\n")
+                .append(getThrownExceptions());
 
         writer.writeShapeDocs(
-            operation,
-            shapeDoc -> shapeDoc + additionalDocs
-        );
+                operation,
+                shapeDoc -> shapeDoc + additionalDocs);
 
         writer.openBlock(
-            "export class $L extends $$Command<$T, $T, $L> {", "}",
-            name, inputType, outputType,
-            configType, () -> {
+                "export class $L extends $$Command<$T, $T, $L> {", "}",
+                name, inputType, outputType,
+                configType, () -> {
 
-                // Section for adding custom command properties.
-                writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
-                writer.pushState(COMMAND_PROPERTIES_SECTION).popState();
-                writer.write("// End section: $L", COMMAND_PROPERTIES_SECTION);
-                writer.write("");
-                generateEndpointParameterInstructionProvider();
-                writer.write("");
+                    // Section for adding custom command properties.
+                    writer.write("// Start section: $L", COMMAND_PROPERTIES_SECTION);
+                    writer.pushState(COMMAND_PROPERTIES_SECTION).popState();
+                    writer.write("// End section: $L", COMMAND_PROPERTIES_SECTION);
+                    writer.write("");
+                    generateEndpointParameterInstructionProvider();
+                    writer.write("");
 
-                generateCommandConstructor();
-                writer.write("");
-                generateCommandMiddlewareResolver(configType);
-                writeSerde();
+                    generateCommandConstructor();
+                    writer.write("");
+                    generateCommandMiddlewareResolver(configType);
+                    writeSerde();
 
-                // Hook for adding more methods to the command.
-                writer.write("// Start section: $L", COMMAND_BODY_EXTRA_SECTION)
-                    .pushState(COMMAND_BODY_EXTRA_SECTION)
-                    .popState()
-                    .write("// End section: $L", COMMAND_BODY_EXTRA_SECTION);
-            }
-        );
+                    // Hook for adding more methods to the command.
+                    writer.write("// Start section: $L", COMMAND_BODY_EXTRA_SECTION)
+                            .pushState(COMMAND_BODY_EXTRA_SECTION)
+                            .popState()
+                            .write("// End section: $L", COMMAND_BODY_EXTRA_SECTION);
+                });
     }
 
     private String getCommandExample(String serviceName, String configName, String commandName, String commandInput,
-                    String commandOutput) {
+            String commandOutput) {
         String packageName = settings.getPackageName();
         return "@example\n"
-            + "Use a bare-bones client and the command you need to make an API call.\n"
-            + "```javascript\n"
-            + String.format("import { %s, %s } from \"%s\"; // ES Modules import%n", serviceName, commandName,
-                    packageName)
-            + String.format("// const { %s, %s } = require(\"%s\"); // CommonJS import%n", serviceName, commandName,
-                    packageName)
-            + String.format("const client = new %s(config);%n", serviceName)
-            + String.format("const command = new %s(input);%n", commandName)
-            + "const response = await client.send(command);\n"
-            + "```\n"
-            + "\n"
-            + String.format("@param %s - {@link %s}%n", commandInput, commandInput)
-            + String.format("@returns {@link %s}%n", commandOutput)
-            + String.format("@see {@link %s} for command's `input` shape.%n", commandInput)
-            + String.format("@see {@link %s} for command's `response` shape.%n", commandOutput)
-            + String.format("@see {@link %s | config} for %s's `config` shape.%n", configName, serviceName);
+                + "Use a bare-bones client and the command you need to make an API call.\n"
+                + "```javascript\n"
+                + String.format("import { %s, %s } from \"%s\"; // ES Modules import%n", serviceName, commandName,
+                        packageName)
+                + String.format("// const { %s, %s } = require(\"%s\"); // CommonJS import%n", serviceName, commandName,
+                        packageName)
+                + String.format("const client = new %s(config);%n", serviceName)
+                + String.format("const command = new %s(input);%n", commandName)
+                + "const response = await client.send(command);\n"
+                + "```\n"
+                + "\n"
+                + String.format("@param %s - {@link %s}%n", commandInput, commandInput)
+                + String.format("@returns {@link %s}%n", commandOutput)
+                + String.format("@see {@link %s} for command's `input` shape.%n", commandInput)
+                + String.format("@see {@link %s} for command's `response` shape.%n", commandOutput)
+                + String.format("@see {@link %s | config} for %s's `config` shape.%n", configName, serviceName);
     }
 
     private String getThrownExceptions() {
@@ -198,10 +195,10 @@ final class CommandGenerator implements Runnable {
 
             if (doc.isPresent()) {
                 buffer.append(String.format("@throws {@link %s} (%s fault)%n %s",
-                    error.getName(), errorTrait.getValue(), doc.get().getValue()));
+                        error.getName(), errorTrait.getValue(), doc.get().getValue()));
             } else {
                 buffer.append(String.format("@throws {@link %s} (%s fault)",
-                    error.getName(), errorTrait.getValue()));
+                        error.getName(), errorTrait.getValue()));
             }
             buffer.append("\n\n");
         }
@@ -210,14 +207,14 @@ final class CommandGenerator implements Runnable {
 
     private void generateCommandConstructor() {
         writer.writeDocs("@public")
-            .openBlock("constructor(readonly input: $T) {", "}", inputType, () -> {
-                // The constructor can be intercepted and changed.
-                writer.write("// Start section: $L", COMMAND_CONSTRUCTOR_SECTION)
-                        .pushState(COMMAND_CONSTRUCTOR_SECTION)
-                        .write("super();")
-                        .popState()
-                        .write("// End section: $L", COMMAND_CONSTRUCTOR_SECTION);
-        });
+                .openBlock("constructor(readonly input: $T) {", "}", inputType, () -> {
+                    // The constructor can be intercepted and changed.
+                    writer.write("// Start section: $L", COMMAND_CONSTRUCTOR_SECTION)
+                            .pushState(COMMAND_CONSTRUCTOR_SECTION)
+                            .write("super();")
+                            .popState()
+                            .write("// End section: $L", COMMAND_CONSTRUCTOR_SECTION);
+                });
     }
 
     private void generateEndpointParameterInstructionProvider() {
@@ -226,52 +223,46 @@ final class CommandGenerator implements Runnable {
         }
         writer.addImport("EndpointParameterInstructions", null, "@aws-sdk/middleware-endpoint");
         writer.openBlock(
-            "public static getEndpointParameterInstructions(): EndpointParameterInstructions {", "}",
-            () -> {
-                writer.openBlock(
-                    "return {", "};",
-                    () -> {
-                        RuleSetParameterFinder parameterFinder = new RuleSetParameterFinder(service);
-                        Set<String> paramNames = new HashSet<>();
+                "public static getEndpointParameterInstructions(): EndpointParameterInstructions {", "}",
+                () -> {
+                    writer.openBlock(
+                            "return {", "};",
+                            () -> {
+                                RuleSetParameterFinder parameterFinder = new RuleSetParameterFinder(service);
+                                Set<String> paramNames = new HashSet<>();
 
-                        parameterFinder.getStaticContextParamValues(operation).forEach((name, value) -> {
-                            writer.write(
-                                "$L: { type: \"staticContextParams\", value: $L },",
-                                name, value
-                            );
-                        });
+                                parameterFinder.getStaticContextParamValues(operation).forEach((name, value) -> {
+                                    writer.write(
+                                            "$L: { type: \"staticContextParams\", value: $L },",
+                                            name, value);
+                                });
 
-                        Shape operationInput = model.getShape(operation.getInputShape()).get();
-                        parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
-                            writer.write(
-                                "$L: { type: \"contextParams\", name: \"$L\" },",
-                                name, name
-                            );
-                        });
+                                Shape operationInput = model.getShape(operation.getInputShape()).get();
+                                parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
+                                    writer.write(
+                                            "$L: { type: \"contextParams\", name: \"$L\" },",
+                                            name, name);
+                                });
 
-                        parameterFinder.getClientContextParams().forEach((name, type) -> {
-                            if (!paramNames.contains(name)) {
-                                writer.write(
-                                    "$L: { type: \"clientContextParams\", name: \"$L\" },",
-                                    name, EndpointsParamNameMap.getLocalName(name)
-                                );
-                            }
-                            paramNames.add(name);
-                        });
+                                parameterFinder.getClientContextParams().forEach((name, type) -> {
+                                    if (!paramNames.contains(name)) {
+                                        writer.write(
+                                                "$L: { type: \"clientContextParams\", name: \"$L\" },",
+                                                name, EndpointsParamNameMap.getLocalName(name));
+                                    }
+                                    paramNames.add(name);
+                                });
 
-                        parameterFinder.getBuiltInParams().forEach((name, type) -> {
-                            if (!paramNames.contains(name)) {
-                                writer.write(
-                                    "$L: { type: \"builtInParams\", name: \"$L\" },",
-                                    name, EndpointsParamNameMap.getLocalName(name)
-                                );
-                            }
-                            paramNames.add(name);
-                        });
-                    }
-                );
-            }
-        );
+                                parameterFinder.getBuiltInParams().forEach((name, type) -> {
+                                    if (!paramNames.contains(name)) {
+                                        writer.write(
+                                                "$L: { type: \"builtInParams\", name: \"$L\" },",
+                                                name, EndpointsParamNameMap.getLocalName(name));
+                                    }
+                                    paramNames.add(name);
+                                });
+                            });
+                });
     }
 
     private void generateCommandMiddlewareResolver(String configType) {
@@ -290,17 +281,15 @@ final class CommandGenerator implements Runnable {
             // EndpointsV2
             if (service.hasTrait(EndpointRuleSetTrait.class)) {
                 writer.addImport(
-                    "getEndpointPlugin",
-                    "getEndpointPlugin",
-                    "@aws-sdk/middleware-endpoint"
-                );
+                        "getEndpointPlugin",
+                        "getEndpointPlugin",
+                        "@aws-sdk/middleware-endpoint");
                 writer.openBlock(
-                    "this.middlewareStack.use(getEndpointPlugin(configuration, ",
-                    "));",
-                    () -> {
-                        writer.write("$L.getEndpointParameterInstructions()", symbol.getName());
-                    }
-                );
+                        "this.middlewareStack.use(getEndpointPlugin(configuration, ",
+                        "));",
+                        () -> {
+                            writer.write("$L.getEndpointParameterInstructions()", symbol.getName());
+                        });
             }
 
             // Add customizations.
@@ -317,46 +306,44 @@ final class CommandGenerator implements Runnable {
                 writer.write("commandName,");
                 writer.openBlock("inputFilterSensitiveLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getInput(operation),
-                        input -> {
-                            if (sensitiveDataFinder.findsSensitiveData(input, model)) {
-                                Symbol inputSymbol = symbolProvider.toSymbol(input);
-                                String filterFunctionName = inputSymbol.getName() + "FilterSensitiveLog";
-                                writer.addImport(
-                                    filterFunctionName,
-                                    filterFunctionName,
-                                    inputSymbol.getNamespace()
-                                );
-                                writer.writeInline(filterFunctionName);
-                            } else {
-                                writer.writeInline("(_: any) => _");
-                            }
-                        },
-                        () -> writer.writeInline("(_: any) => _"));
+                            input -> {
+                                if (sensitiveDataFinder.findsSensitiveDataIn(input)) {
+                                    Symbol inputSymbol = symbolProvider.toSymbol(input);
+                                    String filterFunctionName = inputSymbol.getName() + "FilterSensitiveLog";
+                                    writer.addImport(
+                                            filterFunctionName,
+                                            filterFunctionName,
+                                            inputSymbol.getNamespace());
+                                    writer.writeInline(filterFunctionName);
+                                } else {
+                                    writer.writeInline("(_: any) => _");
+                                }
+                            },
+                            () -> writer.writeInline("(_: any) => _"));
                 });
                 writer.openBlock("outputFilterSensitiveLog: ", ",", () -> {
                     OptionalUtils.ifPresentOrElse(operationIndex.getOutput(operation),
-                        output -> {
-                            if (sensitiveDataFinder.findsSensitiveData(output, model)) {
-                                Symbol outputSymbol = symbolProvider.toSymbol(output);
-                                String filterFunctionName = outputSymbol.getName() + "FilterSensitiveLog";
-                                writer.addImport(
-                                    filterFunctionName,
-                                    filterFunctionName,
-                                    outputSymbol.getNamespace()
-                                );
-                                writer.writeInline(filterFunctionName);
-                            } else {
-                                writer.writeInline("(_: any) => _");
-                            }
-                        },
-                        () -> writer.writeInline("(_: any) => _"));
+                            output -> {
+                                if (sensitiveDataFinder.findsSensitiveDataIn(output)) {
+                                    Symbol outputSymbol = symbolProvider.toSymbol(output);
+                                    String filterFunctionName = outputSymbol.getName() + "FilterSensitiveLog";
+                                    writer.addImport(
+                                            filterFunctionName,
+                                            filterFunctionName,
+                                            outputSymbol.getNamespace());
+                                    writer.writeInline(filterFunctionName);
+                                } else {
+                                    writer.writeInline("(_: any) => _");
+                                }
+                            },
+                            () -> writer.writeInline("(_: any) => _"));
                 });
             });
             writer.write("const { requestHandler } = configuration;");
             writer.openBlock("return stack.resolve(", ");", () -> {
                 writer.write("(request: FinalizeHandlerArguments<any>) => ");
                 writer.write("  requestHandler.handle(request.request as $T, options || {}),",
-                             applicationProtocol.getRequestType());
+                        applicationProtocol.getRequestType());
                 writer.write("handlerExecutionContext");
             });
         });
@@ -417,8 +404,8 @@ final class CommandGenerator implements Runnable {
                 List<String> additionalParameters = CodegenUtils.getFunctionParametersList(paramsMap);
 
                 String additionalParamsString = additionalParameters.isEmpty()
-                    ? ""
-                    : ", { " + String.join(", ", additionalParameters) + "}";
+                        ? ""
+                        : ", { " + String.join(", ", additionalParameters) + "}";
                 writer.write("this.middlewareStack.use($T(configuration$L));",
                         symbol, additionalParamsString);
             });
@@ -427,28 +414,27 @@ final class CommandGenerator implements Runnable {
 
     private void writeSerde() {
         writer.write("")
-            .writeDocs("@internal")
-            .write("private serialize(")
-            .indent()
+                .writeDocs("@internal")
+                .write("private serialize(")
+                .indent()
                 .write("input: $T,", inputType)
                 .write("context: $L", CodegenUtils.getOperationSerializerContextType(writer, model, operation))
-            .dedent()
-            .openBlock(
-                    "): Promise<$T> {", "}",
-                    applicationProtocol.getRequestType(),
-                    () -> writeSerdeDispatcher(true)
-            );
+                .dedent()
+                .openBlock(
+                        "): Promise<$T> {", "}",
+                        applicationProtocol.getRequestType(),
+                        () -> writeSerdeDispatcher(true));
 
         writer.write("")
-            .writeDocs("@internal")
-            .write("private deserialize(")
-            .indent()
+                .writeDocs("@internal")
+                .write("private deserialize(")
+                .indent()
                 .write("output: $T,", applicationProtocol.getResponseType())
                 .write("context: $L",
                         CodegenUtils.getOperationDeserializerContextType(settings, writer, model, operation))
-            .dedent()
-            .openBlock("): Promise<$T> {", "}", outputType, () -> writeSerdeDispatcher(false))
-            .write("");
+                .dedent()
+                .openBlock("): Promise<$T> {", "}", outputType, () -> writeSerdeDispatcher(false))
+                .write("");
     }
 
     private void writeSerdeDispatcher(boolean isInput) {
@@ -461,8 +447,8 @@ final class CommandGenerator implements Runnable {
                     ? ProtocolGenerator.getSerFunctionName(symbol, protocolGenerator.getName())
                     : ProtocolGenerator.getDeserFunctionName(symbol, protocolGenerator.getName());
             writer.addImport(serdeFunctionName, serdeFunctionName,
-                Paths.get(".", CodegenUtils.SOURCE_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
-                    ProtocolGenerator.getSanitizedName(protocolGenerator.getName())).toString());
+                    Paths.get(".", CodegenUtils.SOURCE_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
+                            ProtocolGenerator.getSanitizedName(protocolGenerator.getName())).toString());
             writer.write("return $L($L, context);", serdeFunctionName, isInput ? "input" : "output");
         }
     }
@@ -471,8 +457,7 @@ final class CommandGenerator implements Runnable {
             Model model,
             ServiceShape service,
             SymbolProvider symbolProvider,
-            FileManifest fileManifest
-    ) {
+            FileManifest fileManifest) {
         TypeScriptWriter writer = new TypeScriptWriter("");
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
@@ -482,7 +467,7 @@ final class CommandGenerator implements Runnable {
         }
 
         fileManifest.writeFile(
-            Paths.get(CodegenUtils.SOURCE_FOLDER, CommandGenerator.COMMANDS_FOLDER, "index.ts").toString(),
-            writer.toString());
+                Paths.get(CodegenUtils.SOURCE_FOLDER, CommandGenerator.COMMANDS_FOLDER, "index.ts").toString(),
+                writer.toString());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -337,14 +337,14 @@ final class CommandGenerator implements Runnable {
                     OptionalUtils.ifPresentOrElse(operationIndex.getOutput(operation),
                         output -> {
                             if (sensitiveDataFinder.findsSensitiveData(output, model)) {
-                            Symbol outputSymbol = symbolProvider.toSymbol(output);
-                            String filterFunctionName = outputSymbol.getName() + "FilterSensitiveLog";
-                            writer.addImport(
-                                filterFunctionName,
-                                filterFunctionName,
-                                outputSymbol.getNamespace()
-                            );
-                            writer.writeInline(filterFunctionName);
+                                Symbol outputSymbol = symbolProvider.toSymbol(output);
+                                String filterFunctionName = outputSymbol.getName() + "FilterSensitiveLog";
+                                writer.addImport(
+                                    filterFunctionName,
+                                    filterFunctionName,
+                                    outputSymbol.getNamespace()
+                                );
+                                writer.writeInline(filterFunctionName);
                             } else {
                                 writer.writeInline("(_: any) => _");
                             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -73,7 +73,7 @@ final class StructureGenerator implements Runnable {
     private final StructureShape shape;
     private final boolean includeValidation;
     private final RequiredMemberMode requiredMemberMode;
-    private final SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder();
+    private final SensitiveDataFinder sensitiveDataFinder;
 
     /**
      * sets 'includeValidation' to 'false' and requiredMemberMode
@@ -96,6 +96,7 @@ final class StructureGenerator implements Runnable {
         this.shape = shape;
         this.includeValidation = includeValidation;
         this.requiredMemberMode = requiredMemberMode;
+        sensitiveDataFinder = new SensitiveDataFinder(model);
     }
 
     @Override
@@ -189,7 +190,7 @@ final class StructureGenerator implements Runnable {
         Symbol symbol = symbolProvider.toSymbol(shape);
         String objectParam = "obj";
 
-        if (sensitiveDataFinder.findsSensitiveData(shape, model)) {
+        if (sensitiveDataFinder.findsSensitiveDataIn(shape)) {
             writer.writeDocs("@internal");
             writer.openBlock("export const $LFilterSensitiveLog = ($L: $L): any => ({", "})",
                     symbol.getName(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -174,12 +174,11 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-            model, 
-            symbolProvider, 
-            shape.getAllMembers().values(), 
-            this.requiredMemberMode,
-            sensitiveDataFinder
-        );
+                model,
+                symbolProvider,
+                shape.getAllMembers().values(),
+                this.requiredMemberMode,
+                sensitiveDataFinder);
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -174,7 +174,12 @@ final class StructureGenerator implements Runnable {
         }
 
         StructuredMemberWriter config = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values(), this.requiredMemberMode);
+            model, 
+            symbolProvider, 
+            shape.getAllMembers().values(), 
+            this.requiredMemberMode,
+            sensitiveDataFinder
+        );
         config.writeMembers(writer, shape);
         writer.closeBlock("}");
         writer.write("");
@@ -277,7 +282,7 @@ final class StructureGenerator implements Runnable {
             HttpProtocolGeneratorUtils.writeRetryableTrait(writer, shape, ";");
         }
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(model, symbolProvider,
-                shape.getAllMembers().values(), this.requiredMemberMode);
+                shape.getAllMembers().values(), this.requiredMemberMode, sensitiveDataFinder);
         // since any error interface must extend from JavaScript Error interface,
         // message member is already
         // required in the JavaScript Error interface

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -68,7 +68,7 @@ final class StructuredMemberWriter {
     boolean noDocs;
     RequiredMemberMode requiredMemberMode;
     final Set<String> skipMembers = new HashSet<>();
-    private final SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder();
+    private final SensitiveDataFinder sensitiveDataFinder;
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members) {
         this(model, symbolProvider, members, RequiredMemberMode.NULLABLE);
@@ -76,10 +76,20 @@ final class StructuredMemberWriter {
 
     StructuredMemberWriter(Model model, SymbolProvider symbolProvider, Collection<MemberShape> members,
             RequiredMemberMode requiredMemberMode) {
+        this(model, symbolProvider, members, requiredMemberMode, new SensitiveDataFinder());
+    }
+
+    StructuredMemberWriter(
+            Model model,
+            SymbolProvider symbolProvider,
+            Collection<MemberShape> members,
+            RequiredMemberMode requiredMemberMode,
+            SensitiveDataFinder sensitiveDataFinder) {
         this.model = model;
         this.symbolProvider = symbolProvider;
         this.members = new LinkedHashSet<>(members);
         this.requiredMemberMode = requiredMemberMode;
+        this.sensitiveDataFinder = sensitiveDataFinder;
     }
 
     void writeMembers(TypeScriptWriter writer, Shape shape) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings.RequiredMemberMode;
 import software.amazon.smithy.typescript.codegen.validation.SensitiveDataFinder;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
@@ -255,7 +256,12 @@ final class UnionGenerator implements Runnable {
                     for (MemberShape member : shape.getAllMembers().values()) {
                         String memberName = symbolProvider.toMemberName(member);
                         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
-                                model, symbolProvider, shape.getAllMembers().values());
+                            model, 
+                            symbolProvider, 
+                            shape.getAllMembers().values(),
+                            RequiredMemberMode.NULLABLE,
+                            sensitiveDataFinder
+                        );
                         writer.openBlock("if (${1L}.${2L} !== undefined) return {${2L}: ", "};",
                             objectParam, memberName, () -> {
                                 String memberParam = String.format("%s.%s", objectParam, memberName);
@@ -272,7 +278,12 @@ final class UnionGenerator implements Runnable {
 
     private void writeValidate() {
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
-                model, symbolProvider, shape.getAllMembers().values());
+            model, 
+            symbolProvider, 
+            shape.getAllMembers().values(),
+            RequiredMemberMode.NULLABLE,
+            sensitiveDataFinder
+        );
 
         structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -30,19 +30,22 @@ import software.amazon.smithy.utils.StringUtils;
 /**
  * Renders a TypeScript union.
  *
- * <p>Smithy tagged unions are rendered as a set of TypeScript interfaces
+ * <p>
+ * Smithy tagged unions are rendered as a set of TypeScript interfaces
  * and functionality used to visit each variant. Only a single member
  * can be set at any given time. A member that contains unknown variants
  * is automatically added to each tagged union. If set, it contains the
  * name of the property that was set and its value stored as an
  * {@code any}.
  *
- * <p>A {@code Visitor} interface and a method used to dispatch to the
+ * <p>
+ * A {@code Visitor} interface and a method used to dispatch to the
  * visitor is generated for each tagged union. This allows for working
  * with tagged unions functionally and account for each variant in a
  * typed way.
  *
- * <p>For example, given the following Smithy model:
+ * <p>
+ * For example, given the following Smithy model:
  *
  * <pre>{@code
  * union Attacker {
@@ -52,7 +55,8 @@ import software.amazon.smithy.utils.StringUtils;
  * }
  * }</pre>
  *
- * <p>The following code is generated:
+ * <p>
+ * The following code is generated:
  *
  * <pre>{@code
  * export type Attacker =
@@ -122,7 +126,8 @@ import software.amazon.smithy.utils.StringUtils;
  *
  * }</pre>
  *
- * <p>Important: Tagged unions in TypeScript are intentionally designed
+ * <p>
+ * Important: Tagged unions in TypeScript are intentionally designed
  * so that it is forward-compatible to change a structure with optional
  * and mutually exclusive members to a tagged union.
  */
@@ -146,10 +151,10 @@ final class UnionGenerator implements Runnable {
     }
 
     UnionGenerator(Model model,
-                   SymbolProvider symbolProvider,
-                   TypeScriptWriter writer,
-                   UnionShape shape,
-                   boolean includeValidation) {
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer,
+            UnionShape shape,
+            boolean includeValidation) {
         this.shape = shape;
         this.symbol = symbolProvider.toSymbol(shape);
         this.model = model;
@@ -199,7 +204,7 @@ final class UnionGenerator implements Runnable {
                 for (MemberShape variantMember : shape.getAllMembers().values()) {
                     if (variantMember.getMemberName().equals(member.getMemberName())) {
                         writer.write("$L: $T;", symbolProvider.toMemberName(variantMember),
-                                     symbolProvider.toSymbol(variantMember));
+                                symbolProvider.toSymbol(variantMember));
                     } else {
                         writer.write("$L?: never;", symbolProvider.toMemberName(variantMember));
                     }
@@ -223,7 +228,7 @@ final class UnionGenerator implements Runnable {
         writer.openBlock("export interface Visitor<T> {", "}", () -> {
             for (MemberShape member : shape.getAllMembers().values()) {
                 writer.write("$L: (value: $T) => T;",
-                             symbolProvider.toMemberName(member), symbolProvider.toSymbol(member));
+                        symbolProvider.toMemberName(member), symbolProvider.toSymbol(member));
             }
             writer.write("_: (name: string, value: any) => T;");
         });
@@ -250,40 +255,37 @@ final class UnionGenerator implements Runnable {
             String objectParam = "obj";
             writer.writeDocs("@internal");
             writer.openBlock("export const $LFilterSensitiveLog = ($L: $L): any => {", "}",
-                namespace,
-                objectParam, symbol.getName(),
-                () -> {
-                    for (MemberShape member : shape.getAllMembers().values()) {
-                        String memberName = symbolProvider.toMemberName(member);
-                        StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
-                            model, 
-                            symbolProvider, 
-                            shape.getAllMembers().values(),
-                            RequiredMemberMode.NULLABLE,
-                            sensitiveDataFinder
-                        );
-                        writer.openBlock("if (${1L}.${2L} !== undefined) return {${2L}: ", "};",
-                            objectParam, memberName, () -> {
-                                String memberParam = String.format("%s.%s", objectParam, memberName);
-                                structuredMemberWriter.writeMemberFilterSensitiveLog(writer, member, memberParam);
-                            }
-                        );
-                    }
-                    writer.write("if (${1L}.$$unknown !== undefined) return {[${1L}.$$unknown[0]]: 'UNKNOWN'};",
-                        objectParam);
-                }
-            );
+                    namespace,
+                    objectParam, symbol.getName(),
+                    () -> {
+                        for (MemberShape member : shape.getAllMembers().values()) {
+                            String memberName = symbolProvider.toMemberName(member);
+                            StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
+                                    model,
+                                    symbolProvider,
+                                    shape.getAllMembers().values(),
+                                    RequiredMemberMode.NULLABLE,
+                                    sensitiveDataFinder);
+                            writer.openBlock("if (${1L}.${2L} !== undefined) return {${2L}: ", "};",
+                                    objectParam, memberName, () -> {
+                                        String memberParam = String.format("%s.%s", objectParam, memberName);
+                                        structuredMemberWriter.writeMemberFilterSensitiveLog(writer, member,
+                                                memberParam);
+                                    });
+                        }
+                        writer.write("if (${1L}.$$unknown !== undefined) return {[${1L}.$$unknown[0]]: 'UNKNOWN'};",
+                                objectParam);
+                    });
         }
     }
 
     private void writeValidate() {
         StructuredMemberWriter structuredMemberWriter = new StructuredMemberWriter(
-            model, 
-            symbolProvider, 
-            shape.getAllMembers().values(),
-            RequiredMemberMode.NULLABLE,
-            sensitiveDataFinder
-        );
+                model,
+                symbolProvider,
+                shape.getAllMembers().values(),
+                RequiredMemberMode.NULLABLE,
+                sensitiveDataFinder);
 
         structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
@@ -294,7 +296,6 @@ final class UnionGenerator implements Runnable {
                 () -> {
                     structuredMemberWriter.writeMemberValidatorFactory(writer, "memberValidators");
                     structuredMemberWriter.writeValidateMethodContents(writer, "obj");
-                }
-        );
+                });
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
@@ -16,9 +16,19 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 
+/**
+ * This validator tells you whether a shape contains sensitive data fields.
+ * This is used to decide whether a sensitive log filter function needs to be generated for
+ * a given shape.
+ */
 public class SensitiveDataFinder {
     private Map<Shape, Boolean> cache = new HashMap<>();
 
+    /**
+     * @param shape - the shape in question.
+     * @param model - model context for the shape, containing its related shapes.
+     * @return whether a sensitive field exists in the shape and its downstream shapes.
+     */
     public boolean findsSensitiveData(Shape shape, Model model) {
         boolean found = findRecursive(shape, model);
         cache.put(shape, found);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
@@ -1,16 +1,6 @@
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.typescript.codegen.validation;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.validation;
+
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.SimpleShape;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+
+public class SensitiveDataFinder {
+    private Map<Shape, Boolean> cache = new HashMap<>();
+
+    public boolean findsSensitiveData(Shape shape, Model model) {
+        boolean found = findRecursive(shape, model);
+        cache.put(shape, found);
+        return found;
+    }
+
+    private boolean findRecursive(Shape shape, Model model) {
+        if (cache.containsKey(shape)) {
+            return cache.get(shape);
+        }
+
+        if (shape.hasTrait(SensitiveTrait.class)) {
+            cache.put(shape, true);
+            return true;
+        }
+
+        if (shape instanceof MemberShape) {
+            MemberShape memberShape = (MemberShape) shape;
+            if (memberShape.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
+                cache.put(shape, true);
+                return true;
+            }
+            Shape memberTarget = model.expectShape(memberShape.getTarget());
+            return findRecursive(memberTarget, model);
+        }
+
+        if (shape.getMemberTrait(model, SensitiveTrait.class).isPresent()) {
+            cache.put(shape, true);
+            return true;
+        } else if (shape instanceof SimpleShape) {
+            cache.put(shape, false);
+            return false;
+        } else if (shape.isStructureShape() || shape.isUnionShape()) {
+            boolean found = shape.getAllMembers()
+                    .values()
+                    .stream()
+                    .anyMatch(m -> findRecursive(m, model));
+
+            cache.put(shape, found);
+            return found;
+        } else if (shape instanceof CollectionShape) {
+            MemberShape collectionMember = ((CollectionShape) shape).getMember();
+            return findRecursive(collectionMember, model);
+        } else if (shape instanceof MapShape) {
+            MemberShape keyMember = ((MapShape) shape).getKey();
+            MemberShape valMember = ((MapShape) shape).getValue();
+            return findRecursive(keyMember, model) || findRecursive(valMember, model);
+        }
+
+        cache.put(shape, false);
+        return false;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinder.java
@@ -18,24 +18,34 @@ import software.amazon.smithy.model.traits.StreamingTrait;
 
 /**
  * This validator tells you whether a shape contains sensitive data fields.
- * This is used to decide whether a sensitive log filter function needs to be generated for
+ * This is used to decide whether a sensitive log filter function needs to be
+ * generated for
  * a given shape.
  */
 public class SensitiveDataFinder {
     private Map<Shape, Boolean> cache = new HashMap<>();
+    private final Model model;
+
+    /**
+     * @param model - model context for the {@link #findsSensitiveDataIn(Shape)}
+     *              queries.
+     */
+    public SensitiveDataFinder(Model model) {
+        this.model = model;
+    }
 
     /**
      * @param shape - the shape in question.
-     * @param model - model context for the shape, containing its related shapes.
-     * @return whether a sensitive field exists in the shape and its downstream shapes.
+     * @return whether a sensitive field exists in the shape and its downstream
+     *         shapes.
      */
-    public boolean findsSensitiveData(Shape shape, Model model) {
-        boolean found = findRecursive(shape, model);
+    public boolean findsSensitiveDataIn(Shape shape) {
+        boolean found = findRecursive(shape);
         cache.put(shape, found);
         return found;
     }
 
-    private boolean findRecursive(Shape shape, Model model) {
+    private boolean findRecursive(Shape shape) {
         if (cache.containsKey(shape)) {
             return cache.get(shape);
         }
@@ -66,7 +76,7 @@ public class SensitiveDataFinder {
         if (shape instanceof MapShape) {
             MemberShape keyMember = ((MapShape) shape).getKey();
             MemberShape valMember = ((MapShape) shape).getValue();
-            return findRecursive(keyMember, model) || findRecursive(valMember, model);
+            return findRecursive(keyMember) || findRecursive(valMember);
         }
 
         cache.put(shape, false);

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -252,50 +252,9 @@ public class StructureGeneratorTest {
     }
 
     @Test
-    public void callsFilterInUnionWithoutSensitiveData() {
-        testStructureCodegen("test-union-without-sensitive-data.smithy",
-                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                        + "  if (obj.fooString !== undefined) return {fooString:\n"
-                        + "    obj.fooString\n"
-                        + "  };\n"
-                        + "  if (obj.barString !== undefined) return {barString:\n"
-                        + "    obj.barString\n"
-                        + "  };\n"
-                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                        + "}\n");
-    }
-
-    @Test
-    public void callsFilterInUnionWithStructure() {
-        testStructureCodegen("test-union-with-structure.smithy",
-                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                        + "  if (obj.fooUser !== undefined) return {fooUser:\n"
-                        + "    UserFilterSensitiveLog(obj.fooUser)\n"
-                        + "  };\n"
-                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                        + "}\n");
-    }
-
-    @Test
-    public void callsFilterInUnionWithList() {
-        testStructureCodegen("test-union-with-list.smithy",
-                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                        + "  if (obj.list !== undefined) return {list:\n"
-                        + "    obj.list\n"
-                        + "  };\n"
-                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                        + "}\n");
-    }
-
-    @Test
-    public void callsFilterInUnionWithMap() {
-        testStructureCodegen("test-union-with-map.smithy",
-                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                        + "  if (obj.map !== undefined) return {map:\n"
-                        + "    obj.map\n"
-                        + "  };\n"
-                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                        + "}\n");
+    public void skipsFilterInUnionWithoutSensitiveData() {
+        testStructureCodegenExcludes("test-union-without-sensitive-data.smithy",
+                "TestUnionFilterSensitiveLog");
     }
 
     @Test

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/StructureGeneratorTest.java
@@ -2,7 +2,7 @@ package software.amazon.smithy.typescript.codegen;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-
+import static org.hamcrest.Matchers.not;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
@@ -18,431 +18,420 @@ public class StructureGeneratorTest {
     @Test
     public void properlyGeneratesEmptyMessageMemberOfException() {
         testErrorStructureCodegen("error-test-empty.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void properlyGeneratesOptionalMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-message.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void properlyGeneratesRequiredMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-message.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void properlyGeneratesOptionalNonMessageMemberOfException() {
         testErrorStructureCodegen("error-test-optional-member-no-message.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  foo?: string;\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "    this.foo = opts.foo;\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  foo?: string;\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "    this.foo = opts.foo;\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void properlyGeneratesRequiredNonMessageMemberOfException() {
         testErrorStructureCodegen("error-test-required-member-no-message.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  foo: string | undefined;\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "    this.foo = opts.foo;\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  foo: string | undefined;\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "    this.foo = opts.foo;\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void generatesEmptyRetryableTrait() {
         testErrorStructureCodegen("error-test-retryable.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  $retryable = {\n"
-                                  + "  };\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  $retryable = {\n"
+                        + "  };\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void generatesRetryableTraitWithThrottling() {
         testErrorStructureCodegen("error-test-retryable-throttling.smithy",
-                                  "export class Err extends __BaseException {\n"
-                                  + "  readonly name: \"Err\" = \"Err\";\n"
-                                  + "  readonly $fault: \"client\" = \"client\";\n"
-                                  + "  $retryable = {\n"
-                                  + "    throttling: true,\n"
-                                  + "  };\n"
-                                  + "  /**\n"
-                                  + "   * @internal\n"
-                                  + "   */\n"
-                                  + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
-                                  + "    super({\n"
-                                  + "      name: \"Err\",\n"
-                                  + "      $fault: \"client\",\n"
-                                  + "      ...opts\n"
-                                  + "    });\n"
-                                  + "    Object.setPrototypeOf(this, Err.prototype);\n"
-                                  + "  }\n"
-                                  + "}\n");
+                "export class Err extends __BaseException {\n"
+                        + "  readonly name: \"Err\" = \"Err\";\n"
+                        + "  readonly $fault: \"client\" = \"client\";\n"
+                        + "  $retryable = {\n"
+                        + "    throttling: true,\n"
+                        + "  };\n"
+                        + "  /**\n"
+                        + "   * @internal\n"
+                        + "   */\n"
+                        + "  constructor(opts: __ExceptionOptionType<Err, __BaseException>) {\n"
+                        + "    super({\n"
+                        + "      name: \"Err\",\n"
+                        + "      $fault: \"client\",\n"
+                        + "      ...opts\n"
+                        + "    });\n"
+                        + "    Object.setPrototypeOf(this, Err.prototype);\n"
+                        + "  }\n"
+                        + "}\n");
     }
 
     @Test
     public void filtersSensitiveSimpleShape() {
         testStructureCodegen("test-sensitive-simple-shape.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.password && { password:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})\n");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.password && { password:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})\n");
     }
 
     @Test
     public void skipsFilterForInsensitiveSimpleShape() {
-        testStructureCodegen("test-insensitive-simple-shape.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "})");
+        testStructureCodegenExcludes("test-insensitive-simple-shape.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void callsFilterForStructureWithSensitiveData() {
         testStructureCodegen("test-structure-with-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    UserFilterSensitiveLog(obj.foo)\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    UserFilterSensitiveLog(obj.foo)\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterInStructureWithSensitiveData() {
         testStructureCodegen("test-structure-with-sensitive-data.smithy",
-                                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.password && { password:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.password && { password:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void filtersSensitiveStructure() {
         testStructureCodegen("test-sensitive-structure.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void skipsFilterForStructureWithoutSensitiveData() {
-        testStructureCodegen("test-structure-without-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "})");
+        testStructureCodegenExcludes("test-structure-without-sensitive-data.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void callsFilterForUnionWithSensitiveData() {
         testStructureCodegen("test-union-with-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    TestUnionFilterSensitiveLog(obj.foo)\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    TestUnionFilterSensitiveLog(obj.foo)\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterInUnionWithSensitiveData() {
         testStructureCodegen("test-union-with-sensitive-data.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.bar !== undefined) return {bar:\n"
-                                + "    obj.bar\n"
-                                + "  };\n"
-                                + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.bar !== undefined) return {bar:\n"
+                        + "    obj.bar\n"
+                        + "  };\n"
+                        + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}");
     }
 
     @Test
     public void callsFilterForUnionWithoutSensitiveData() {
-        testStructureCodegen("test-union-without-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    TestUnionFilterSensitiveLog(obj.foo)\n"
-                                + "  }),\n"
-                                + "})");
+        testStructureCodegenExcludes("test-union-without-sensitive-data.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void callsFilterInUnionWithoutSensitiveData() {
         testStructureCodegen("test-union-without-sensitive-data.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.fooString !== undefined) return {fooString:\n"
-                                + "    obj.fooString\n"
-                                + "  };\n"
-                                + "  if (obj.barString !== undefined) return {barString:\n"
-                                + "    obj.barString\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.fooString !== undefined) return {fooString:\n"
+                        + "    obj.fooString\n"
+                        + "  };\n"
+                        + "  if (obj.barString !== undefined) return {barString:\n"
+                        + "    obj.barString\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
 
     @Test
     public void callsFilterInUnionWithStructure() {
         testStructureCodegen("test-union-with-structure.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.fooUser !== undefined) return {fooUser:\n"
-                                + "    UserFilterSensitiveLog(obj.fooUser)\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.fooUser !== undefined) return {fooUser:\n"
+                        + "    UserFilterSensitiveLog(obj.fooUser)\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
 
     @Test
     public void callsFilterInUnionWithList() {
         testStructureCodegen("test-union-with-list.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.list !== undefined) return {list:\n"
-                                + "    obj.list\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.list !== undefined) return {list:\n"
+                        + "    obj.list\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
 
     @Test
     public void callsFilterInUnionWithMap() {
         testStructureCodegen("test-union-with-map.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.map !== undefined) return {map:\n"
-                                + "    obj.map\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.map !== undefined) return {map:\n"
+                        + "    obj.map\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
 
     @Test
     public void filtersStreamingUnion() {
         testStructureCodegen("test-streaming-union.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    'STREAMING_CONTENT'\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    'STREAMING_CONTENT'\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void filtersSensitiveUnion() {
         testStructureCodegen("test-sensitive-union.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterForListWithStructureWithSensitiveData() {
         testStructureCodegen("test-list-with-structure-with-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    obj.foo.map(\n"
-                                + "      item =>\n"
-                                + "      UserFilterSensitiveLog(item)\n"
-                                + "    )\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    obj.foo.map(\n"
+                        + "      item =>\n"
+                        + "      UserFilterSensitiveLog(item)\n"
+                        + "    )\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterInListWithStructureWithSensitiveData() {
         testStructureCodegen("test-list-with-structure-with-sensitive-data.smithy",
-                                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.password && { password:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.password && { password:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterForListWithUnionWithSensitiveData() {
         testStructureCodegen("test-list-with-union-with-sensitive-data.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    obj.foo.map(\n"
-                                + "      item =>\n"
-                                + "      TestUnionFilterSensitiveLog(item)\n"
-                                + "    )\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    obj.foo.map(\n"
+                        + "      item =>\n"
+                        + "      TestUnionFilterSensitiveLog(item)\n"
+                        + "    )\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterInListWithUnionWithSensitiveData() {
         testStructureCodegen("test-list-with-union-with-sensitive-data.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.bar !== undefined) return {bar:\n"
-                                + "    obj.bar\n"
-                                + "  };\n"
-                                + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.bar !== undefined) return {bar:\n"
+                        + "    obj.bar\n"
+                        + "  };\n"
+                        + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
 
     @Test
     public void callsFilterForListWithSensitiveMember() {
         testStructureCodegen("test-list-with-sensitive-member.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void filtersSensitiveList() {
         testStructureCodegen("test-sensitive-list.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void skipsFilterForInsensitiveList() {
-        testStructureCodegen("test-insensitive-list.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "})");
+        testStructureCodegenExcludes("test-insensitive-list.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void callsFilterForMapWithStructureWithSensitiveData() {
         testStructureCodegen("test-map-with-structure-with-sensitive-data.smithy",
-                            "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                            + "  ...obj,\n"
-                            + "  ...(obj.foo && { foo:\n"
-                            + "    Object.entries(obj.foo).reduce((acc: any, [key, value]: [string, User]) => (\n"
-                            + "      acc[key] =\n"
-                            + "        UserFilterSensitiveLog(value)\n"
-                            + "        ,\n"
-                            + "      acc\n"
-                            + "    ), {})\n"
-                            + "  }),\n"
-                            + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    Object.entries(obj.foo).reduce((acc: any, [key, value]: [string, User]) => (\n"
+                        + "      acc[key] =\n"
+                        + "        UserFilterSensitiveLog(value)\n"
+                        + "        ,\n"
+                        + "      acc\n"
+                        + "    ), {})\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterInMapWithStructureWithSensitiveData() {
         testStructureCodegen("test-map-with-structure-with-sensitive-data.smithy",
-                                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.password && { password:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const UserFilterSensitiveLog = (obj: User): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.password && { password:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void callsFilterForMapWithUnionWithSensitiveData() {
         testStructureCodegen("test-map-with-union-with-sensitive-data.smithy",
-                        "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
                         + "  ...obj,\n"
                         + "  ...(obj.foo && { foo:\n"
                         + "    Object.entries(obj.foo).reduce((acc: any, [key, value]: [string, TestUnion]) => (\n"
@@ -458,69 +447,73 @@ public class StructureGeneratorTest {
     @Test
     public void callsFilterInMapWithUnionWithSensitiveData() {
         testStructureCodegen("test-map-with-union-with-sensitive-data.smithy",
-                                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
-                                + "  if (obj.bar !== undefined) return {bar:\n"
-                                + "    obj.bar\n"
-                                + "  };\n"
-                                + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  };\n"
-                                + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
-                                + "}\n");
+                "export const TestUnionFilterSensitiveLog = (obj: TestUnion): any => {\n"
+                        + "  if (obj.bar !== undefined) return {bar:\n"
+                        + "    obj.bar\n"
+                        + "  };\n"
+                        + "  if (obj.sensitiveBar !== undefined) return {sensitiveBar:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  };\n"
+                        + "  if (obj.$unknown !== undefined) return {[obj.$unknown[0]]: 'UNKNOWN'};\n"
+                        + "}\n");
     }
-
 
     @Test
     public void callsFilterForMapWithSensitiveMember() {
         testStructureCodegen("test-map-with-sensitive-member.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "  ...(obj.foo && { foo:\n"
-                                + "    SENSITIVE_STRING\n"
-                                + "  }),\n"
-                                + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void filtersSensitiveMap() {
         testStructureCodegen("test-sensitive-map.smithy",
-                            "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                            + "  ...obj,\n"
-                            + "  ...(obj.foo && { foo:\n"
-                            + "    SENSITIVE_STRING\n"
-                            + "  }),\n"
-                            + "})");
+                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
+                        + "  ...obj,\n"
+                        + "  ...(obj.foo && { foo:\n"
+                        + "    SENSITIVE_STRING\n"
+                        + "  }),\n"
+                        + "})");
     }
 
     @Test
     public void skipsFilterForInsensitiveMap() {
-        testStructureCodegen("test-insensitive-map.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "})");
+        testStructureCodegenExcludes("test-insensitive-map.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void skipsFilterOnEncounteringRecursiveShapes() {
-        testStructureCodegen("test-recursive-shapes.smithy",
-                                "export const GetFooInputFilterSensitiveLog = (obj: GetFooInput): any => ({\n"
-                                + "  ...obj,\n"
-                                + "})");
+        testStructureCodegenExcludes("test-recursive-shapes.smithy",
+                "GetFooInputFilterSensitiveLog");
     }
 
     @Test
     public void properlyGeneratesRequiredMessageMemberNotBackwardCompatible() {
         testStructureCodegenBase("test-required-member.smithy",
-                                "export interface GetFooOutput {\n"
-                                + "  someRequiredMember: string;\n"
-                                + "}\n", RequiredMemberMode.STRICT);
+                "export interface GetFooOutput {\n"
+                        + "  someRequiredMember: string;\n"
+                        + "}\n",
+                RequiredMemberMode.STRICT, true);
     }
 
-    private String testStructureCodegen(String file, String expectedType) {
-        return testStructureCodegenBase(file, expectedType, RequiredMemberMode.NULLABLE);
+    private String testStructureCodegen(String file, String includedString) {
+        return testStructureCodegenBase(file, includedString, RequiredMemberMode.NULLABLE, true);
     }
 
-    private String testStructureCodegenBase(String file, String expectedType, RequiredMemberMode requiredMemberMode) {
+    private String testStructureCodegenExcludes(String file, String excludedString) {
+        return testStructureCodegenBase(file, excludedString, RequiredMemberMode.NULLABLE, false);
+    }
+
+    private String testStructureCodegenBase(
+            String file,
+            String testString,
+            RequiredMemberMode requiredMemberMode,
+            boolean assertContains) {
         Model model = Model.assembler()
                 .addImport(getClass().getResource(file))
                 .assemble()
@@ -540,7 +533,12 @@ public class StructureGeneratorTest {
         new TypeScriptCodegenPlugin().execute(context);
         String contents = manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "//models/models_0.ts").get();
 
-        assertThat(contents, containsString(expectedType));
+        if (assertContains) {
+            assertThat(contents, containsString(testString));
+        } else {
+            assertThat(contents, not(containsString(testString)));
+        }
+
         return contents;
     }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinderTest.java
@@ -1,0 +1,180 @@
+package software.amazon.smithy.typescript.codegen.validation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.CollectionShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+
+public class SensitiveDataFinderTest {
+    private SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder();
+
+    StringShape sensitiveString = StringShape.builder()
+            .addTrait(new SensitiveTrait())
+            .id("foo.bar#sensitiveString")
+            .build();
+
+    StringShape dullString = StringShape.builder()
+            .id("foo.bar#dullString")
+            .build();
+
+    MemberShape memberWithSensitiveData = MemberShape.builder()
+            .id("foo.bar#sensitive$member")
+            .target(sensitiveString.getId())
+            .build();
+
+    MemberShape memberWithDullData = MemberShape.builder()
+            .id("foo.bar#dull$member")
+            .target(dullString.getId())
+            .build();
+
+    MemberShape listMemberWithSensitiveData = MemberShape.builder()
+            .id("foo.bar#listSensitive$member")
+            .target(sensitiveString.getId())
+            .build();
+
+    MemberShape listMemberWithDullData = MemberShape.builder()
+            .id("foo.bar#listDull$member")
+            .target(dullString.getId())
+            .build();
+
+    MemberShape mapMemberWithSensitiveKeyData = MemberShape.builder()
+            .id("foo.bar#mapSensitiveKey$member")
+            .target(sensitiveString.getId())
+            .build();
+
+    MemberShape mapMemberWithSensitiveValueData = MemberShape.builder()
+            .id("foo.bar#mapSensitiveValue$member")
+            .target(sensitiveString.getId())
+            .build();
+
+    StructureShape structureShapeSensitive = StructureShape.builder()
+            .id("foo.bar#sensitive")
+            .members(
+                    Collections.singleton(memberWithSensitiveData))
+            .build();
+
+    StructureShape structureShapeDull = StructureShape.builder()
+            .id("foo.bar#dull")
+            .members(
+                    Collections.singleton(memberWithDullData))
+            .build();
+
+    CollectionShape collectionSensitive = ListShape.builder()
+            .id("foo.bar#listSensitive")
+            .addMember(listMemberWithSensitiveData)
+            .build();
+
+    CollectionShape collectionDull = ListShape.builder()
+            .id("foo.bar#listDull")
+            .addMember(listMemberWithDullData)
+            .build();
+
+    MapShape mapSensitiveKey = MapShape.builder()
+            .id("foo.bar#mapSensitiveKey")
+            .key(mapMemberWithSensitiveKeyData)
+            .value(MemberShape.builder()
+                    .id("foo.bar#mapSensitiveKey$member")
+                    .target(dullString.getId())
+                    .build())
+            .build();
+
+    MapShape mapSensitiveValue = MapShape.builder()
+            .id("foo.bar#mapSensitiveValue")
+            .key(MemberShape.builder()
+                    .id("foo.bar#mapSensitiveValue$member")
+                    .target(dullString.getId())
+                    .build())
+            .value(mapMemberWithSensitiveValueData)
+            .build();
+
+    MapShape mapDull = MapShape.builder()
+            .id("foo.bar#mapDull")
+            .key(MemberShape.builder()
+                    .id("foo.bar#mapDull$member")
+                    .target(dullString.getId())
+                    .build())
+            .value(MemberShape.builder()
+                    .id("foo.bar#mapDull$member")
+                    .target(dullString.getId())
+                    .build())
+            .build();
+
+    MapShape nested2 = MapShape.builder()
+            .id("foo.bar#mapNested2")
+            .key(MemberShape.builder()
+                    .id("foo.bar#mapNested2$member")
+                    .target(dullString.getId())
+                    .build())
+            .value(MemberShape.builder()
+                    .id("foo.bar#mapNested2$member")
+                    .target(mapSensitiveValue)
+                    .build())
+            .build();
+
+    MapShape nested = MapShape.builder()
+            .id("foo.bar#mapNested")
+            .key(MemberShape.builder()
+                    .id("foo.bar#mapNested$member")
+                    .target(dullString.getId())
+                    .build())
+            .value(MemberShape.builder()
+                    .id("foo.bar#mapNested$member")
+                    .target(nested2)
+                    .build())
+            .build();
+
+    private Model model = Model.builder()
+            .addShapes(
+                    sensitiveString, dullString,
+                    memberWithSensitiveData, memberWithDullData,
+                    structureShapeSensitive, structureShapeDull,
+                    collectionSensitive, collectionDull,
+                    mapSensitiveKey, mapSensitiveValue, mapDull,
+                    nested, nested2)
+            .build();
+
+    @Test
+    public void findsSensitiveData_inShapes() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(sensitiveString, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(dullString, model), equalTo(false));
+    }
+
+    @Test
+    public void findsSensitiveData_inTargetShapes() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(memberWithSensitiveData, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(memberWithDullData, model), equalTo(false));
+    }
+
+    @Test
+    public void findsSensitiveData_inStructures() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(structureShapeSensitive, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(structureShapeDull, model), equalTo(false));
+    }
+
+    @Test
+    public void findsSensitiveData_inCollections() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(collectionSensitive, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(collectionDull, model), equalTo(false));
+    }
+
+    @Test
+    public void findsSensitiveData_inMaps() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(mapSensitiveKey, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(mapSensitiveValue, model), equalTo(true));
+        assertThat(sensitiveDataFinder.findsSensitiveData(mapDull, model), equalTo(false));
+    }
+
+    @Test
+    public void findsSensitiveData_deeplyNested() {
+        assertThat(sensitiveDataFinder.findsSensitiveData(nested, model), equalTo(true));
+    }
+}

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinderTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/validation/SensitiveDataFinderTest.java
@@ -15,166 +15,166 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
 public class SensitiveDataFinderTest {
-    private SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder();
+        StringShape sensitiveString = StringShape.builder()
+                        .addTrait(new SensitiveTrait())
+                        .id("foo.bar#sensitiveString")
+                        .build();
 
-    StringShape sensitiveString = StringShape.builder()
-            .addTrait(new SensitiveTrait())
-            .id("foo.bar#sensitiveString")
-            .build();
+        StringShape dullString = StringShape.builder()
+                        .id("foo.bar#dullString")
+                        .build();
 
-    StringShape dullString = StringShape.builder()
-            .id("foo.bar#dullString")
-            .build();
+        MemberShape memberWithSensitiveData = MemberShape.builder()
+                        .id("foo.bar#sensitive$member")
+                        .target(sensitiveString.getId())
+                        .build();
 
-    MemberShape memberWithSensitiveData = MemberShape.builder()
-            .id("foo.bar#sensitive$member")
-            .target(sensitiveString.getId())
-            .build();
+        MemberShape memberWithDullData = MemberShape.builder()
+                        .id("foo.bar#dull$member")
+                        .target(dullString.getId())
+                        .build();
 
-    MemberShape memberWithDullData = MemberShape.builder()
-            .id("foo.bar#dull$member")
-            .target(dullString.getId())
-            .build();
+        MemberShape listMemberWithSensitiveData = MemberShape.builder()
+                        .id("foo.bar#listSensitive$member")
+                        .target(sensitiveString.getId())
+                        .build();
 
-    MemberShape listMemberWithSensitiveData = MemberShape.builder()
-            .id("foo.bar#listSensitive$member")
-            .target(sensitiveString.getId())
-            .build();
+        MemberShape listMemberWithDullData = MemberShape.builder()
+                        .id("foo.bar#listDull$member")
+                        .target(dullString.getId())
+                        .build();
 
-    MemberShape listMemberWithDullData = MemberShape.builder()
-            .id("foo.bar#listDull$member")
-            .target(dullString.getId())
-            .build();
+        MemberShape mapMemberWithSensitiveKeyData = MemberShape.builder()
+                        .id("foo.bar#mapSensitiveKey$member")
+                        .target(sensitiveString.getId())
+                        .build();
 
-    MemberShape mapMemberWithSensitiveKeyData = MemberShape.builder()
-            .id("foo.bar#mapSensitiveKey$member")
-            .target(sensitiveString.getId())
-            .build();
+        MemberShape mapMemberWithSensitiveValueData = MemberShape.builder()
+                        .id("foo.bar#mapSensitiveValue$member")
+                        .target(sensitiveString.getId())
+                        .build();
 
-    MemberShape mapMemberWithSensitiveValueData = MemberShape.builder()
-            .id("foo.bar#mapSensitiveValue$member")
-            .target(sensitiveString.getId())
-            .build();
+        StructureShape structureShapeSensitive = StructureShape.builder()
+                        .id("foo.bar#sensitive")
+                        .members(
+                                        Collections.singleton(memberWithSensitiveData))
+                        .build();
 
-    StructureShape structureShapeSensitive = StructureShape.builder()
-            .id("foo.bar#sensitive")
-            .members(
-                    Collections.singleton(memberWithSensitiveData))
-            .build();
+        StructureShape structureShapeDull = StructureShape.builder()
+                        .id("foo.bar#dull")
+                        .members(
+                                        Collections.singleton(memberWithDullData))
+                        .build();
 
-    StructureShape structureShapeDull = StructureShape.builder()
-            .id("foo.bar#dull")
-            .members(
-                    Collections.singleton(memberWithDullData))
-            .build();
+        CollectionShape collectionSensitive = ListShape.builder()
+                        .id("foo.bar#listSensitive")
+                        .addMember(listMemberWithSensitiveData)
+                        .build();
 
-    CollectionShape collectionSensitive = ListShape.builder()
-            .id("foo.bar#listSensitive")
-            .addMember(listMemberWithSensitiveData)
-            .build();
+        CollectionShape collectionDull = ListShape.builder()
+                        .id("foo.bar#listDull")
+                        .addMember(listMemberWithDullData)
+                        .build();
 
-    CollectionShape collectionDull = ListShape.builder()
-            .id("foo.bar#listDull")
-            .addMember(listMemberWithDullData)
-            .build();
+        MapShape mapSensitiveKey = MapShape.builder()
+                        .id("foo.bar#mapSensitiveKey")
+                        .key(mapMemberWithSensitiveKeyData)
+                        .value(MemberShape.builder()
+                                        .id("foo.bar#mapSensitiveKey$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .build();
 
-    MapShape mapSensitiveKey = MapShape.builder()
-            .id("foo.bar#mapSensitiveKey")
-            .key(mapMemberWithSensitiveKeyData)
-            .value(MemberShape.builder()
-                    .id("foo.bar#mapSensitiveKey$member")
-                    .target(dullString.getId())
-                    .build())
-            .build();
+        MapShape mapSensitiveValue = MapShape.builder()
+                        .id("foo.bar#mapSensitiveValue")
+                        .key(MemberShape.builder()
+                                        .id("foo.bar#mapSensitiveValue$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .value(mapMemberWithSensitiveValueData)
+                        .build();
 
-    MapShape mapSensitiveValue = MapShape.builder()
-            .id("foo.bar#mapSensitiveValue")
-            .key(MemberShape.builder()
-                    .id("foo.bar#mapSensitiveValue$member")
-                    .target(dullString.getId())
-                    .build())
-            .value(mapMemberWithSensitiveValueData)
-            .build();
+        MapShape mapDull = MapShape.builder()
+                        .id("foo.bar#mapDull")
+                        .key(MemberShape.builder()
+                                        .id("foo.bar#mapDull$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .value(MemberShape.builder()
+                                        .id("foo.bar#mapDull$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .build();
 
-    MapShape mapDull = MapShape.builder()
-            .id("foo.bar#mapDull")
-            .key(MemberShape.builder()
-                    .id("foo.bar#mapDull$member")
-                    .target(dullString.getId())
-                    .build())
-            .value(MemberShape.builder()
-                    .id("foo.bar#mapDull$member")
-                    .target(dullString.getId())
-                    .build())
-            .build();
+        MapShape nested2 = MapShape.builder()
+                        .id("foo.bar#mapNested2")
+                        .key(MemberShape.builder()
+                                        .id("foo.bar#mapNested2$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .value(MemberShape.builder()
+                                        .id("foo.bar#mapNested2$member")
+                                        .target(mapSensitiveValue)
+                                        .build())
+                        .build();
 
-    MapShape nested2 = MapShape.builder()
-            .id("foo.bar#mapNested2")
-            .key(MemberShape.builder()
-                    .id("foo.bar#mapNested2$member")
-                    .target(dullString.getId())
-                    .build())
-            .value(MemberShape.builder()
-                    .id("foo.bar#mapNested2$member")
-                    .target(mapSensitiveValue)
-                    .build())
-            .build();
+        MapShape nested = MapShape.builder()
+                        .id("foo.bar#mapNested")
+                        .key(MemberShape.builder()
+                                        .id("foo.bar#mapNested$member")
+                                        .target(dullString.getId())
+                                        .build())
+                        .value(MemberShape.builder()
+                                        .id("foo.bar#mapNested$member")
+                                        .target(nested2)
+                                        .build())
+                        .build();
 
-    MapShape nested = MapShape.builder()
-            .id("foo.bar#mapNested")
-            .key(MemberShape.builder()
-                    .id("foo.bar#mapNested$member")
-                    .target(dullString.getId())
-                    .build())
-            .value(MemberShape.builder()
-                    .id("foo.bar#mapNested$member")
-                    .target(nested2)
-                    .build())
-            .build();
+        private Model model = Model.builder()
+                        .addShapes(
+                                        sensitiveString, dullString,
+                                        memberWithSensitiveData, memberWithDullData,
+                                        structureShapeSensitive, structureShapeDull,
+                                        collectionSensitive, collectionDull,
+                                        mapSensitiveKey, mapSensitiveValue, mapDull,
+                                        nested, nested2)
+                        .build();
 
-    private Model model = Model.builder()
-            .addShapes(
-                    sensitiveString, dullString,
-                    memberWithSensitiveData, memberWithDullData,
-                    structureShapeSensitive, structureShapeDull,
-                    collectionSensitive, collectionDull,
-                    mapSensitiveKey, mapSensitiveValue, mapDull,
-                    nested, nested2)
-            .build();
+        private SensitiveDataFinder sensitiveDataFinder = new SensitiveDataFinder(model);
 
-    @Test
-    public void findsSensitiveData_inShapes() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(sensitiveString, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(dullString, model), equalTo(false));
-    }
+        @Test
+        public void findsSensitiveData_inShapes() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(sensitiveString), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(dullString), equalTo(false));
+        }
 
-    @Test
-    public void findsSensitiveData_inTargetShapes() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(memberWithSensitiveData, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(memberWithDullData, model), equalTo(false));
-    }
+        @Test
+        public void findsSensitiveData_inTargetShapes() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(memberWithSensitiveData), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(memberWithDullData), equalTo(false));
+        }
 
-    @Test
-    public void findsSensitiveData_inStructures() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(structureShapeSensitive, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(structureShapeDull, model), equalTo(false));
-    }
+        @Test
+        public void findsSensitiveData_inStructures() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(structureShapeSensitive), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(structureShapeDull), equalTo(false));
+        }
 
-    @Test
-    public void findsSensitiveData_inCollections() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(collectionSensitive, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(collectionDull, model), equalTo(false));
-    }
+        @Test
+        public void findsSensitiveData_inCollections() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(collectionSensitive), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(collectionDull), equalTo(false));
+        }
 
-    @Test
-    public void findsSensitiveData_inMaps() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(mapSensitiveKey, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(mapSensitiveValue, model), equalTo(true));
-        assertThat(sensitiveDataFinder.findsSensitiveData(mapDull, model), equalTo(false));
-    }
+        @Test
+        public void findsSensitiveData_inMaps() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(mapSensitiveKey), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(mapSensitiveValue), equalTo(true));
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(mapDull), equalTo(false));
+        }
 
-    @Test
-    public void findsSensitiveData_deeplyNested() {
-        assertThat(sensitiveDataFinder.findsSensitiveData(nested, model), equalTo(true));
-    }
+        @Test
+        public void findsSensitiveData_deeplyNested() {
+                assertThat(sensitiveDataFinder.findsSensitiveDataIn(nested), equalTo(true));
+        }
 }


### PR DESCRIPTION
Adds a recursive check for sensitive fields before generating a sensitive data filter function. 
Currently all input/output have their own function even if it does nothing. This removes the no-op functions to reduce the code size.

For diff in JSv3 as an example, see https://github.com/aws/aws-sdk-js-v3/pull/4544 
(first commit contains a single client for easier viewing).

- [x] manual testing
- [x] what is the effect on code generation time?
  - for AWS EC2, generation took 4s to 5s both before and after this change.
- [x] use https://smithy.io/2.0/spec/selectors.html#forward-recursive-neighbors like `~> [trait|sensitive]`, look for `Selector.parse` (suggestion from @kstich)