### PR TITLE
Add gradle composite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ dist-*
 
 # NPM release staging
 .release
+
+# Gradle composite build properties
+local.properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,19 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
+## Gradle Composite Build
+The `smithy-typescript` repository uses Gradle as a build tool and has Gradle based dependencies such as `smithy`.
+To improve development experience when making changes to the dependencies locally, we can
+use the [Gradle composite build feature](https://docs.gradle.org/current/userguide/composite_builds.html),
+which allows picking up any local changes from dependencies automatically and rebuilding them when `smithy-typescript` is rebuilt.
+
+This also makes IDE integration more pleasant, as Intellij IDEA will open the included projects as modules when the Gradle build is imported.
+
+In order to utilise this feature, create a file `local.properties` in the project directory with the following content:
+
+```
+smithy=/Volumes/workplace/smithy
+```
 
 ## Reporting Bugs/Feature Requests
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,26 @@
  * permissions and limitations under the License.
  */
 
+import java.io.FileInputStream
+import java.nio.charset.StandardCharsets.UTF_8
+
 rootProject.name = "smithy-typescript"
 include(":smithy-typescript-codegen")
 include(":smithy-typescript-codegen-test")
+
+file(
+    java.nio.file.Paths.get(rootProject.projectDir.absolutePath, "local.properties"))
+    .takeIf { it.isFile }?.let { f ->
+        java.util.Properties().apply { load(java.io.InputStreamReader(FileInputStream(f), UTF_8)) }
+    }?.run {
+        listOf("smithy")
+            .map { it to getProperty(it) }
+            .filterNot { it.second.isNullOrEmpty() }
+            .onEach { println("Found property `${it.first}`: ${it.second}") }
+            .map { file(it.second) }
+            .filter { it.isDirectory }
+            .forEach { includeBuild(it.absolutePath) }
+    }
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
### Description
Add gradle composite build

### Testing
Validate local dependency changes are included automatically when `local.properties` exists


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
