### PR TITLE
yarn pack before releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ dist-*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# NPM release staging
+_release

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ dist-*
 !.yarn/versions
 
 # NPM release staging
-_release
+.release

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "turbo run test",
     "lint": "turbo run lint --parallel",
     "format": "turbo run format --parallel",
-    "release": "yarn build && yarn changeset publish"
+    "stage-release": "turbo run stage-release",
+    "release": "yarn stage-release && yarn changeset publish"
   },
   "repository": {
     "type": "git",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
@@ -54,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "_release/package"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -7,7 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
@@ -57,6 +57,6 @@
     "entryPoint": "src/index.ts"
   },
   "publishConfig": {
-    "directory": "_release/package"
+    "directory": ".release/package"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
@@ -53,5 +54,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": "_release/package"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
@@ -56,6 +56,6 @@
     "entryPoint": "src/index.ts"
   },
   "publishConfig": {
-    "directory": "_release/package"
+    "directory": ".release/package"
   }
 }

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
+    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
     "test": "jest --passWithNoTests",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -56,5 +57,8 @@
   "bugs": {
     "url": "https://github.com/awslabs/smithy-typescript/issues"
   },
-  "homepage": "https://github.com/awslabs/smithy-typescript#readme"
+  "homepage": "https://github.com/awslabs/smithy-typescript#readme",
+  "publishConfig": {
+    "directory": "_release/package"
+  }
 }

--- a/smithy-typescript-ssdk-libs/server-apigateway/package.json
+++ b/smithy-typescript-ssdk-libs/server-apigateway/package.json
@@ -13,7 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
-    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
     "test": "jest --passWithNoTests",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -59,6 +59,6 @@
   },
   "homepage": "https://github.com/awslabs/smithy-typescript#readme",
   "publishConfig": {
-    "directory": "_release/package"
+    "directory": ".release/package"
   }
 }

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
+    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
     "test": "jest",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -56,5 +57,8 @@
   "bugs": {
     "url": "https://github.com/awslabs/smithy-typescript/issues"
   },
-  "homepage": "https://github.com/awslabs/smithy-typescript#readme"
+  "homepage": "https://github.com/awslabs/smithy-typescript#readme",
+  "publishConfig": {
+    "directory": "_release/package"
+  }
 }

--- a/smithy-typescript-ssdk-libs/server-common/package.json
+++ b/smithy-typescript-ssdk-libs/server-common/package.json
@@ -13,7 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
-    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
     "test": "jest",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -59,6 +59,6 @@
   },
   "homepage": "https://github.com/awslabs/smithy-typescript#readme",
   "publishConfig": {
-    "directory": "_release/package"
+    "directory": ".release/package"
   }
 }

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
+    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
     "test": "jest --passWithNoTests",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -55,5 +56,8 @@
   "bugs": {
     "url": "https://github.com/awslabs/smithy-typescript/issues"
   },
-  "homepage": "https://github.com/awslabs/smithy-typescript#readme"
+  "homepage": "https://github.com/awslabs/smithy-typescript#readme",
+  "publishConfig": {
+    "directory": "_release/package"
+  }
 }

--- a/smithy-typescript-ssdk-libs/server-node/package.json
+++ b/smithy-typescript-ssdk-libs/server-node/package.json
@@ -13,7 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "rimraf dist/types/ts3.4 && downlevel-dts dist/types dist/types/ts3.4",
-    "stage-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
     "test": "jest --passWithNoTests",
     "clean": "rimraf dist",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
@@ -58,6 +58,6 @@
   },
   "homepage": "https://github.com/awslabs/smithy-typescript#readme",
   "publishConfig": {
-    "directory": "_release/package"
+    "directory": ".release/package"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,9 @@
     },
     "clean": {
       "cache": false
+    },
+    "stage-release": {
+        "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
This PR adds a `stage-release` script which is run as part of the `release` script.

Before `yarn changeset publish` can be invoked by the release script, yarn needs to handle converting the `workspace:^` entries in each package's package.json into a real version number. The `stage-release` script invokes `yarn pack` which performs this conversion while packing the contents into a `package.tgz` file. The contents of the packed package are then unpacked into a `.release` directory, which is used for publishing. Turbo will assure that `yarn build` is successfully run before attempting to stage the release contents to `.release`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
