### PR TITLE
improve documentation truncation behavior

### DIFF
--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
@@ -53,7 +53,36 @@ public class StructureExampleGeneratorTest {
     StructureShape structure = StructureShape.builder()
             .id("foo.bar#structure")
             .members(
-                    List.<MemberShape>of(memberForString, memberForList, memberForMap))
+                    List.<MemberShape>of(
+                            memberForString, memberForList, memberForMap,
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list2")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list3")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list4")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list5")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list6")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$list7")
+                                    .target(list.getId())
+                                    .build(),
+                            MemberShape.builder()
+                                    .id("foo.bar#structure$structure")
+                                    .target("foo.bar#structure")
+                                    .build()))
             .build();
 
     private Model model = Model.builder()
@@ -84,6 +113,34 @@ public class StructureExampleGeneratorTest {
                           ],
                           map: { // map
                             "<keys>": "STRING_VALUE",
+                          },
+                          list2: [
+                            "STRING_VALUE",
+                          ],
+                          list3: [
+                            "STRING_VALUE",
+                          ],
+                          list4: [
+                            "STRING_VALUE",
+                          ],
+                          list5: [
+                            "STRING_VALUE",
+                          ],
+                          list6: "<list>",
+                          list7: "<list>",
+                          structure: {
+                            string: "STRING_VALUE",
+                            list: "<list>",
+                            map: {
+                              "<keys>": "STRING_VALUE",
+                            },
+                            list2: "<list>",
+                            list3: "<list>",
+                            list4: "<list>",
+                            list5: "<list>",
+                            list6: "<list>",
+                            list7: "<list>",
+                            structure: "<structure>",
                           },
                         };"""));
     }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/documentation/StructureExampleGeneratorTest.java
@@ -67,7 +67,7 @@ public class StructureExampleGeneratorTest {
         assertThat(
                 StructureExampleGenerator.generateStructuralHintDocumentation(map, model),
                 equalTo("""
-                        {
+                        { // map
                           "<keys>": "STRING_VALUE",
                         };"""));
     }
@@ -77,12 +77,12 @@ public class StructureExampleGeneratorTest {
         assertThat(
                 StructureExampleGenerator.generateStructuralHintDocumentation(structure, model),
                 equalTo("""
-                        {
+                        { // structure
                           string: "STRING_VALUE",
-                          list: [
+                          list: [ // list
                             "STRING_VALUE",
                           ],
-                          map: {
+                          map: { // map
                             "<keys>": "STRING_VALUE",
                           },
                         };"""));
@@ -93,7 +93,7 @@ public class StructureExampleGeneratorTest {
         assertThat(
                 StructureExampleGenerator.generateStructuralHintDocumentation(list, model),
                 equalTo("""
-                        [
+                        [ // list
                           "STRING_VALUE",
                         ];"""));
     }


### PR DESCRIPTION
You can see that some shapes get quite long, CLI example: https://docs.aws.amazon.com/cli/latest/reference/quicksight/update-template.html

JSv3 API example: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-quicksight/classes/updatetemplatecommand.html

----

This PR aims to improve the recently implemented structural hint doc generation.

- more aggressive truncation for repeated shapes

- truncated item shows the target shape name instead of its entire structure
  - the name appears earlier in the shape hint

example, original shape appearance with name tag and then subsequent repeated shape truncation
```
{
  myShape: { // MyShape
    field1: "STRING_VALUE",
    field2: "STRING_VALUE"
  },
  myShape2: "<MyShape>"
}
```

JSv3 diff in https://github.com/aws/aws-sdk-js-v3/pull/4585/files