### PR TITLE
Update HttpRpcProtocolGenerator to allow request header code generati…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.27.2
+smithyVersion=1.30.0
 smithyGradleVersion=0.6.0


### PR DESCRIPTION
*Description of changes:*
* Bump Smithy version to 1.30.0
* Update HttpRpcProtocolGenerator to allow request header code generation customization
* This change was motivated by reducing the generated HTTP request header code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
