### PR TITLE
Fix the `uniqueItems` implementation to accomodate undefined values nested inside lists of objects

### DIFF
--- a/smithy-typescript-ssdk-libs/server-common/CHANGELOG.md
+++ b/smithy-typescript-ssdk-libs/server-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # server-common Changelog
 
+## 1.0.0-alpha.10 (2023-04-04)
+
+### Bug Fixes
+
+- Fix `uniqueItems` validation not to throw when undefined values are nested inside a list of objects.
+
 ## 1.0.0-alpha.9 (2023-03-16)
 
 ### Features

--- a/smithy-typescript-ssdk-libs/server-common/src/unique.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/unique.spec.ts
@@ -48,6 +48,13 @@ describe("findDuplicates", () => {
         Uint8Array.of(4, 5, 6),
       ]);
     });
+    it("nulls", () => {
+      expect(findDuplicates([null, 1, null])).toEqual([null]);
+    });
+    it("undefineds", () => {
+      const arr: Array<any> = [undefined, 1, undefined];
+      expect(findDuplicates(arr)).toEqual([undefined]);
+    });
     it("objects", () => {
       expect(findDuplicates([{ a: "b" }, { b: [1, 2, 3] }, { a: "b" }, { a: "b" }])).toEqual([{ a: "b" }]);
       expect(findDuplicates([{ a: "b" }, { b: 1, c: 2 }, { c: 2, b: 1 }])).toEqual([{ b: 1, c: 2 }]);
@@ -101,8 +108,14 @@ describe("findDuplicates", () => {
     it("blobs", () => {
       expect(findDuplicates([Uint8Array.of(1, 2, 3), Uint8Array.of(1, 2)])).toEqual([]);
     });
+    it("nulls", () => {
+      expect(findDuplicates([null, 1])).toEqual([]);
+    });
+    it("undefineds", () => {
+      const arr: Array<any> = [undefined, 1];
+      expect(findDuplicates(arr)).toEqual([]);
+    });
   });
-
   // This is relatively slow and may be flaky if the input size is tuned to let it run reasonably fast
   it.skip("is faster than the naive implementation", () => {
     const input: Input[] = [true, false, 1, 2, 3, 4, 5, 6];

--- a/smithy-typescript-ssdk-libs/server-common/src/unique.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/unique.ts
@@ -76,6 +76,10 @@ const hash = (input: Input): string => {
  * @return a canonical string representation
  */
 const canonicalize = (input: Input): string => {
+  if (input === undefined) {
+    return "undefined()";
+  }
+
   if (input === null) {
     return "null()";
   }

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -260,4 +260,13 @@ describe("uniqueItems", () => {
       path: "aField",
     });
   });
+  describe("supports undefined values inside objects in lists", () => {
+    expect(() => validator.validate([{ a: [{ a: undefined }] }], "aField")).not.toThrowError();
+    expect(validator.validate([{ a: [{ a: null }] }, { a: [{ a: undefined }] }], "aField")).toBeNull();
+    expect(validator.validate([{ a: [{ a: undefined }] }, { a: [{ a: undefined }] }], "aField")).toEqual({
+      constraintType: "uniqueItems",
+      failureValue: [{ a: [{ a: undefined }] }],
+      path: "aField",
+    });
+  });
 });


### PR DESCRIPTION
*Description of changes:* I'm explicitly adding handling and test cases for scenarios where `undefined` and `null` values are passed.

I also added a new validation test for restJson1:

```
  ● RestJsonMalformedUniqueItemsStructureMissingKeyList:MalformedRequest

    expect(received).toBe(expected) // Object.is equality

    Expected: 400
    Received: 500

      4818 |
      4819 |   expect(testFunction.mock.calls.length).toBe(0);
    > 4820 |   expect(r.statusCode).toBe(400);
           |                        ^
      4821 |   expect(r.headers["x-amzn-errortype"]).toBeDefined();
      4822 |   expect(r.headers["x-amzn-errortype"]).toBe("ValidationException");
      4823 |

      at Object.<anonymous> (test/functional/restjson1.spec.ts:4820:24)
```

Locally, after `yarn link`ing the new changes, the error is gone which indicated that the regression has been fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

