### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  schedule:
+    # Monday-Friday at 16:00 UTC
+    - cron:  '16 0 * * 1-5'
+  workflow_dispatch: # on button click
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: yarn install
+      - name: Version
+        id: version
+        run: |
+          yarn changeset version
+          echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
+      - name: Configure AWS Credentials
+        id: credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          role-session-name: SmithyTypeScriptGitHubRelease
+          audience: sts.amazonaws.com
+      - name: Commit
+        id: commit
+        if: steps.version.outputs.porcelain != '0'
+        run: |
+          git config --global user.email "github-aws-smithy-automation@amazon.com"
+          git config --global user.name "Smithy Automation"
+          echo "packages=$(git diff --name-only | grep package.json | wc -l)" >> $GITHUB_OUTPUT
+          git add .
+          git commit -m 'Verison NPM packages'
+          git push
+      - name: Fetch NPM token
+        id: token
+        if: steps.commit.outcome == 'success'
+        run: |
+          aws configure --profile token set role_arn ${{ secrets.TOKEN_ROLE }}
+          aws configure --profile token set credential_source Environment
+          npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=npm-token --query SecretString --output text --profile token)
+          echo "::add-mask::$npm_token"
+          echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
+      - name: Release
+        id: release
+        uses: changesets/action@v1
+        if: steps.token.outcome == 'success'
+        with:
+          publish: yarn release
+        env:
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Failure Nofitication
+        if: ${{ failure() }}
+        run: aws cloudwatch put-metric-data --namespace SmithyTypeScriptPublish --metric-name NpmPackagePublishFailure --value 1


### PR DESCRIPTION
This PR adds a release workflow which automates publishing NPM packages each weekday at 16:00 UTC.

This workflow needs the following secrets configured: 
* ROLE_TO_ASSUME - an IAM role to assume which can publish failure metrics to CloudWatch and assume another role
* TOKEN_ROLE - an IAM role to assume which can access the NPM token used for publishing

The workflow performs the following steps:
1. Runs `yarn install`
2. Runs `yarn changeset version` to determine if versioning for any NPM packages is needed, updating package.json and changelog entries if necessary. See https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md#versioning-and-publishing
3. AWS Credentials are configured.
4. If changes result from `yarn changeset version`, a versioning commit is created and pushed.
5. The NPM token is fetched and saved as an environment variable.
6. The `changesets/action@v1` action publishes any versioned packages to NPM.
7. If any failures occur, a failure metric is emitted to CloudWatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
