### PR TITLE
Do not trim collection query param output values

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -2623,14 +2623,18 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     ) {
         MemberShape targetMember = target.getMember();
         Shape collectionTarget = context.getModel().expectShape(targetMember.getTarget());
-        String collectionTargetValue = getOutputValue(context, bindingType, "_entry.trim()",
+        boolean trimParameterValue = bindingType != Location.QUERY && bindingType != Location.QUERY_PARAMS;
+        String outputValueDataSource = "_entry";
+        if (trimParameterValue) {
+            outputValueDataSource += ".trim()";
+        }
+        String collectionTargetValue = getOutputValue(context, bindingType, outputValueDataSource,
                 targetMember, collectionTarget);
         String outputParam;
         switch (bindingType) {
             case QUERY_PARAMS:
             case QUERY:
-                return String.format("%1$s.map(_entry => %2$s as any)",
-                        dataSource, collectionTargetValue);
+                return String.format("%1$s.map(_entry => %2$s as any)", dataSource, collectionTargetValue);
             case LABEL:
                 dataSource = "(" + dataSource + " || \"\")";
                 // Split these values on slashes.


### PR DESCRIPTION
*Description of changes:*
Previously, server request deserializers would trim leading and trailing whitespace of output query parameter values. This PR stops that, so the whitespace is preserved as part of the query value.

Tested using JS SDK. All protocol tests continue to pass, there is a codegen diff.

This PR is required for https://github.com/awslabs/smithy/pull/1759

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
