### PR TITLE
Add NPM packages release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@aws-smithy/*"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,33 @@ jobs:
       # changes) it'll return a non-zero error code.
       - name: Ensure there are no changes from running the formatter
         run: test -z "$(git diff)"
+
+  ensure-typescript-packages-have-changesets:
+    runs-on: ubuntu-latest
+    name: Ensure TypeScript packages have changesets
+    steps:
+      - uses: actions/checkout@v3
+        # Include full git history needed for `yarn changeset status`
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Install
+        run: yarn
+      - name: Create empty changeset for ssdk libs
+        run: |
+          echo --- >> .changeset/empty-ssdk-changeset.md
+          echo '"@aws-smithy/server-apigateway": patch' >> .changeset/empty-ssdk-changeset.md
+          echo '"@aws-smithy/server-common": patch' >> .changeset/empty-ssdk-changeset.md
+          echo '"@aws-smithy/server-node": patch' >> .changeset/empty-ssdk-changeset.md
+          echo --- >> .changeset/empty-ssdk-changeset.md
+          echo "" >> .changeset/empty-ssdk-changeset.md
+          echo "empty changeset" >> .changeset/empty-ssdk-changeset.md
+          git config --global user.email "github-aws-smithy-automation@amazon.com"
+          git config --global user.name "Smithy Automation"
+          git add .
+          git commit -m "Create empty changeset"
+      - name: Ensure changesets exist for each changed package
+        run: yarn changeset status --since=origin/main

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -1,4 +1,4 @@
-name: release
+name: release-npm-packages
 
 on:
   workflow_dispatch: # on button click
@@ -17,6 +17,11 @@ jobs:
           node-version: 18
       - name: Install dependencies
         run: yarn install
+      - name: Version
+        id: version
+        run: |
+          yarn changeset version
+          echo "porcelain=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Configure AWS Credentials
         id: credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -25,8 +30,18 @@ jobs:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           role-session-name: SmithyTypeScriptGitHubRelease
           audience: sts.amazonaws.com
+      - name: Commit
+        id: commit
+        if: steps.version.outputs.porcelain != '0'
+        run: |
+          git config --global user.email "github-aws-smithy-automation@amazon.com"
+          git config --global user.name "Smithy Automation"
+          git add .
+          git commit -m 'Verison NPM packages'
+          git push
       - name: Fetch NPM token
         id: token
+        if: steps.commit.outcome == 'success'
         run: |
           aws configure --profile token set role_arn ${{ secrets.TOKEN_ROLE }}
           aws configure --profile token set credential_source Environment

--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -1,0 +1,47 @@
+name: release-npm-ssdk-libs
+
+on:
+  workflow_dispatch: # on button click
+
+jobs:
+  release:
+    name: Release to SSDK lib packages to NPM
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: yarn install
+      - name: Configure AWS Credentials
+        id: credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          role-session-name: SmithyTypeScriptGitHubRelease
+          audience: sts.amazonaws.com
+      - name: Fetch NPM token
+        id: token
+        run: |
+          aws configure --profile token set role_arn ${{ secrets.TOKEN_ROLE }}
+          aws configure --profile token set credential_source Environment
+          npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=npm-token --query SecretString --output text --profile token)
+          echo "::add-mask::$npm_token"
+          echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
+      - name: Release
+        id: release
+        uses: changesets/action@v1
+        if: steps.token.outcome == 'success'
+        with:
+          publish: yarn release
+        env:
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Failure Nofitication
+        if: ${{ failure() }}
+        run: aws cloudwatch put-metric-data --namespace SmithyTypeScriptPublish --metric-name NpmPackagePublishFailure --value 1


### PR DESCRIPTION
This PR moves the existing `release.yml` to be an SSDK-libs-specific workflow and adds a new release workflow that will publish changes to NPM packages that will be added to the `/packages` directory. Changes to packages in this directory can be released in an automated fashion, since the workflow will run `yarn changeset version` which will update the version numbers and add changelogs according to the changeset entries defined. See: https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#version

Additionally, it updates the CI workflow to check that each PR has the proper changeset entry defined and included in the PR's commits. By running `yarn changeset status --since=origin/main`, the `ensure-typescript-packages-have-changeset` step will check that when any NPM packages have been updated, a corresponding changeset has been defined. The SSDK libs packages will continue to be manually versioned and released while they are still using the prerelease alpha tag. To allow the `yarn changeset status` check to succeed, a fake changeset is injected to cover the SSDK libs packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
