### PR TITLE
shorten internal serde fn names

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -448,8 +448,8 @@ final class CommandGenerator implements Runnable {
             writer.write("throw new Error(\"No supported protocol was found\");");
         } else {
             String serdeFunctionName = isInput
-                    ? ProtocolGenerator.getSerFunctionName(symbol, protocolGenerator.getName())
-                    : ProtocolGenerator.getDeserFunctionName(symbol, protocolGenerator.getName());
+                    ? ProtocolGenerator.getSerFunctionShortName(symbol)
+                    : ProtocolGenerator.getDeserFunctionShortName(symbol);
             writer.addImport(serdeFunctionName, serdeFunctionName,
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
                             ProtocolGenerator.getSanitizedName(protocolGenerator.getName())).toString());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -283,7 +283,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     private String getDelegateDeserializer(Shape shape, String customDataSource) {
         // Use the shape for the function name.
         Symbol symbol = context.getSymbolProvider().toSymbol(shape);
-        return ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
+        return ProtocolGenerator.getDeserFunctionShortName(symbol)
                 + "(" + customDataSource + ", context)";
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -252,7 +252,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     private String getDelegateSerializer(Shape shape) {
         // Use the shape for the function name.
         Symbol symbol = context.getSymbolProvider().toSymbol(shape);
-        return ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName())
+        return ProtocolGenerator.getSerFunctionShortName(symbol)
                 + "(" + dataSource + ", context)";
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeDeserVisitor.java
@@ -301,9 +301,12 @@ public abstract class DocumentShapeDeserVisitor extends ShapeVisitor.Default<Voi
 
         Symbol symbol = symbolProvider.toSymbol(shape);
         // Use the shape name for the function name.
-        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName());
+        String methodName = ProtocolGenerator.getDeserFunctionShortName(symbol);
+        String methodLongName =
+                ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName());
 
         writer.addImport(symbol, symbol.getName());
+        writer.writeDocs(methodLongName);
         writer.openBlock("const $L = (\n"
                        + "  output: any,\n"
                        + "  context: __SerdeContext\n"

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentShapeSerVisitor.java
@@ -297,9 +297,12 @@ public abstract class DocumentShapeSerVisitor extends ShapeVisitor.Default<Void>
 
         Symbol symbol = symbolProvider.toSymbol(shape);
         // Use the shape name for the function name.
-        String methodName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
+        String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
+        String methodLongName = ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName());
 
         writer.addImport(symbol, symbol.getName());
+
+        writer.writeDocs(methodLongName);
         writer.openBlock("const $L = (\n"
                        + "  input: $T,\n"
                        + "  context: __SerdeContext\n"

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -90,10 +90,10 @@ public class EventStreamGenerator {
      *                                  Shapes that referred by event will be added.
      */
     public void generateEventStreamSerializers(
-            GenerationContext context,
-            ServiceShape service,
-            String documentContentType,
-            Runnable serializeInputEventDocumentPayload,
+        GenerationContext context,
+        ServiceShape service,
+        String documentContentType,
+        Runnable serializeInputEventDocumentPayload,
         Set<Shape> documentShapesToSerialize
     ) {
         Model model = context.getModel();
@@ -118,11 +118,11 @@ public class EventStreamGenerator {
         });
         eventShapesToMarshall.forEach(event -> {
             generateEventMarshaller(
-                    context,
-                    event,
-                    documentContentType,
-                    serializeInputEventDocumentPayload,
-                    documentShapesToSerialize);
+                context,
+                event,
+                documentContentType,
+                serializeInputEventDocumentPayload,
+                documentShapesToSerialize);
         });
     }
 
@@ -190,14 +190,14 @@ public class EventStreamGenerator {
                 + "  context: $L\n"
                 + "): any => {", "}", methodName, getEventStreamSerdeContextType(context, eventsUnion), () -> {
             writer.openBlock("const eventMarshallingVisitor = (event: any): __Message => $T.visit(event, {", "});",
-                            eventsUnionSymbol, () -> {
-                                eventsUnion.getAllMembers().forEach((memberName, memberShape) -> {
-                            StructureShape target = model.expectShape(memberShape.getTarget(), StructureShape.class);
-                                    String eventSerMethodName = getEventSerFunctionName(context, target);
-                                    writer.write("$L: value => $L(value, context),", memberName, eventSerMethodName);
-                                });
-                                writer.write("_: value => value as any");
-                            });
+                    eventsUnionSymbol, () -> {
+                        eventsUnion.getAllMembers().forEach((memberName, memberShape) -> {
+                    StructureShape target = model.expectShape(memberShape.getTarget(), StructureShape.class);
+                            String eventSerMethodName = getEventSerFunctionName(context, target);
+                            writer.write("$L: value => $L(value, context),", memberName, eventSerMethodName);
+                        });
+                        writer.write("_: value => value as any");
+                    });
                     writer.write("return context.eventStreamMarshaller.serialize(input, eventMarshallingVisitor);");
                 });
     }
@@ -229,10 +229,10 @@ public class EventStreamGenerator {
     }
 
     public void generateEventMarshaller(
-            GenerationContext context,
-            StructureShape event,
-            String documentContentType,
-            Runnable serializeInputEventDocumentPayload,
+        GenerationContext context,
+        StructureShape event,
+        String documentContentType,
+        Runnable serializeInputEventDocumentPayload,
         Set<Shape> documentShapesToSerialize
     ) {
         String methodName = getEventSerFunctionName(context, event);
@@ -243,17 +243,17 @@ public class EventStreamGenerator {
                 + "  input: $T,\n"
                 + "  context: __SerdeContext\n"
                 + "): __Message => {", "}", methodName, symbol, () -> {
-                    writer.openBlock("const headers: __MessageHeaders = {", "}", () -> {
-                        //fix headers required by event stream
-                        writer.write("\":event-type\": { type: \"string\", value: $S },", symbol.getName());
-                        writer.write("\":message-type\": { type: \"string\", value: \"event\" },");
-                        writeEventContentTypeHeader(context, event, documentContentType);
-                    });
-                    writeEventHeaders(context, event);
-                    writeEventBody(context, event, serializeInputEventDocumentPayload,
-                            documentShapesToSerialize);
-                    writer.openBlock("return { headers, body };");
-                });
+            writer.openBlock("const headers: __MessageHeaders = {", "}", () -> {
+                //fix headers required by event stream
+                writer.write("\":event-type\": { type: \"string\", value: $S },", symbol.getName());
+                writer.write("\":message-type\": { type: \"string\", value: \"event\" },");
+                writeEventContentTypeHeader(context, event, documentContentType);
+            });
+            writeEventHeaders(context, event);
+            writeEventBody(context, event, serializeInputEventDocumentPayload,
+                    documentShapesToSerialize);
+            writer.openBlock("return { headers, body };");
+        });
     }
 
     private void writeEventContentTypeHeader(
@@ -283,8 +283,8 @@ public class EventStreamGenerator {
                 .filter(member -> member.hasTrait(EventPayloadTrait.class))
                 .collect(Collectors.toList());
         return payloadMembers.isEmpty()
-                ? Optional.empty() // implicit payload
-                : Optional.of(payloadMembers.get(0));
+                        ? Optional.empty() // implicit payload
+                        : Optional.of(payloadMembers.get(0));
     }
 
     private void writeEventHeaders(GenerationContext context, StructureShape event) {
@@ -327,8 +327,8 @@ public class EventStreamGenerator {
      */
     private MemberShape getExplicitEventPayloadMember(StructureShape event) {
         return event.getAllMembers().values().stream()
-                .filter(member -> member.hasTrait(EventPayloadTrait.class))
-                .collect(Collectors.toList()).get(0);
+                    .filter(member -> member.hasTrait(EventPayloadTrait.class))
+                    .collect(Collectors.toList()).get(0);
     }
 
     private void writeEventBody(
@@ -356,7 +356,7 @@ public class EventStreamGenerator {
                     serializeInputEventDocumentPayload.run();
                 } else {
                     throw new CodegenException(String.format("Unexpected shape type bound to event payload: `%s`",
-                            payloadShape.getType()));
+                        payloadShape.getType()));
                 }
             });
         } else {
@@ -388,22 +388,22 @@ public class EventStreamGenerator {
                 + "  output: any,\n"
                 + "  context: $L\n"
                 + "): AsyncIterable<$T> => {", "}", methodName, contextType, eventsUnionSymbol, () -> {
-                    writer.openBlock("return context.eventStreamMarshaller.deserialize(", ");", () -> {
-                        writer.write("output,");
-                        writer.openBlock("async event => {", "}", () -> {
-                            eventsUnion.getAllMembers().forEach((name, member) -> {
-                                StructureShape event = model.expectShape(member.getTarget(), StructureShape.class);
-                                writer.openBlock("if (event[$S] != null) {", "}", name, () -> {
-                                    writer.openBlock("return {", "};", () -> {
-                                        String eventDeserMethodName = getEventDeserFunctionName(context, event);
-                                        writer.write("$1L: await $2L(event[$1S], context),", name, eventDeserMethodName);
-                                    });
-                                });
+            writer.openBlock("return context.eventStreamMarshaller.deserialize(", ");", () -> {
+                writer.write("output,");
+                writer.openBlock("async event => {", "}", () -> {
+                    eventsUnion.getAllMembers().forEach((name, member) -> {
+                        StructureShape event = model.expectShape(member.getTarget(), StructureShape.class);
+                        writer.openBlock("if (event[$S] != null) {", "}", name, () -> {
+                            writer.openBlock("return {", "};", () -> {
+                                String eventDeserMethodName = getEventDeserFunctionName(context, event);
+                                writer.write("$1L: await $2L(event[$1S], context),", name, eventDeserMethodName);
                             });
-                            writer.write("return {$$unknown: output};");
                         });
                     });
+                    writer.write("return {$$unknown: output};");
                 });
+            });
+        });
     }
 
     private String getDeserFunctionName(GenerationContext context, Shape shape) {
@@ -429,15 +429,15 @@ public class EventStreamGenerator {
                 + "  output: any,\n"
                 + "  context: __SerdeContext\n"
                 + "): Promise<$T> => {", "}", methodName, symbol, () -> {
-                    if (event.hasTrait(ErrorTrait.class)) {
-                        generateErrorEventUnmarshaller(context, event, errorShapesToDeserialize, isErrorCodeInBody);
-                    } else {
-                        writer.write("const contents: $L = {} as any;", symbol.getName());
-                        readEventHeaders(context, event);
-                        readEventBody(context, event, eventShapesToDeserialize);
-                        writer.write("return contents;");
-                    }
-                });
+            if (event.hasTrait(ErrorTrait.class)) {
+                generateErrorEventUnmarshaller(context, event, errorShapesToDeserialize, isErrorCodeInBody);
+            } else {
+                writer.write("const contents: $L = {} as any;", symbol.getName());
+                readEventHeaders(context, event);
+                readEventBody(context, event, eventShapesToDeserialize);
+                writer.write("return contents;");
+            }
+        });
     }
 
     // Writes function content that unmarshall error event with error deserializer

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -263,17 +263,17 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", responseType, () -> {
 
-            writeEmptyEndpoint(context);
+                    writeEmptyEndpoint(context);
 
-            writer.openBlock("switch (input.name) {", "}", () -> {
+                    writer.openBlock("switch (input.name) {", "}", () -> {
                 for (final Shape shape : new TreeSet<>(context.getModel().getShapesWithTrait(HttpErrorTrait.class))) {
                     StructureShape errorShape = shape.asStructureShape().orElseThrow(IllegalArgumentException::new);
-                    writer.openBlock("case $S: {", "}", errorShape.getId().getName(), () -> {
+                            writer.openBlock("case $S: {", "}", errorShape.getId().getName(), () -> {
                         generateErrorSerializationImplementation(context, errorShape, responseType, bindingIndex);
+                            });
+                        }
                     });
-                }
-            });
-        });
+                });
         writer.write("");
     }
 
@@ -318,8 +318,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     private void generateUriSpec(GenerationContext context,
-                                 OperationShape operation,
-                                 HttpTrait httpTrait) {
+            OperationShape operation,
+            HttpTrait httpTrait) {
         TypeScriptWriter writer = context.getWriter();
 
         String serviceName = context.getService().getId().getName();
@@ -372,8 +372,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-            Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
-                ProtocolGenerator.getSanitizedName(getName())).toString());
+                Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
+                        ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
@@ -384,12 +384,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (context.getSettings().isDisableDefaultValidation()) {
             writer.write("export const get$L = <Context>(service: $T<Context>, "
-                            + "customizer: __ValidationCustomizer<$T>): "
-                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                    + "customizer: __ValidationCustomizer<$T>): "
+                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     handlerSymbol.getName(), serviceSymbol, operationsSymbol);
         } else {
             writer.write("export const get$L = <Context>(service: $T<Context>): "
-                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     handlerSymbol.getName(), serviceSymbol);
         }
         writer.indent();
@@ -397,21 +397,21 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         generateServiceMux(context);
         writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
         writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T<Context>, $1T, __ServiceException> = "
-                        + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
-            writer.openBlock("switch (op) {", "}", () -> {
-                operations.stream()
-                        .filter(o -> o.getTrait(HttpTrait.class).isPresent())
-                        .forEach(writeOperationCase(writer, symbolProvider));
-            });
-        });
+                + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
+                    writer.openBlock("switch (op) {", "}", () -> {
+                        operations.stream()
+                                .filter(o -> o.getTrait(HttpTrait.class).isPresent())
+                                .forEach(writeOperationCase(writer, symbolProvider));
+                    });
+                });
 
         if (!context.getSettings().isDisableDefaultValidation()) {
             writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
             writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
             writer.openBlock("const customizer: __ValidationCustomizer<$T> = (ctx, failures) => {", "};",
-                operationsSymbol,
-                () -> {
-                    writeDefaultValidationCustomizer(writer);
+                    operationsSymbol,
+                    () -> {
+                        writeDefaultValidationCustomizer(writer);
                 }
             );
         }
@@ -427,8 +427,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-            Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
-                ProtocolGenerator.getSanitizedName(getName())).toString());
+                Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
+                        ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
 
@@ -440,12 +440,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (context.getSettings().isDisableDefaultValidation()) {
             writer.write("export const get$L = <Context>(operation: __Operation<$T, $T, Context>, "
-                            + "customizer: __ValidationCustomizer<$S>): "
-                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                    + "customizer: __ValidationCustomizer<$S>): "
+                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     operationHandlerSymbol.getName(), inputType, outputType, operationSymbol.getName());
         } else {
             writer.write("export const get$L = <Context>(operation: __Operation<$T, $T, Context>): "
-                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     operationHandlerSymbol.getName(), inputType, outputType);
         }
         writer.indent();
@@ -456,9 +456,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
             writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
             writer.openBlock("const customizer: __ValidationCustomizer<$S> = (ctx, failures) => {", "};",
-                operationSymbol.getName(),
-                () -> {
-                    writeDefaultValidationCustomizer(writer);
+                    operationSymbol.getName(),
+                    () -> {
+                        writeDefaultValidationCustomizer(writer);
                 }
             );
         }
@@ -531,28 +531,28 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  input: $T,\n"
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", methodName, outputType, responseType, () -> {
-            writeEmptyEndpoint(context);
-            writeOperationStatusCode(context, operation, bindingIndex, trait);
-            writeResponseHeaders(context, operation, bindingIndex,
-                    () -> writeDefaultOutputHeaders(context, operation));
+                    writeEmptyEndpoint(context);
+                    writeOperationStatusCode(context, operation, bindingIndex, trait);
+                    writeResponseHeaders(context, operation, bindingIndex,
+                            () -> writeDefaultOutputHeaders(context, operation));
 
-            List<HttpBinding> bodyBindings = writeResponseBody(context, operation, bindingIndex);
-            if (!bodyBindings.isEmpty()) {
-                // Track all shapes bound to the body so their serializers may be generated.
-                bodyBindings.stream()
-                        .map(HttpBinding::getMember)
-                        .map(member -> context.getModel().expectShape(member.getTarget()))
-                        .forEach(serializingDocumentShapes::add);
-            }
+                    List<HttpBinding> bodyBindings = writeResponseBody(context, operation, bindingIndex);
+                    if (!bodyBindings.isEmpty()) {
+                        // Track all shapes bound to the body so their serializers may be generated.
+                        bodyBindings.stream()
+                                .map(HttpBinding::getMember)
+                                .map(member -> context.getModel().expectShape(member.getTarget()))
+                                .forEach(serializingDocumentShapes::add);
+                    }
 
-            calculateContentLength(context);
+                    calculateContentLength(context);
 
-            writer.openBlock("return new $T({", "});", responseType, () -> {
-                writer.write("headers,");
-                writer.write("body,");
-                writer.write("statusCode,");
-            });
-        });
+                    writer.openBlock("return new $T({", "});", responseType, () -> {
+                        writer.write("headers,");
+                        writer.write("body,");
+                        writer.write("statusCode,");
+                    });
+                });
         writer.write("");
 
         serializingErrorShapes.addAll(OperationIndex.of(context.getModel()).getErrors(operation, context.getService()));
@@ -564,11 +564,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.addImport("calculateBodyLength", null, "@aws-sdk/util-body-length-node");
         writer.openBlock("if (body && Object.keys(headers).map((str) => str.toLowerCase())"
                 + ".indexOf('content-length') === -1) {", "}", () -> {
-            writer.write("const length = calculateBodyLength(body);");
-            writer.openBlock("if (length !== undefined) {", "}", () -> {
-                writer.write("headers = { ...headers, 'content-length': String(length) };");
-            });
-        });
+                    writer.write("const length = calculateBodyLength(body);");
+                    writer.openBlock("if (length !== undefined) {", "}", () -> {
+                        writer.write("headers = { ...headers, 'content-length': String(length) };");
+                    });
+                });
 
     }
 
@@ -587,16 +587,16 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  input: $T,\n"
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", methodName, symbol, responseType, () -> {
-            writeEmptyEndpoint(context);
-            generateErrorSerializationImplementation(context, error, responseType, bindingIndex);
-        });
+                    writeEmptyEndpoint(context);
+                    generateErrorSerializationImplementation(context, error, responseType, bindingIndex);
+                });
         writer.write("");
     }
 
     private void generateErrorSerializationImplementation(GenerationContext context,
-                                                          StructureShape error,
-                                                          SymbolReference responseType,
-                                                          HttpBindingIndex bindingIndex) {
+            StructureShape error,
+            SymbolReference responseType,
+            HttpBindingIndex bindingIndex) {
         TypeScriptWriter writer = context.getWriter();
         writeErrorStatusCode(context, error);
         writeResponseHeaders(context, error, bindingIndex, () -> writeDefaultErrorHeaders(context, error));
@@ -642,57 +642,62 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
         writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
+
+        // e.g., se_ES
+        String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
         // e.g., serializeAws_restJson1_1ExecuteStatement
-        String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName());
+        String methodLongName = ProtocolGenerator.getSerFunctionName(symbol, getName());
+
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
         String contextType = CodegenUtils.getOperationSerializerContextType(writer, context.getModel(), operation);
 
+        writer.writeDocs(methodLongName);
         writer.openBlock("export const $L = async(\n"
                        + "  input: $T,\n"
                        + "  context: $L\n"
                        + "): Promise<$T> => {", "}", methodName, inputType, contextType, requestType, () -> {
 
-            // Get the hostname, path, port, and scheme from client's resolved endpoint. Then construct the request from
-            // them. The client's resolved endpoint can be default one or supplied by users.
-            writer.write("const {hostname, protocol = $S, port, path: basePath} = await context.endpoint();", "https");
+                // Get the hostname, path, port, and scheme from client's resolved endpoint. Then construct the request from
+                // them. The client's resolved endpoint can be default one or supplied by users.
+                writer.write("const {hostname, protocol = $S, port, path: basePath} = await context.endpoint();", "https");
 
-            writeRequestHeaders(context, operation, bindingIndex);
-            writeResolvedPath(context, operation, bindingIndex, trait);
-            boolean hasQueryComponents = writeRequestQueryString(context, operation, bindingIndex, trait);
+                writeRequestHeaders(context, operation, bindingIndex);
+                writeResolvedPath(context, operation, bindingIndex, trait);
+                boolean hasQueryComponents = writeRequestQueryString(context, operation, bindingIndex, trait);
 
-            List<HttpBinding> bodyBindings = writeRequestBody(context, operation, bindingIndex);
-            if (!bodyBindings.isEmpty()) {
-                // Track all shapes bound to the body so their serializers may be generated.
-                bodyBindings.stream()
-                        .map(HttpBinding::getMember)
-                        .map(member -> context.getModel().expectShape(member.getTarget()))
-                        .filter(shape -> !EventStreamGenerator.isEventStreamShape(shape))
-                        .forEach(serializingDocumentShapes::add);
-            }
+                List<HttpBinding> bodyBindings = writeRequestBody(context, operation, bindingIndex);
+                if (!bodyBindings.isEmpty()) {
+                    // Track all shapes bound to the body so their serializers may be generated.
+                    bodyBindings.stream()
+                            .map(HttpBinding::getMember)
+                            .map(member -> context.getModel().expectShape(member.getTarget()))
+                            .filter(shape -> !EventStreamGenerator.isEventStreamShape(shape))
+                            .forEach(serializingDocumentShapes::add);
+                }
 
-            boolean hasHostPrefix = operation.hasTrait(EndpointTrait.class);
-            if (hasHostPrefix) {
-                HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
-            }
-            writer.openBlock("return new $T({", "});", requestType, () -> {
-                writer.write("protocol,");
+                boolean hasHostPrefix = operation.hasTrait(EndpointTrait.class);
                 if (hasHostPrefix) {
-                    writer.write("hostname: resolvedHostname,");
-                } else {
-                    writer.write("hostname,");
+                    HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
                 }
-                writer.write("port,");
-                writer.write("method: $S,", trait.getMethod());
-                writer.write("headers,");
-                writer.write("path: resolvedPath,");
-                if (hasQueryComponents) {
-                    writer.write("query,");
-                }
-                // Always set the body,
-                writer.write("body,");
+                writer.openBlock("return new $T({", "});", requestType, () -> {
+                    writer.write("protocol,");
+                    if (hasHostPrefix) {
+                        writer.write("hostname: resolvedHostname,");
+                    } else {
+                        writer.write("hostname,");
+                    }
+                    writer.write("port,");
+                    writer.write("method: $S,", trait.getMethod());
+                    writer.write("headers,");
+                    writer.write("path: resolvedPath,");
+                    if (hasQueryComponents) {
+                        writer.write("query,");
+                    }
+                    // Always set the body,
+                    writer.write("body,");
+                });
             });
-        });
 
         writer.write("");
     }
@@ -739,9 +744,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         final boolean useEndpointsV2 = context.getService().hasTrait(EndpointRuleSetTrait.class);
         final Map<String, String> contextParams = useEndpointsV2
-            ? new RuleSetParameterFinder(context.getService())
-                .getContextParams(context.getModel().getShape(operation.getInputShape()).get())
-            : Collections.emptyMap();
+                ? new RuleSetParameterFinder(context.getService())
+                        .getContextParams(context.getModel().getShape(operation.getInputShape()).get())
+                : Collections.emptyMap();
 
         // Always write the bound path, but only the actual segments.
         writer.write("let resolvedPath = `$L` + $S;",
@@ -760,7 +765,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         // We use this logic plus a temporary control-list, since it is not yet known
                         // how many services and param names will have this issue.
                         return !(isContextParam
-                            && contextParamDeduplicationParamControlSet.contains(content));
+                                && contextParamDeduplicationParamControlSet.contains(content));
                     })
                     .map(Segment::toString)
                     .collect(Collectors.joining("/"))
@@ -880,11 +885,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (isRequired) {
                 // __expectNonNull is immediately invoked and not inside a function.
                 writer.write(
-                    "$S: [__expectNonNull(input.$L, `$L`) != null, () => $L],",
-                    binding.getLocationName(),
-                    memberName,
-                    memberName,
-                    queryValue // no idempotency token default for required members
+                        "$S: [__expectNonNull(input.$L, `$L`) != null, () => $L],",
+                        binding.getLocationName(),
+                        memberName,
+                        memberName,
+                        queryValue // no idempotency token default for required members
                 );
             } else {
                 // undefined check with lazy eval
@@ -927,8 +932,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             closing = "};";
         } else {
             opening = normalHeaderCount > 0
-                ? "const headers: any = map({}, isSerializableHeaderValue, {"
-                : "const headers: any = map({";
+                    ? "const headers: any = map({}, isSerializableHeaderValue, {"
+                    : "const headers: any = map({";
             closing = "});";
         }
 
@@ -1005,17 +1010,17 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Shape target = model.expectShape(prefixMap.getValue().getTarget());
         // Iterate through each entry in the member.
         writer.openBlock("...($1L !== undefined) && Object.keys($1L).reduce(", "),", memberLocation,
-            () -> {
-                writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
-                    () -> {
-                        // Use a ! since we already validated the input member is defined above.
-                        String headerValue = getInputValue(context, binding.getLocation(),
-                                memberLocation + "![suffix]", binding.getMember(), target);
-                        // Append the prefix to key.
-                        writer.write("acc[`$L$${suffix.toLowerCase()}`] = $L;",
-                                binding.getLocationName().toLowerCase(Locale.US), headerValue);
-                        writer.write("return acc;");
-                    });
+                () -> {
+                    writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
+                        () -> {
+                            // Use a ! since we already validated the input member is defined above.
+                            String headerValue = getInputValue(context, binding.getLocation(),
+                                    memberLocation + "![suffix]", binding.getMember(), target);
+                            // Append the prefix to key.
+                            writer.write("acc[`$L$${suffix.toLowerCase()}`] = $L;",
+                                    binding.getLocationName().toLowerCase(Locale.US), headerValue);
+                            writer.write("return acc;");
+                        });
             }
         );
     }
@@ -1342,7 +1347,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         switch (bindingType) {
             case PAYLOAD:
                 Symbol symbol = context.getSymbolProvider().toSymbol(target);
-                return ProtocolGenerator.getSerFunctionName(symbol, context.getProtocolName())
+                return ProtocolGenerator.getSerFunctionShortName(symbol)
                         + "(" + dataSource + ", context)";
             default:
                 throw new CodegenException("Unexpected named member shape binding location `" + bindingType + "`");
@@ -1373,10 +1378,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         String valueString = getInputValue(context, bindingType, "value", mapMember,
                 model.expectShape(mapMember.getTarget()));
         return "Object.entries(" + dataSource + " || {}).reduce("
-            + "(acc: any, [key, value]: [string, " + symbolProvider.toSymbol(mapMember) + "]) => {"
-            +   "acc[key] = " + valueString + ";"
-            +   "return acc;"
-            + "}, {})";
+                + "(acc: any, [key, value]: [string, " + symbolProvider.toSymbol(mapMember) + "]) => {"
+                +   "acc[key] = " + valueString + ";"
+                +   "return acc;"
+                + "}, {})";
     }
 
     /**
@@ -1534,7 +1539,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Writes the code needed to serialize a protocol output document.
      *
-     * <p>Implementations of this method are expected to set a value to the
+     * <p>
+     * Implementations of this method are expected to set a value to the
      * {@code body} variable that will be serialized as the request body.
      * This variable will already be defined in scope.
      *
@@ -1716,23 +1722,23 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  output: $T,\n"
                 + "  context: $L\n"
                 + "): Promise<$T> => {", "}", methodName, requestType, contextType, inputType, () -> {
-            handleContentType(context, operation, bindingIndex);
-            handleAccept(context, operation, bindingIndex);
-            // Start deserializing the response.
-            writer.openBlock("const contents: any = map({", "});", () -> {
-                readRequestHeaders(context, operation, bindingIndex, "output");
-            });
-            readQueryString(context, operation, bindingIndex);
-            readPath(context, operation, bindingIndex, trait);
-            readHost(context, operation);
-            List<HttpBinding> documentBindings = readRequestBody(context, operation, bindingIndex);
-            // Track all shapes bound to the document so their deserializers may be generated.
-            documentBindings.forEach(binding -> {
-                Shape target = model.expectShape(binding.getMember().getTarget());
-                deserializingDocumentShapes.add(target);
-            });
-            writer.write("return contents;");
-        });
+                    handleContentType(context, operation, bindingIndex);
+                    handleAccept(context, operation, bindingIndex);
+                    // Start deserializing the response.
+                    writer.openBlock("const contents: any = map({", "});", () -> {
+                        readRequestHeaders(context, operation, bindingIndex, "output");
+                    });
+                    readQueryString(context, operation, bindingIndex);
+                    readPath(context, operation, bindingIndex, trait);
+                    readHost(context, operation);
+                    List<HttpBinding> documentBindings = readRequestBody(context, operation, bindingIndex);
+                    // Track all shapes bound to the document so their deserializers may be generated.
+                    documentBindings.forEach(binding -> {
+                        Shape target = model.expectShape(binding.getMember().getTarget());
+                        deserializingDocumentShapes.add(target);
+                    });
+                    writer.write("return contents;");
+                });
         writer.write("");
     }
 
@@ -1890,10 +1896,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             binding.getLocationName(),
                             () -> {
                                 writer.openBlock("if (query[$S].length === 1) {", "}",
-                                    binding.getLocationName(),
-                                    () -> {
-                                        writer.write("queryValue = query[$S][0];", binding.getLocationName());
-                                    });
+                                        binding.getLocationName(),
+                                        () -> {
+                                            writer.write("queryValue = query[$S][0];", binding.getLocationName());
+                                        });
                                 writer.openBlock("else {", "}", () -> {
                                     writer.write("throw new __SerializationException();");
                                 });
@@ -1944,7 +1950,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     writer.write("queryValue = value as string;");
                 });
                 parsedValue = getOutputValue(context, mappedBinding.getLocation(),
-                                "queryValue", target.getValue(), valueShape);
+                        "queryValue", target.getValue(), valueShape);
             }
             writer.write("parsedQuery[key] = $L;", parsedValue);
         });
@@ -2052,7 +2058,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Ensure that the response type is imported.
         writer.addUseImports(responseType);
         // e.g., deserializeAws_restJson1_1ExecuteStatement
-        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, getName());
+        String methodName = ProtocolGenerator.getDeserFunctionShortName(symbol);
+        String methodLongName = ProtocolGenerator.getDeserFunctionName(symbol, getName());
         String errorMethodName = methodName + "Error";
         // Add the normalized output type.
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
@@ -2060,35 +2067,36 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 context.getModel(), operation);
 
         // Handle the general response.
+        writer.writeDocs(methodLongName);
         writer.openBlock("export const $L = async(\n"
-                       + "  output: $T,\n"
-                       + "  context: $L\n"
-                       + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
-            // Redirect error deserialization to the dispatcher if we receive an error range
-            // status code that's not the modeled code (300 or higher). This allows for
-            // returning other 2XX codes that don't match the defined value.
-            writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
-                    () -> writer.write("return $L(output, context);", errorMethodName));
+                + "  output: $T,\n"
+                + "  context: $L\n"
+                + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
+                    // Redirect error deserialization to the dispatcher if we receive an error range
+                    // status code that's not the modeled code (300 or higher). This allows for
+                    // returning other 2XX codes that don't match the defined value.
+                    writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
+                            () -> writer.write("return $L(output, context);", errorMethodName));
 
-            // Start deserializing the response.
-            writer.openBlock("const contents: any = map({", "});", () -> {
-                writer.write("$$metadata: deserializeMetadata(output),");
+                    // Start deserializing the response.
+                    writer.openBlock("const contents: any = map({", "});", () -> {
+                        writer.write("$$metadata: deserializeMetadata(output),");
 
-                readResponseHeaders(context, operation, bindingIndex, "output");
-            });
+                        readResponseHeaders(context, operation, bindingIndex, "output");
+                    });
 
-            List<HttpBinding> documentBindings = readResponseBody(context, operation, bindingIndex);
+                    List<HttpBinding> documentBindings = readResponseBody(context, operation, bindingIndex);
 
-            // Track all shapes bound to the document so their deserializers may be generated.
-            documentBindings.forEach(binding -> {
-                Shape target = model.expectShape(binding.getMember().getTarget());
-                if (!EventStreamGenerator.isEventStreamShape(target)) {
-                    deserializingDocumentShapes.add(target);
-                }
-            });
+                    // Track all shapes bound to the document so their deserializers may be generated.
+                    documentBindings.forEach(binding -> {
+                        Shape target = model.expectShape(binding.getMember().getTarget());
+                        if (!EventStreamGenerator.isEventStreamShape(target)) {
+                            deserializingDocumentShapes.add(target);
+                        }
+                    });
 
-            writer.write("return contents;");
-        });
+                    writer.write("return contents;");
+                });
         writer.write("");
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
@@ -2103,34 +2111,37 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         HttpBindingIndex bindingIndex = HttpBindingIndex.of(context.getModel());
         Model model = context.getModel();
         Symbol errorSymbol = symbolProvider.toSymbol(error);
-        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
-                context.getProtocolName()) + "Response";
+        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionShortName(errorSymbol) + "Res";
+        String errorDeserMethodLongName = ProtocolGenerator.getDeserFunctionName(errorSymbol, context.getProtocolName())
+                + "Res";
+
         String outputName = isErrorCodeInBody ? "parsedOutput" : "output";
 
+        writer.writeDocs(errorDeserMethodLongName);
         writer.openBlock("const $L = async (\n"
-                       + "  $L: any,\n"
-                       + "  context: __SerdeContext\n"
-                       + "): Promise<$T> => {", "};",
+                + "  $L: any,\n"
+                + "  context: __SerdeContext\n"
+                + "): Promise<$T> => {", "};",
                 errorDeserMethodName, outputName, errorSymbol, () -> {
-            writer.openBlock("const contents: any = map({", "});", () -> {
-                readResponseHeaders(context, error, bindingIndex, outputName);
-            });
+                    writer.openBlock("const contents: any = map({", "});", () -> {
+                        readResponseHeaders(context, error, bindingIndex, outputName);
+                    });
 
-            List<HttpBinding> documentBindings = readErrorResponseBody(context, error, bindingIndex);
+                    List<HttpBinding> documentBindings = readErrorResponseBody(context, error, bindingIndex);
             // Track all shapes bound to the document so their deserializers may be generated.
-            documentBindings.forEach(binding -> {
-                Shape target = model.expectShape(binding.getMember().getTarget());
-                deserializingDocumentShapes.add(target);
-            });
-            writer.openBlock("const exception = new $T({", "});", errorSymbol, () -> {
-                writer.write("$$metadata: deserializeMetadata($L),", outputName);
-                writer.write("...contents");
-            });
-            String errorLocation = this.getErrorBodyLocation(context, outputName + ".body");
-            writer.addImport("decorateServiceException", "__decorateServiceException",
-                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-            writer.write("return __decorateServiceException(exception, $L);", errorLocation);
-        });
+                    documentBindings.forEach(binding -> {
+                        Shape target = model.expectShape(binding.getMember().getTarget());
+                        deserializingDocumentShapes.add(target);
+                    });
+                    writer.openBlock("const exception = new $T({", "});", errorSymbol, () -> {
+                        writer.write("$$metadata: deserializeMetadata($L),", outputName);
+                        writer.write("...contents");
+                    });
+                    String errorLocation = this.getErrorBodyLocation(context, outputName + ".body");
+                    writer.addImport("decorateServiceException", "__decorateServiceException",
+                            TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                    writer.write("return __decorateServiceException(exception, $L);", errorLocation);
+                });
 
         writer.write("");
     }
@@ -2246,9 +2257,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     MapShape prefixMap = model.expectShape(binding.getMember().getTarget()).asMapShape().get();
                     Shape target = model.expectShape(prefixMap.getValue().getTarget());
                     String headerValue = getOutputValue(context, binding.getLocation(),
-                        outputName + ".headers[header]", binding.getMember(), target);
+                            outputName + ".headers[header]", binding.getMember(), target);
                     writer.write("acc[header.substring($L)] = $L;",
-                        headerLocation.length(), headerValue);
+                            headerLocation.length(), headerValue);
                     writer.write("return acc;");
                 });
             });
@@ -2661,8 +2672,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case PAYLOAD:
                 // Redirect to a deserialization function.
                 Symbol symbol = context.getSymbolProvider().toSymbol(target);
-                return ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
-                               + "(" + dataSource + ", context)";
+                return ProtocolGenerator.getDeserFunctionShortName(symbol)
+                        + "(" + dataSource + ", context)";
             default:
                 throw new CodegenException("Unexpected named member shape binding location `" + bindingType + "`");
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -658,8 +658,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "  context: $L\n"
                        + "): Promise<$T> => {", "}", methodName, inputType, contextType, requestType, () -> {
 
-            // Get the hostname, path, port, and scheme from client's resolved endpoint. Then construct the request from
-            // them. The client's resolved endpoint can be default one or supplied by users.
+            // Get the hostname, path, port, and scheme from client's resolved endpoint.
+            // Then construct the request from them. The client's resolved endpoint can
+            // be default one or supplied by users.
             writer.write("const {hostname, protocol = $S, port, path: basePath} = await context.endpoint();", "https");
 
             writeRequestHeaders(context, operation, bindingIndex);
@@ -2071,7 +2072,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.openBlock("export const $L = async(\n"
                        + "  output: $T,\n"
                        + "  context: $L\n"
-                       + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
+                       + "): Promise<$T> => {", "}",
+                       methodName, responseType, contextType, outputType, () -> {
             // Redirect error deserialization to the dispatcher if we receive an error range
             // status code that's not the modeled code (300 or higher). This allows for
             // returning other 2XX codes that don't match the defined value.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -263,17 +263,17 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", responseType, () -> {
 
-                    writeEmptyEndpoint(context);
+            writeEmptyEndpoint(context);
 
-                    writer.openBlock("switch (input.name) {", "}", () -> {
+            writer.openBlock("switch (input.name) {", "}", () -> {
                 for (final Shape shape : new TreeSet<>(context.getModel().getShapesWithTrait(HttpErrorTrait.class))) {
                     StructureShape errorShape = shape.asStructureShape().orElseThrow(IllegalArgumentException::new);
-                            writer.openBlock("case $S: {", "}", errorShape.getId().getName(), () -> {
+                    writer.openBlock("case $S: {", "}", errorShape.getId().getName(), () -> {
                         generateErrorSerializationImplementation(context, errorShape, responseType, bindingIndex);
-                            });
-                        }
                     });
-                });
+                }
+            });
+        });
         writer.write("");
     }
 
@@ -318,8 +318,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     private void generateUriSpec(GenerationContext context,
-            OperationShape operation,
-            HttpTrait httpTrait) {
+                                 OperationShape operation,
+                                 HttpTrait httpTrait) {
         TypeScriptWriter writer = context.getWriter();
 
         String serviceName = context.getService().getId().getName();
@@ -372,8 +372,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-                Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
-                        ProtocolGenerator.getSanitizedName(getName())).toString());
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
+                ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
@@ -384,12 +384,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (context.getSettings().isDisableDefaultValidation()) {
             writer.write("export const get$L = <Context>(service: $T<Context>, "
-                    + "customizer: __ValidationCustomizer<$T>): "
-                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                            + "customizer: __ValidationCustomizer<$T>): "
+                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     handlerSymbol.getName(), serviceSymbol, operationsSymbol);
         } else {
             writer.write("export const get$L = <Context>(service: $T<Context>): "
-                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                            + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     handlerSymbol.getName(), serviceSymbol);
         }
         writer.indent();
@@ -397,21 +397,21 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         generateServiceMux(context);
         writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
         writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T<Context>, $1T, __ServiceException> = "
-                + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
-                    writer.openBlock("switch (op) {", "}", () -> {
-                        operations.stream()
-                                .filter(o -> o.getTrait(HttpTrait.class).isPresent())
-                                .forEach(writeOperationCase(writer, symbolProvider));
-                    });
-                });
+                       + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
+            writer.openBlock("switch (op) {", "}", () -> {
+                operations.stream()
+                        .filter(o -> o.getTrait(HttpTrait.class).isPresent())
+                        .forEach(writeOperationCase(writer, symbolProvider));
+            });
+        });
 
         if (!context.getSettings().isDisableDefaultValidation()) {
             writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
             writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
             writer.openBlock("const customizer: __ValidationCustomizer<$T> = (ctx, failures) => {", "};",
-                    operationsSymbol,
-                    () -> {
-                        writeDefaultValidationCustomizer(writer);
+                operationsSymbol,
+                () -> {
+                    writeDefaultValidationCustomizer(writer);
                 }
             );
         }
@@ -427,8 +427,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
         writer.addImport("serializeFrameworkException", null,
-                Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
-                        ProtocolGenerator.getSanitizedName(getName())).toString());
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
+                ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
         writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
 
@@ -440,12 +440,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (context.getSettings().isDisableDefaultValidation()) {
             writer.write("export const get$L = <Context>(operation: __Operation<$T, $T, Context>, "
-                    + "customizer: __ValidationCustomizer<$S>): "
-                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                       + "customizer: __ValidationCustomizer<$S>): "
+                       + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     operationHandlerSymbol.getName(), inputType, outputType, operationSymbol.getName());
         } else {
             writer.write("export const get$L = <Context>(operation: __Operation<$T, $T, Context>): "
-                    + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
+                       + "__ServiceHandler<Context, __HttpRequest, __HttpResponse> => {",
                     operationHandlerSymbol.getName(), inputType, outputType);
         }
         writer.indent();
@@ -456,9 +456,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
             writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
             writer.openBlock("const customizer: __ValidationCustomizer<$S> = (ctx, failures) => {", "};",
-                    operationSymbol.getName(),
-                    () -> {
-                        writeDefaultValidationCustomizer(writer);
+                operationSymbol.getName(),
+                () -> {
+                    writeDefaultValidationCustomizer(writer);
                 }
             );
         }
@@ -531,28 +531,28 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  input: $T,\n"
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", methodName, outputType, responseType, () -> {
-                    writeEmptyEndpoint(context);
-                    writeOperationStatusCode(context, operation, bindingIndex, trait);
-                    writeResponseHeaders(context, operation, bindingIndex,
-                            () -> writeDefaultOutputHeaders(context, operation));
+            writeEmptyEndpoint(context);
+            writeOperationStatusCode(context, operation, bindingIndex, trait);
+            writeResponseHeaders(context, operation, bindingIndex,
+                    () -> writeDefaultOutputHeaders(context, operation));
 
-                    List<HttpBinding> bodyBindings = writeResponseBody(context, operation, bindingIndex);
-                    if (!bodyBindings.isEmpty()) {
-                        // Track all shapes bound to the body so their serializers may be generated.
-                        bodyBindings.stream()
-                                .map(HttpBinding::getMember)
-                                .map(member -> context.getModel().expectShape(member.getTarget()))
-                                .forEach(serializingDocumentShapes::add);
-                    }
+            List<HttpBinding> bodyBindings = writeResponseBody(context, operation, bindingIndex);
+            if (!bodyBindings.isEmpty()) {
+                // Track all shapes bound to the body so their serializers may be generated.
+                bodyBindings.stream()
+                        .map(HttpBinding::getMember)
+                        .map(member -> context.getModel().expectShape(member.getTarget()))
+                        .forEach(serializingDocumentShapes::add);
+            }
 
-                    calculateContentLength(context);
+            calculateContentLength(context);
 
-                    writer.openBlock("return new $T({", "});", responseType, () -> {
-                        writer.write("headers,");
-                        writer.write("body,");
-                        writer.write("statusCode,");
-                    });
-                });
+            writer.openBlock("return new $T({", "});", responseType, () -> {
+                writer.write("headers,");
+                writer.write("body,");
+                writer.write("statusCode,");
+            });
+        });
         writer.write("");
 
         serializingErrorShapes.addAll(OperationIndex.of(context.getModel()).getErrors(operation, context.getService()));
@@ -564,11 +564,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.addImport("calculateBodyLength", null, "@aws-sdk/util-body-length-node");
         writer.openBlock("if (body && Object.keys(headers).map((str) => str.toLowerCase())"
                 + ".indexOf('content-length') === -1) {", "}", () -> {
-                    writer.write("const length = calculateBodyLength(body);");
-                    writer.openBlock("if (length !== undefined) {", "}", () -> {
-                        writer.write("headers = { ...headers, 'content-length': String(length) };");
-                    });
-                });
+            writer.write("const length = calculateBodyLength(body);");
+            writer.openBlock("if (length !== undefined) {", "}", () -> {
+                writer.write("headers = { ...headers, 'content-length': String(length) };");
+            });
+        });
 
     }
 
@@ -587,16 +587,16 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  input: $T,\n"
                 + "  ctx: ServerSerdeContext\n"
                 + "): Promise<$T> => {", "}", methodName, symbol, responseType, () -> {
-                    writeEmptyEndpoint(context);
-                    generateErrorSerializationImplementation(context, error, responseType, bindingIndex);
-                });
+            writeEmptyEndpoint(context);
+            generateErrorSerializationImplementation(context, error, responseType, bindingIndex);
+        });
         writer.write("");
     }
 
     private void generateErrorSerializationImplementation(GenerationContext context,
-            StructureShape error,
-            SymbolReference responseType,
-            HttpBindingIndex bindingIndex) {
+                                                          StructureShape error,
+                                                          SymbolReference responseType,
+                                                          HttpBindingIndex bindingIndex) {
         TypeScriptWriter writer = context.getWriter();
         writeErrorStatusCode(context, error);
         writeResponseHeaders(context, error, bindingIndex, () -> writeDefaultErrorHeaders(context, error));
@@ -658,46 +658,46 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                        + "  context: $L\n"
                        + "): Promise<$T> => {", "}", methodName, inputType, contextType, requestType, () -> {
 
-                // Get the hostname, path, port, and scheme from client's resolved endpoint. Then construct the request from
-                // them. The client's resolved endpoint can be default one or supplied by users.
-                writer.write("const {hostname, protocol = $S, port, path: basePath} = await context.endpoint();", "https");
+            // Get the hostname, path, port, and scheme from client's resolved endpoint. Then construct the request from
+            // them. The client's resolved endpoint can be default one or supplied by users.
+            writer.write("const {hostname, protocol = $S, port, path: basePath} = await context.endpoint();", "https");
 
-                writeRequestHeaders(context, operation, bindingIndex);
-                writeResolvedPath(context, operation, bindingIndex, trait);
-                boolean hasQueryComponents = writeRequestQueryString(context, operation, bindingIndex, trait);
+            writeRequestHeaders(context, operation, bindingIndex);
+            writeResolvedPath(context, operation, bindingIndex, trait);
+            boolean hasQueryComponents = writeRequestQueryString(context, operation, bindingIndex, trait);
 
-                List<HttpBinding> bodyBindings = writeRequestBody(context, operation, bindingIndex);
-                if (!bodyBindings.isEmpty()) {
-                    // Track all shapes bound to the body so their serializers may be generated.
-                    bodyBindings.stream()
-                            .map(HttpBinding::getMember)
-                            .map(member -> context.getModel().expectShape(member.getTarget()))
-                            .filter(shape -> !EventStreamGenerator.isEventStreamShape(shape))
-                            .forEach(serializingDocumentShapes::add);
-                }
+            List<HttpBinding> bodyBindings = writeRequestBody(context, operation, bindingIndex);
+            if (!bodyBindings.isEmpty()) {
+                // Track all shapes bound to the body so their serializers may be generated.
+                bodyBindings.stream()
+                        .map(HttpBinding::getMember)
+                        .map(member -> context.getModel().expectShape(member.getTarget()))
+                        .filter(shape -> !EventStreamGenerator.isEventStreamShape(shape))
+                        .forEach(serializingDocumentShapes::add);
+            }
 
-                boolean hasHostPrefix = operation.hasTrait(EndpointTrait.class);
+            boolean hasHostPrefix = operation.hasTrait(EndpointTrait.class);
+            if (hasHostPrefix) {
+                HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
+            }
+            writer.openBlock("return new $T({", "});", requestType, () -> {
+                writer.write("protocol,");
                 if (hasHostPrefix) {
-                    HttpProtocolGeneratorUtils.writeHostPrefix(context, operation);
+                    writer.write("hostname: resolvedHostname,");
+                } else {
+                    writer.write("hostname,");
                 }
-                writer.openBlock("return new $T({", "});", requestType, () -> {
-                    writer.write("protocol,");
-                    if (hasHostPrefix) {
-                        writer.write("hostname: resolvedHostname,");
-                    } else {
-                        writer.write("hostname,");
-                    }
-                    writer.write("port,");
-                    writer.write("method: $S,", trait.getMethod());
-                    writer.write("headers,");
-                    writer.write("path: resolvedPath,");
-                    if (hasQueryComponents) {
-                        writer.write("query,");
-                    }
-                    // Always set the body,
-                    writer.write("body,");
-                });
+                writer.write("port,");
+                writer.write("method: $S,", trait.getMethod());
+                writer.write("headers,");
+                writer.write("path: resolvedPath,");
+                if (hasQueryComponents) {
+                    writer.write("query,");
+                }
+                // Always set the body,
+                writer.write("body,");
             });
+        });
 
         writer.write("");
     }
@@ -744,9 +744,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         final boolean useEndpointsV2 = context.getService().hasTrait(EndpointRuleSetTrait.class);
         final Map<String, String> contextParams = useEndpointsV2
-                ? new RuleSetParameterFinder(context.getService())
-                        .getContextParams(context.getModel().getShape(operation.getInputShape()).get())
-                : Collections.emptyMap();
+            ? new RuleSetParameterFinder(context.getService())
+                .getContextParams(context.getModel().getShape(operation.getInputShape()).get())
+            : Collections.emptyMap();
 
         // Always write the bound path, but only the actual segments.
         writer.write("let resolvedPath = `$L` + $S;",
@@ -765,7 +765,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                         // We use this logic plus a temporary control-list, since it is not yet known
                         // how many services and param names will have this issue.
                         return !(isContextParam
-                                && contextParamDeduplicationParamControlSet.contains(content));
+                            && contextParamDeduplicationParamControlSet.contains(content));
                     })
                     .map(Segment::toString)
                     .collect(Collectors.joining("/"))
@@ -782,12 +782,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 Shape target = model.expectShape(binding.getMember().getTarget());
 
                 String labelValueProvider = "() => " + getInputValue(
-                        context,
-                        binding.getLocation(),
-                        "input." + memberName + "!",
-                        binding.getMember(),
-                        target
-                    );
+                    context,
+                    binding.getLocation(),
+                    "input." + memberName + "!",
+                    binding.getMember(),
+                    target
+                );
 
                 // Get the correct label to use.
                 Segment uriLabel = uriLabels.stream().filter(s -> s.getContent().equals(memberName)).findFirst().get();
@@ -885,11 +885,11 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             if (isRequired) {
                 // __expectNonNull is immediately invoked and not inside a function.
                 writer.write(
-                        "$S: [__expectNonNull(input.$L, `$L`) != null, () => $L],",
-                        binding.getLocationName(),
-                        memberName,
-                        memberName,
-                        queryValue // no idempotency token default for required members
+                    "$S: [__expectNonNull(input.$L, `$L`) != null, () => $L],",
+                    binding.getLocationName(),
+                    memberName,
+                    memberName,
+                    queryValue // no idempotency token default for required members
                 );
             } else {
                 // undefined check with lazy eval
@@ -932,8 +932,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             closing = "};";
         } else {
             opening = normalHeaderCount > 0
-                    ? "const headers: any = map({}, isSerializableHeaderValue, {"
-                    : "const headers: any = map({";
+                ? "const headers: any = map({}, isSerializableHeaderValue, {"
+                : "const headers: any = map({";
             closing = "});";
         }
 
@@ -1010,17 +1010,17 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Shape target = model.expectShape(prefixMap.getValue().getTarget());
         // Iterate through each entry in the member.
         writer.openBlock("...($1L !== undefined) && Object.keys($1L).reduce(", "),", memberLocation,
-                () -> {
-                    writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
-                        () -> {
-                            // Use a ! since we already validated the input member is defined above.
-                            String headerValue = getInputValue(context, binding.getLocation(),
-                                    memberLocation + "![suffix]", binding.getMember(), target);
-                            // Append the prefix to key.
-                            writer.write("acc[`$L$${suffix.toLowerCase()}`] = $L;",
-                                    binding.getLocationName().toLowerCase(Locale.US), headerValue);
-                            writer.write("return acc;");
-                        });
+            () -> {
+                writer.openBlock("(acc: any, suffix: string) => {", "}, {}",
+                    () -> {
+                        // Use a ! since we already validated the input member is defined above.
+                        String headerValue = getInputValue(context, binding.getLocation(),
+                                memberLocation + "![suffix]", binding.getMember(), target);
+                        // Append the prefix to key.
+                        writer.write("acc[`$L$${suffix.toLowerCase()}`] = $L;",
+                                binding.getLocationName().toLowerCase(Locale.US), headerValue);
+                        writer.write("return acc;");
+                    });
             }
         );
     }
@@ -1378,10 +1378,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         String valueString = getInputValue(context, bindingType, "value", mapMember,
                 model.expectShape(mapMember.getTarget()));
         return "Object.entries(" + dataSource + " || {}).reduce("
-                + "(acc: any, [key, value]: [string, " + symbolProvider.toSymbol(mapMember) + "]) => {"
-                +   "acc[key] = " + valueString + ";"
-                +   "return acc;"
-                + "}, {})";
+            + "(acc: any, [key, value]: [string, " + symbolProvider.toSymbol(mapMember) + "]) => {"
+            +   "acc[key] = " + valueString + ";"
+            +   "return acc;"
+            + "}, {})";
     }
 
     /**
@@ -1539,8 +1539,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     /**
      * Writes the code needed to serialize a protocol output document.
      *
-     * <p>
-     * Implementations of this method are expected to set a value to the
+     * <p>Implementations of this method are expected to set a value to the
      * {@code body} variable that will be serialized as the request body.
      * This variable will already be defined in scope.
      *
@@ -1722,23 +1721,23 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 + "  output: $T,\n"
                 + "  context: $L\n"
                 + "): Promise<$T> => {", "}", methodName, requestType, contextType, inputType, () -> {
-                    handleContentType(context, operation, bindingIndex);
-                    handleAccept(context, operation, bindingIndex);
-                    // Start deserializing the response.
-                    writer.openBlock("const contents: any = map({", "});", () -> {
-                        readRequestHeaders(context, operation, bindingIndex, "output");
-                    });
-                    readQueryString(context, operation, bindingIndex);
-                    readPath(context, operation, bindingIndex, trait);
-                    readHost(context, operation);
-                    List<HttpBinding> documentBindings = readRequestBody(context, operation, bindingIndex);
-                    // Track all shapes bound to the document so their deserializers may be generated.
-                    documentBindings.forEach(binding -> {
-                        Shape target = model.expectShape(binding.getMember().getTarget());
-                        deserializingDocumentShapes.add(target);
-                    });
-                    writer.write("return contents;");
-                });
+            handleContentType(context, operation, bindingIndex);
+            handleAccept(context, operation, bindingIndex);
+            // Start deserializing the response.
+            writer.openBlock("const contents: any = map({", "});", () -> {
+                readRequestHeaders(context, operation, bindingIndex, "output");
+            });
+            readQueryString(context, operation, bindingIndex);
+            readPath(context, operation, bindingIndex, trait);
+            readHost(context, operation);
+            List<HttpBinding> documentBindings = readRequestBody(context, operation, bindingIndex);
+            // Track all shapes bound to the document so their deserializers may be generated.
+            documentBindings.forEach(binding -> {
+                Shape target = model.expectShape(binding.getMember().getTarget());
+                deserializingDocumentShapes.add(target);
+            });
+            writer.write("return contents;");
+        });
         writer.write("");
     }
 
@@ -1893,17 +1892,18 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                             "@aws-smithy/server-common");
                     writer.write("let queryValue: string;");
                     writer.openBlock("if (Array.isArray(query[$S])) {", "}",
-                            binding.getLocationName(),
-                            () -> {
-                                writer.openBlock("if (query[$S].length === 1) {", "}",
-                                        binding.getLocationName(),
-                                        () -> {
-                                            writer.write("queryValue = query[$S][0];", binding.getLocationName());
-                                        });
-                                writer.openBlock("else {", "}", () -> {
-                                    writer.write("throw new __SerializationException();");
-                                });
+                        binding.getLocationName(),
+                        () -> {
+                            writer.openBlock("if (query[$S].length === 1) {", "}",
+                                binding.getLocationName(),
+                                () -> {
+                                    writer.write("queryValue = query[$S][0];", binding.getLocationName());
+                                }
+                            );
+                            writer.openBlock("else {", "}", () -> {
+                                writer.write("throw new __SerializationException();");
                             });
+                        });
                     writer.openBlock("else {", "}", () -> {
                         writer.write("queryValue = query[$S] as string;", binding.getLocationName());
                     });
@@ -1950,7 +1950,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     writer.write("queryValue = value as string;");
                 });
                 parsedValue = getOutputValue(context, mappedBinding.getLocation(),
-                        "queryValue", target.getValue(), valueShape);
+                                "queryValue", target.getValue(), valueShape);
             }
             writer.write("parsedQuery[key] = $L;", parsedValue);
         });
@@ -2069,34 +2069,34 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Handle the general response.
         writer.writeDocs(methodLongName);
         writer.openBlock("export const $L = async(\n"
-                + "  output: $T,\n"
-                + "  context: $L\n"
-                + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
-                    // Redirect error deserialization to the dispatcher if we receive an error range
-                    // status code that's not the modeled code (300 or higher). This allows for
-                    // returning other 2XX codes that don't match the defined value.
-                    writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
-                            () -> writer.write("return $L(output, context);", errorMethodName));
+                       + "  output: $T,\n"
+                       + "  context: $L\n"
+                       + "): Promise<$T> => {", "}", methodName, responseType, contextType, outputType, () -> {
+            // Redirect error deserialization to the dispatcher if we receive an error range
+            // status code that's not the modeled code (300 or higher). This allows for
+            // returning other 2XX codes that don't match the defined value.
+            writer.openBlock("if (output.statusCode !== $L && output.statusCode >= 300) {", "}", trait.getCode(),
+                    () -> writer.write("return $L(output, context);", errorMethodName));
 
-                    // Start deserializing the response.
-                    writer.openBlock("const contents: any = map({", "});", () -> {
-                        writer.write("$$metadata: deserializeMetadata(output),");
+            // Start deserializing the response.
+            writer.openBlock("const contents: any = map({", "});", () -> {
+                writer.write("$$metadata: deserializeMetadata(output),");
 
-                        readResponseHeaders(context, operation, bindingIndex, "output");
-                    });
+                readResponseHeaders(context, operation, bindingIndex, "output");
+            });
 
-                    List<HttpBinding> documentBindings = readResponseBody(context, operation, bindingIndex);
+            List<HttpBinding> documentBindings = readResponseBody(context, operation, bindingIndex);
 
-                    // Track all shapes bound to the document so their deserializers may be generated.
-                    documentBindings.forEach(binding -> {
-                        Shape target = model.expectShape(binding.getMember().getTarget());
-                        if (!EventStreamGenerator.isEventStreamShape(target)) {
-                            deserializingDocumentShapes.add(target);
-                        }
-                    });
+            // Track all shapes bound to the document so their deserializers may be generated.
+            documentBindings.forEach(binding -> {
+                Shape target = model.expectShape(binding.getMember().getTarget());
+                if (!EventStreamGenerator.isEventStreamShape(target)) {
+                    deserializingDocumentShapes.add(target);
+                }
+            });
 
-                    writer.write("return contents;");
-                });
+            writer.write("return contents;");
+        });
         writer.write("");
         // Write out the error deserialization dispatcher.
         Set<StructureShape> errorShapes = HttpProtocolGeneratorUtils.generateErrorDispatcher(
@@ -2119,29 +2119,29 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.writeDocs(errorDeserMethodLongName);
         writer.openBlock("const $L = async (\n"
-                + "  $L: any,\n"
-                + "  context: __SerdeContext\n"
-                + "): Promise<$T> => {", "};",
+                       + "  $L: any,\n"
+                       + "  context: __SerdeContext\n"
+                       + "): Promise<$T> => {", "};",
                 errorDeserMethodName, outputName, errorSymbol, () -> {
-                    writer.openBlock("const contents: any = map({", "});", () -> {
-                        readResponseHeaders(context, error, bindingIndex, outputName);
-                    });
+            writer.openBlock("const contents: any = map({", "});", () -> {
+                readResponseHeaders(context, error, bindingIndex, outputName);
+            });
 
-                    List<HttpBinding> documentBindings = readErrorResponseBody(context, error, bindingIndex);
+            List<HttpBinding> documentBindings = readErrorResponseBody(context, error, bindingIndex);
             // Track all shapes bound to the document so their deserializers may be generated.
-                    documentBindings.forEach(binding -> {
-                        Shape target = model.expectShape(binding.getMember().getTarget());
-                        deserializingDocumentShapes.add(target);
-                    });
-                    writer.openBlock("const exception = new $T({", "});", errorSymbol, () -> {
-                        writer.write("$$metadata: deserializeMetadata($L),", outputName);
-                        writer.write("...contents");
-                    });
-                    String errorLocation = this.getErrorBodyLocation(context, outputName + ".body");
-                    writer.addImport("decorateServiceException", "__decorateServiceException",
-                            TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-                    writer.write("return __decorateServiceException(exception, $L);", errorLocation);
-                });
+            documentBindings.forEach(binding -> {
+                Shape target = model.expectShape(binding.getMember().getTarget());
+                deserializingDocumentShapes.add(target);
+            });
+            writer.openBlock("const exception = new $T({", "});", errorSymbol, () -> {
+                writer.write("$$metadata: deserializeMetadata($L),", outputName);
+                writer.write("...contents");
+            });
+            String errorLocation = this.getErrorBodyLocation(context, outputName + ".body");
+            writer.addImport("decorateServiceException", "__decorateServiceException",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+            writer.write("return __decorateServiceException(exception, $L);", errorLocation);
+        });
 
         writer.write("");
     }
@@ -2257,9 +2257,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                     MapShape prefixMap = model.expectShape(binding.getMember().getTarget()).asMapShape().get();
                     Shape target = model.expectShape(prefixMap.getValue().getTarget());
                     String headerValue = getOutputValue(context, binding.getLocation(),
-                            outputName + ".headers[header]", binding.getMember(), target);
+                        outputName + ".headers[header]", binding.getMember(), target);
                     writer.write("acc[header.substring($L)] = $L;",
-                            headerLocation.length(), headerValue);
+                        headerLocation.length(), headerValue);
                     writer.write("return acc;");
                 });
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -402,8 +402,7 @@ public final class HttpProtocolGeneratorUtils {
                         // Track errors bound to the operation so their deserializers may be generated.
                         errorShapes.add(error);
                         Symbol errorSymbol = symbolProvider.toSymbol(error);
-                        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
-                            context.getProtocolName()) + "Response";
+                        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionShortName(errorSymbol) + "Res";
                         // Dispatch to the error deserialization function.
                         String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
                         writer.write("case $S:", name);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -107,12 +107,12 @@ public final class HttpProtocolGeneratorUtils {
      * @return Returns a value or expression of the output timestamp.
      */
     public static String getTimestampOutputParam(TypeScriptWriter writer,
-                                                 String dataSource,
-                                                 Location bindingType,
-                                                 Shape shape,
-                                                 Format format,
-                                                 boolean requireNumericEpochSecondsInPayload,
-                                                 boolean isClient) {
+            String dataSource,
+            Location bindingType,
+            Shape shape,
+            Format format,
+            boolean requireNumericEpochSecondsInPayload,
+            boolean isClient) {
         // This has always explicitly wrapped the dataSource in "new Date(..)", so it could never generate
         // an expression that evaluates to null. Codegen relies on this.
         writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
@@ -121,7 +121,7 @@ public final class HttpProtocolGeneratorUtils {
                 // Clients should be able to handle offsets and normalize the datetime to an offset of zero.
                 if (isClient) {
                     writer.addImport("parseRfc3339DateTimeWithOffset", "__parseRfc3339DateTimeWithOffset",
-                        "@aws-sdk/smithy-client");
+                            "@aws-sdk/smithy-client");
                     return String.format("__expectNonNull(__parseRfc3339DateTimeWithOffset(%s))", dataSource);
                 } else {
                     writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime", "@aws-sdk/smithy-client");
@@ -239,8 +239,8 @@ public final class HttpProtocolGeneratorUtils {
                 () -> {
                     writer.write("httpStatusCode: output.statusCode,");
                     writer.write("requestId: output.headers[\"x-amzn-requestid\"] ??"
-                        + " output.headers[\"x-amzn-request-id\"] ??"
-                        + " output.headers[\"x-amz-request-id\"],");
+                            + " output.headers[\"x-amzn-request-id\"] ??"
+                            + " output.headers[\"x-amz-request-id\"],");
                     writer.write("extendedRequestId: output.headers[\"x-amz-id-2\"],");
                     writer.write("cfId: output.headers[\"x-amz-cf-id\"],");
                 });
@@ -260,11 +260,11 @@ public final class HttpProtocolGeneratorUtils {
         writer.write("// Collect low-level response body stream to Uint8Array.");
         writer.openBlock("const collectBody = (streamBody: any = new Uint8Array(), context: __SerdeContext): "
                 + "Promise<Uint8Array> => {", "};", () -> {
-            writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
-                writer.write("return Promise.resolve(streamBody);");
-            });
-            writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
-        });
+                    writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
+                        writer.write("return Promise.resolve(streamBody);");
+                    });
+                    writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
+                });
 
         writer.write("");
     }
@@ -344,80 +344,83 @@ public final class HttpProtocolGeneratorUtils {
 
         Symbol symbol = symbolProvider.toSymbol(operation);
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
-        String errorMethodName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName()) + "Error";
+        String errorMethodName = ProtocolGenerator.getDeserFunctionShortName(symbol) + "Error";
+        String errorMethodLongName = ProtocolGenerator.getDeserFunctionName(symbol, context.getProtocolName())
+                + "Error";
 
+        writer.writeDocs(errorMethodLongName);
         writer.openBlock("const $L = async(\n"
-                       + "  output: $T,\n"
-                       + "  context: __SerdeContext,\n"
-                       + "): Promise<$T> => {", "}", errorMethodName, responseType, outputType, () -> {
+                + "  output: $T,\n"
+                + "  context: __SerdeContext,\n"
+                + "): Promise<$T> => {", "}", errorMethodName, responseType, outputType, () -> {
             // Prepare error response for parsing error code. If error code needs to be parsed from response body
             // then we collect body and parse it to JS object, otherwise leave the response body as is.
-            if (shouldParseErrorBody) {
-                writer.openBlock("const parsedOutput: any = {", "};",
-                        () -> {
-                            writer.write("...output,");
-                            writer.write("body: await parseErrorBody(output.body, context)");
-                        });
-            }
-
-            // Error responses must be at least BaseException interface
-            SymbolReference baseExceptionReference = getClientBaseException(context);
-            errorCodeGenerator.accept(context);
-
-            Runnable defaultErrorHandler = () -> {
-                if (shouldParseErrorBody) {
-                    // Body is already parsed above
-                    writer.write("const parsedBody = parsedOutput.body;");
-                } else {
-                    // Body is not parsed above, so parse it here
-                    writer.write("const parsedBody = await parseBody(output.body, context);");
-                }
-
-                writer.addImport("throwDefaultError", "throwDefaultError", "@aws-sdk/smithy-client");
-
-                // Get the protocol specific error location for retrieving contents.
-                String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
-                writer.openBlock("throwDefaultError({", "})", () -> {
-                    writer.write("output,");
-                    if (errorLocation.equals("parsedBody")) {
-                        writer.write("parsedBody,");
-                    } else {
-                        writer.write("parsedBody: $L,", errorLocation);
+                    if (shouldParseErrorBody) {
+                        writer.openBlock("const parsedOutput: any = {", "};",
+                                () -> {
+                                    writer.write("...output,");
+                                    writer.write("body: await parseErrorBody(output.body, context)");
+                                });
                     }
-                    writer.write("exceptionCtor: $T,", baseExceptionReference);
-                    writer.write("errorCode");
+
+                    // Error responses must be at least BaseException interface
+                    SymbolReference baseExceptionReference = getClientBaseException(context);
+                    errorCodeGenerator.accept(context);
+
+                    Runnable defaultErrorHandler = () -> {
+                        if (shouldParseErrorBody) {
+                            // Body is already parsed above
+                            writer.write("const parsedBody = parsedOutput.body;");
+                        } else {
+                            // Body is not parsed above, so parse it here
+                            writer.write("const parsedBody = await parseBody(output.body, context);");
+                        }
+
+                        writer.addImport("throwDefaultError", "throwDefaultError", "@aws-sdk/smithy-client");
+
+                        // Get the protocol specific error location for retrieving contents.
+                        String errorLocation = bodyErrorLocationModifier.apply(context, "parsedBody");
+                        writer.openBlock("throwDefaultError({", "})", () -> {
+                            writer.write("output,");
+                            if (errorLocation.equals("parsedBody")) {
+                                writer.write("parsedBody,");
+                            } else {
+                                writer.write("parsedBody: $L,", errorLocation);
+                            }
+                            writer.write("exceptionCtor: $T,", baseExceptionReference);
+                            writer.write("errorCode");
+                        });
+                    };
+
+                    Map<String, ShapeId> operationNamesToShapes = operationErrorsToShapes.apply(context, operation);
+                    if (!operationNamesToShapes.isEmpty()) {
+                        writer.openBlock("switch (errorCode) {", "}", () -> {
+                            // Generate the case statement for each error, invoking the specific deserializer.
+
+                            operationNamesToShapes.forEach((name, errorId) -> {
+                                StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
+                                // Track errors bound to the operation so their deserializers may be generated.
+                                errorShapes.add(error);
+                                Symbol errorSymbol = symbolProvider.toSymbol(error);
+                                String errorDeserMethodName = ProtocolGenerator.getDeserFunctionShortName(errorSymbol)
+                                        + "Res";
+                                // Dispatch to the error deserialization function.
+                                String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
+                                writer.write("case $S:", name);
+                                writer.write("case $S:", errorId.toString());
+                                writer.indent()
+                                        .write("throw await $L($L, context);", errorDeserMethodName, outputParam)
+                                        .dedent();
+                            });
+
+                            // Build a generic error the best we can for ones we don't know about.
+                            writer.write("default:").indent();
+                            defaultErrorHandler.run();
+                        });
+                    } else {
+                        defaultErrorHandler.run();
+                    }
                 });
-            };
-
-            Map<String, ShapeId> operationNamesToShapes = operationErrorsToShapes.apply(context, operation);
-            if (!operationNamesToShapes.isEmpty()) {
-                writer.openBlock("switch (errorCode) {", "}", () -> {
-                    // Generate the case statement for each error, invoking the specific deserializer.
-
-                    operationNamesToShapes.forEach((name, errorId) -> {
-                        StructureShape error = context.getModel().expectShape(errorId).asStructureShape().get();
-                        // Track errors bound to the operation so their deserializers may be generated.
-                        errorShapes.add(error);
-                        Symbol errorSymbol = symbolProvider.toSymbol(error);
-                        String errorDeserMethodName = ProtocolGenerator.getDeserFunctionName(errorSymbol,
-                            context.getProtocolName()) + "Response";
-                        // Dispatch to the error deserialization function.
-                        String outputParam = shouldParseErrorBody ? "parsedOutput" : "output";
-                        writer.write("case $S:", name);
-                        writer.write("case $S:", errorId.toString());
-                        writer.indent()
-                            .write("throw await $L($L, context);", errorDeserMethodName, outputParam)
-                            .dedent();
-                    });
-
-                    // Build a generic error the best we can for ones we don't know about.
-                    writer.write("default:").indent();
-                    defaultErrorHandler.run();
-                });
-            } else {
-                defaultErrorHandler.run();
-            }
-        });
         writer.write("");
 
         return errorShapes;
@@ -467,12 +470,12 @@ public final class HttpProtocolGeneratorUtils {
         ServiceShape service = context.getService();
         SymbolProvider symbolProvider = context.getSymbolProvider();
         String serviceExceptionName = symbolProvider.toSymbol(service).getName()
-                        .replaceAll("(Client)$", "ServiceException");
+                .replaceAll("(Client)$", "ServiceException");
         String namespace = Paths.get(".", "src", "models", serviceExceptionName).toString();
         Symbol serviceExceptionSymbol = Symbol.builder()
-                            .name(serviceExceptionName)
-                            .namespace(namespace, "/")
-                            .definitionFile(namespace + ".ts").build();
+                .name(serviceExceptionName)
+                .namespace(namespace, "/")
+                .definitionFile(namespace + ".ts").build();
         return SymbolReference.builder()
                 .options(SymbolReference.ContextOption.USE)
                 .alias("__BaseException")
@@ -489,14 +492,14 @@ public final class HttpProtocolGeneratorUtils {
      */
     public static Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
         return operation.getErrors().stream()
-            .collect(Collectors.toMap(
-                shapeId -> shapeId.getName(context.getService()),
-                Function.identity(),
-                (x, y) -> {
-                    if (!x.equals(y)) {
-                        throw new CodegenException(String.format("conflicting error shape ids: %s, %s", x, y));
-                    }
-                    return x;
-                }, TreeMap::new));
+                .collect(Collectors.toMap(
+                        shapeId -> shapeId.getName(context.getService()),
+                        Function.identity(),
+                        (x, y) -> {
+                            if (!x.equals(y)) {
+                                throw new CodegenException(String.format("conflicting error shape ids: %s, %s", x, y));
+                            }
+                            return x;
+                        }, TreeMap::new));
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -114,8 +114,8 @@ public interface ProtocolGenerator {
                     .collect(Collectors.joining(", "));
             throw new CodegenException(String.format(
                     "All of the protocols generated for a service must be runtime compatible, but "
-                    + "protocol `%s` is incompatible with other application protocols: [%s]. Please pick a "
-                    + "set of compatible protocols using the `protocols` option when generating %s.",
+                            + "protocol `%s` is incompatible with other application protocols: [%s]. Please pick a "
+                            + "set of compatible protocols using the `protocols` option when generating %s.",
                     getProtocol().getName(), protocolNames, service.getId()));
         }
 
@@ -211,7 +211,21 @@ public interface ProtocolGenerator {
     }
 
     /**
-     * Generates the name of a serializer function for shapes of a service that is not protocol-specific.
+     * @param symbol The symbol the deserializer function is being generated for.
+     * @return Returns the generated function short name.
+     */
+    static String getSerFunctionShortName(Symbol symbol) {
+        // e.g., se_ES for ExecuteStatement
+        String functionName = "se_";
+        // Update the function to have a component based on the symbol.
+        functionName += ProtocolGenerator.getSerdeFunctionSymbolComponent(symbol,
+                symbol.expectProperty("shape", Shape.class));
+        return functionName;
+    }
+
+    /**
+     * Generates the name of a serializer function for shapes of a service that is not
+     * protocol-specific.
      *
      * @param symbol The symbol the serializer function is being generated for.
      * @return Returns the generated function name.
@@ -235,6 +249,19 @@ public interface ProtocolGenerator {
         // Update the function to have a component based on the symbol.
         functionName += getSerdeFunctionSymbolComponent(symbol, symbol.expectProperty("shape", Shape.class));
 
+        return functionName;
+    }
+
+    /**
+     * @param symbol The symbol the deserializer function is being generated for.
+     * @return Returns the generated function short name.
+     */
+    static String getDeserFunctionShortName(Symbol symbol) {
+        // e.g., de_ES for ExecuteStatement
+        String functionName = "de_";
+        // Update the function to have a component based on the symbol.
+        functionName += ProtocolGenerator.getSerdeFunctionSymbolComponent(symbol,
+                symbol.expectProperty("shape", Shape.class));
         return functionName;
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -114,8 +114,8 @@ public interface ProtocolGenerator {
                     .collect(Collectors.joining(", "));
             throw new CodegenException(String.format(
                     "All of the protocols generated for a service must be runtime compatible, but "
-                            + "protocol `%s` is incompatible with other application protocols: [%s]. Please pick a "
-                            + "set of compatible protocols using the `protocols` option when generating %s.",
+                    + "protocol `%s` is incompatible with other application protocols: [%s]. Please pick a "
+                    + "set of compatible protocols using the `protocols` option when generating %s.",
                     getProtocol().getName(), protocolNames, service.getId()));
         }
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -67,12 +67,12 @@ public class DocumentMemberDeserVisitorTest {
         mockContext.setModel(Model.builder().addShapes(shape, fakeStruct).build());
         DocumentMemberDeserVisitor visitor =
                 new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT) {
-                    @Override
-                    protected MemberShape getMemberShape() {
-                        return memberShape;
-                    }
-                };
-        assertThat(expected, equalTo(shape.accept(visitor)));
+            @Override
+            protected MemberShape getMemberShape() {
+                return memberShape;
+            }
+        };
+        assertThat(shape.accept(visitor), equalTo(expected));
     }
 
     public static Collection<Object[]> validMemberTargetTypes() {
@@ -82,7 +82,7 @@ public class DocumentMemberDeserVisitorTest {
         MemberShape member = MemberShape.builder().id(id + "$member").target(targetId).build();
         MemberShape key = MemberShape.builder().id(id + "$key").target(targetId).build();
         MemberShape value = MemberShape.builder().id(id + "$value").target(targetId).build();
-        String delegate = "deserialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
+        String delegate = "de_Foo"
                 + "(" + DATA_SOURCE + ", context)";
 
         return ListUtils.of(new Object[][]{
@@ -95,9 +95,9 @@ public class DocumentMemberDeserVisitorTest {
                 {ShortShape.builder().id(id).build(), "__expectShort(" + DATA_SOURCE + ")", source},
                 {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")", source},
                 {
-                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                    "new __LazyJsonString(" + DATA_SOURCE + ")",
-                    source
+                        StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                        "new __LazyJsonString(" + DATA_SOURCE + ")",
+                        source
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")", source},
                 {DocumentShape.builder().id(id).build(), delegate, source},
@@ -106,25 +106,24 @@ public class DocumentMemberDeserVisitorTest {
                 {MapShape.builder().id(id).key(key).value(value).build(), delegate, source},
                 {StructureShape.builder().id(id).build(), delegate, source},
                 {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
-                    source
+                        TimestampShape.builder().id(id).build(),
+                        "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
+                        source
                 },
                 {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
-                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME)).build()
+                        TimestampShape.builder().id(id).build(),
+                        "__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
+                        source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME)).build()
                 },
                 {
-                    TimestampShape.builder().id(id).build(),
-                    "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
-                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
+                        TimestampShape.builder().id(id).build(),
+                        "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
+                        source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
                 },
                 {
-                    UnionShape.builder().id(id).addMember(member).build(),
-                    "deserialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
-                        + "(__expectUnion(" + DATA_SOURCE + "), context)",
-                    source
+                        UnionShape.builder().id(id).addMember(member).build(),
+                        "de_Foo(__expectUnion(" + DATA_SOURCE + "), context)",
+                        source
                 },
         });
     }
@@ -161,13 +160,13 @@ public class DocumentMemberDeserVisitorTest {
 
         @Override
         public Symbol toSymbol(Shape shape) {
-        if (shape instanceof CollectionShape) {
-            MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
-            return collectionMock.toBuilder().putProperty("shape",
-                    ListShape.builder().id(id).member(member).build()).build();
-        }
-        return mock.toBuilder().putProperty("shape",
-                StructureShape.builder().id(id).build()).build();
+            if (shape instanceof CollectionShape) {
+                MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
+                return collectionMock.toBuilder().putProperty("shape",
+                        ListShape.builder().id(id).member(member).build()).build();
+            }
+            return mock.toBuilder().putProperty("shape",
+                    StructureShape.builder().id(id).build()).build();
         }
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitorTest.java
@@ -67,11 +67,11 @@ public class DocumentMemberDeserVisitorTest {
         mockContext.setModel(Model.builder().addShapes(shape, fakeStruct).build());
         DocumentMemberDeserVisitor visitor =
                 new DocumentMemberDeserVisitor(mockContext, DATA_SOURCE, FORMAT) {
-            @Override
-            protected MemberShape getMemberShape() {
-                return memberShape;
-            }
-        };
+                    @Override
+                    protected MemberShape getMemberShape() {
+                        return memberShape;
+                    }
+                };
         assertThat(shape.accept(visitor), equalTo(expected));
     }
 
@@ -95,9 +95,9 @@ public class DocumentMemberDeserVisitorTest {
                 {ShortShape.builder().id(id).build(), "__expectShort(" + DATA_SOURCE + ")", source},
                 {StringShape.builder().id(id).build(), "__expectString(" + DATA_SOURCE + ")", source},
                 {
-                        StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                        "new __LazyJsonString(" + DATA_SOURCE + ")",
-                        source
+                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                    "new __LazyJsonString(" + DATA_SOURCE + ")",
+                    source
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Decoder(" + DATA_SOURCE + ")", source},
                 {DocumentShape.builder().id(id).build(), delegate, source},
@@ -106,24 +106,24 @@ public class DocumentMemberDeserVisitorTest {
                 {MapShape.builder().id(id).key(key).value(value).build(), delegate, source},
                 {StructureShape.builder().id(id).build(), delegate, source},
                 {
-                        TimestampShape.builder().id(id).build(),
-                        "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
-                        source
+                    TimestampShape.builder().id(id).build(),
+                    "__expectNonNull(__parseEpochTimestamp(" + DATA_SOURCE + "))",
+                    source
                 },
                 {
-                        TimestampShape.builder().id(id).build(),
-                        "__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
-                        source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME)).build()
+                    TimestampShape.builder().id(id).build(),
+                    "__expectNonNull(__parseRfc3339DateTime(" + DATA_SOURCE + "))",
+                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.DATE_TIME)).build()
                 },
                 {
-                        TimestampShape.builder().id(id).build(),
-                        "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
-                        source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
+                    TimestampShape.builder().id(id).build(),
+                    "__expectNonNull(__parseRfc7231DateTime(" + DATA_SOURCE + "))",
+                    source.toBuilder().addTrait(new TimestampFormatTrait(TimestampFormatTrait.HTTP_DATE)).build()
                 },
                 {
-                        UnionShape.builder().id(id).addMember(member).build(),
-                        "de_Foo(__expectUnion(" + DATA_SOURCE + "), context)",
-                        source
+                    UnionShape.builder().id(id).addMember(member).build(),
+                    "de_Foo(__expectUnion(" + DATA_SOURCE + "), context)",
+                    source
                 },
         });
     }
@@ -163,10 +163,10 @@ public class DocumentMemberDeserVisitorTest {
             if (shape instanceof CollectionShape) {
                 MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
                 return collectionMock.toBuilder().putProperty("shape",
-                        ListShape.builder().id(id).member(member).build()).build();
+                    ListShape.builder().id(id).member(member).build()).build();
             }
             return mock.toBuilder().putProperty("shape",
-                    StructureShape.builder().id(id).build()).build();
+                StructureShape.builder().id(id).build()).build();
         }
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -57,7 +57,7 @@ public class DocumentMemberSerVisitorTest {
     @MethodSource("validMemberTargetTypes")
     public void providesExpectedDefaults(Shape shape, String expected) {
         DocumentMemberSerVisitor visitor = new DocumentMemberSerVisitor(mockContext, DATA_SOURCE, FORMAT);
-        assertThat(expected, equalTo(shape.accept(visitor)));
+        assertThat(shape.accept(visitor), equalTo(expected));
     }
 
     public static Collection<Object[]> validMemberTargetTypes() {
@@ -66,8 +66,7 @@ public class DocumentMemberSerVisitorTest {
         MemberShape member = MemberShape.builder().id(id + "$member").target(targetId).build();
         MemberShape key = MemberShape.builder().id(id + "$key").target(targetId).build();
         MemberShape value = MemberShape.builder().id(id + "$value").target(targetId).build();
-        String delegate = "serialize" + ProtocolGenerator.getSanitizedName(PROTOCOL) + "Foo"
-                + "(" + DATA_SOURCE + ", context)";
+        String delegate = "se_Foo(" + DATA_SOURCE + ", context)";
 
         return ListUtils.of(new Object[][]{
                 {BooleanShape.builder().id(id).build(), DATA_SOURCE},
@@ -81,8 +80,8 @@ public class DocumentMemberSerVisitorTest {
                 {ShortShape.builder().id(id).build(), DATA_SOURCE},
                 {StringShape.builder().id(id).build(), DATA_SOURCE},
                 {
-                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                    "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
+                        StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                        "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Encoder(" + DATA_SOURCE + ")"},
                 {DocumentShape.builder().id(id).build(), delegate},
@@ -126,13 +125,13 @@ public class DocumentMemberSerVisitorTest {
 
         @Override
         public Symbol toSymbol(Shape shape) {
-        if (shape instanceof CollectionShape) {
-            MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
-            return collectionMock.toBuilder().putProperty("shape",
-                    ListShape.builder().id(id).member(member).build()).build();
-        }
-        return mock.toBuilder().putProperty("shape",
-                StructureShape.builder().id(id).build()).build();
+            if (shape instanceof CollectionShape) {
+                MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
+                return collectionMock.toBuilder().putProperty("shape",
+                        ListShape.builder().id(id).member(member).build()).build();
+            }
+            return mock.toBuilder().putProperty("shape",
+                    StructureShape.builder().id(id).build()).build();
         }
     }
 }

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitorTest.java
@@ -80,8 +80,8 @@ public class DocumentMemberSerVisitorTest {
                 {ShortShape.builder().id(id).build(), DATA_SOURCE},
                 {StringShape.builder().id(id).build(), DATA_SOURCE},
                 {
-                        StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
-                        "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
+                    StringShape.builder().id(id).addTrait(new MediaTypeTrait("foo+json")).build(),
+                    "__LazyJsonString.fromObject(" + DATA_SOURCE + ")"
                 },
                 {BlobShape.builder().id(id).build(), "context.base64Encoder(" + DATA_SOURCE + ")"},
                 {DocumentShape.builder().id(id).build(), delegate},
@@ -128,10 +128,10 @@ public class DocumentMemberSerVisitorTest {
             if (shape instanceof CollectionShape) {
                 MemberShape member = MemberShape.builder().id(id + "$member").target(id + "Target").build();
                 return collectionMock.toBuilder().putProperty("shape",
-                        ListShape.builder().id(id).member(member).build()).build();
+                    ListShape.builder().id(id).member(member).build()).build();
             }
             return mock.toBuilder().putProperty("shape",
-                    StructureShape.builder().id(id).build()).build();
+                StructureShape.builder().id(id).build()).build();
         }
     }
 }


### PR DESCRIPTION
Shorten generated serde function names. Source code contains a comment with the original long name, distribution uses shorter names.

The premise is that serde function names do not need to contain the protocol -- it's repetitive when the protocol file containing the functions is named after the protocol already. 

JSv3 codegen paired PR https://github.com/aws/aws-sdk-js-v3/pull/4611

Benefits:
reduced code size

Potential Downsides:
- breaking change for anyone is using these internal functions directly (though no one should be). 
- no benefit to anyone who was applying mangling already (most browser applications, some server applications).

Example
```js
/**
 * deserializeAws_restJson1PrefetchConsumption
 */
const de_PrefetchConsumption = ...
```