### PR TITLE
Fix npm publish access

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@aws-smithy/*"]


### PR DESCRIPTION
Sets NPM publish access to `public`.  See: https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#access-restricted--public

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
