### PR TITLE
Revert "Do not suppress on tagged internal enum shape member"

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -542,7 +542,7 @@ final class StructuredMemberWriter {
                             }
                             writer.write("], [");
                             for (MemberShape member : shape.asEnumShape().get().getAllMembers().values()) {
-                                if (!member.hasTrait((InternalTrait.class))) {
+                                if (!member.hasTrait((InternalTrait.class)) && !member.hasTag("internal")) {
                                     writer.write("$S,", member.expectTrait(EnumValueTrait.class).expectStringValue());
                                 }
                             }


### PR DESCRIPTION
This reverts commit 4f16c8bba722d61635b0ce51acb84be8728376ac.

This commit temporarily reverts the change from https://github.com/awslabs/smithy-typescript/pull/741.

That change is only compatible with the protocol test changes in Smithy 1.31.0. This change specifically: https://github.com/awslabs/smithy/pull/1746

This change should be re-introduced when upgrading to Smithy 1.31.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
