### PR TITLE
Bump version to re-publish

### DIFF
--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/protocol-http",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
Bumps version of @smithy/protocol-http after release packaging update in https://github.com/awslabs/smithy-typescript/pull/749, enabling re-publishing this package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
