### PR TITLE
Do not suppress on tagged internal enum shape member

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -542,7 +542,7 @@ final class StructuredMemberWriter {
                             }
                             writer.write("], [");
                             for (MemberShape member : shape.asEnumShape().get().getAllMembers().values()) {
-                                if (!member.hasTrait((InternalTrait.class)) && !member.hasTag("internal")) {
+                                if (!member.hasTrait((InternalTrait.class))) {
                                     writer.write("$S,", member.expectTrait(EnumValueTrait.class).expectStringValue());
                                 }
                             }


### PR DESCRIPTION
This PR updates the enum validator to not remove an enum shape member from the validation message if it has been tagged as "internal". Instead, only enum shape members with the `@internal` trait will be suppressed from the validation message.

See https://github.com/awslabs/smithy/pull/1746.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
