### PR TITLE
Use @smithy scoped packages

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
@@ -65,11 +65,11 @@ public final class ApplicationProtocol {
                         .alias("__HttpHandlerOptions")
                         .build(),
                 SymbolReference.builder()
-                        .symbol(createHttpSymbol(TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP, "HttpRequest"))
+                        .symbol(createHttpSymbol(TypeScriptDependency.PROTOCOL_HTTP, "HttpRequest"))
                         .alias("__HttpRequest")
                         .build(),
                 SymbolReference.builder()
-                        .symbol(createHttpSymbol(TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP, "HttpResponse"))
+                        .symbol(createHttpSymbol(TypeScriptDependency.PROTOCOL_HTTP, "HttpResponse"))
                         .alias("__HttpResponse")
                         .build()
         );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -110,7 +110,7 @@ public final class CodegenUtils {
     private static List<String> getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
         List<String> contextInterfaceList = new ArrayList<>();
         // Get default SerdeContext.
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         contextInterfaceList.add("__SerdeContext");
         return contextInterfaceList;
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -110,7 +110,7 @@ public final class CodegenUtils {
     private static List<String> getDefaultOperationSerdeContextTypes(TypeScriptWriter writer) {
         List<String> contextInterfaceList = new ArrayList<>();
         // Get default SerdeContext.
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
         contextInterfaceList.add("__SerdeContext");
         return contextInterfaceList;
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -230,7 +230,8 @@ public final class HttpProtocolTestGenerator implements Runnable {
         if (writer == null) {
             context.getWriterDelegator().useFileWriter(createTestCaseFilename(), writer -> this.writer = writer);
             writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
-            writer.addDependency(TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP);
+            writer.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            writer.addDependency(TypeScriptDependency.PROTOCOL_HTTP);
             // Add the template to each generated test.
             writer.write(IoUtils.readUtf8Resource(getClass(), "protocol-test-stub.ts"));
         }
@@ -580,7 +581,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 additionalStubs.add("protocol-test-xml-stub.ts");
                 return "compareEquivalentXmlBodies(bodyString, r.body.toString())";
             case "application/octet-stream":
-                writer.addImport("Encoder", "__Encoder", "@aws-sdk/types");
+                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
                 additionalStubs.add("protocol-test-octet-stream-stub.ts");
                 return "compareEquivalentOctetStreamBodies(utf8Encoder, bodyString, r.body)";
             case "text/plain":
@@ -589,7 +590,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             default:
                 LOGGER.warning("Unable to compare bodies with unknown media type `" + mediaType
                         + "`, defaulting to direct comparison.");
-                writer.addImport("Encoder", "__Encoder", "@aws-sdk/types");
+                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
                 additionalStubs.add("protocol-test-unknown-type-stub.ts");
                 return "compareEquivalentUnknownTypeBodies(utf8Encoder, bodyString, r.body)";
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -581,7 +581,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
                 additionalStubs.add("protocol-test-xml-stub.ts");
                 return "compareEquivalentXmlBodies(bodyString, r.body.toString())";
             case "application/octet-stream":
-                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
+                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES);
                 additionalStubs.add("protocol-test-octet-stream-stub.ts");
                 return "compareEquivalentOctetStreamBodies(utf8Encoder, bodyString, r.body)";
             case "text/plain":
@@ -590,7 +590,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
             default:
                 LOGGER.warning("Unable to compare bodies with unknown media type `" + mediaType
                         + "`, defaulting to direct comparison.");
-                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
+                writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES);
                 additionalStubs.add("protocol-test-unknown-type-stub.ts");
                 return "compareEquivalentUnknownTypeBodies(utf8Encoder, bodyString, r.body)";
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -45,6 +46,10 @@ final class IndexGenerator {
         ProtocolGenerator protocolGenerator,
         TypeScriptWriter writer
     ) {
+        writer.write("/* eslint-disable */");
+        settings.getService(model).getTrait(DocumentationTrait.class).ifPresent(trait ->
+                writer.writeDocs(trait.getValue() + "\n\n" + "@packageDocumentation"));
+
         if (settings.generateClient()) {
             writeClientExports(settings, model, symbolProvider, writer);
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -46,10 +45,6 @@ final class IndexGenerator {
         ProtocolGenerator protocolGenerator,
         TypeScriptWriter writer
     ) {
-        writer.write("/* eslint-disable */");
-        settings.getService(model).getTrait(DocumentationTrait.class).ifPresent(trait ->
-                writer.writeDocs(trait.getValue() + "\n\n" + "@packageDocumentation"));
-
         if (settings.generateClient()) {
             writeClientExports(settings, model, symbolProvider, writer);
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -206,8 +206,8 @@ final class ServerGenerator {
         writer.addImport("InternalFailureException", "__InternalFailureException", "@aws-smithy/server-common");
         writer.addImport("SerializationException", "__SerializationException", "@aws-smithy/server-common");
         writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", "@aws-smithy/server-common");
-        writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
-        writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
         writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -262,14 +262,14 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                             + "@internal");
             writer.write("bodyLengthChecker?: __BodyLengthCalculator;\n");
 
-            writer.addImport("StreamCollector", "__StreamCollector", TypeScriptDependency.SMITHY_TYPES.packageName);
+            writer.addImport("StreamCollector", "__StreamCollector", TypeScriptDependency.SMITHY_TYPES);
             writer.writeDocs("A function that converts a stream into an array of bytes.\n"
                             + "@internal");
             writer.write("streamCollector?: __StreamCollector;\n");
 
             // Note: Encoder and Decoder are both used for base64 and UTF.
-            writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
-            writer.addImport("Decoder", "__Decoder", TypeScriptDependency.SMITHY_TYPES.packageName);
+            writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES);
+            writer.addImport("Decoder", "__Decoder", TypeScriptDependency.SMITHY_TYPES);
 
             writer.writeDocs("The function that will be used to convert a base64-encoded string to a byte array.\n"
                             + "@internal");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -237,7 +237,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
             .openBlock("export interface ClientDefaults\n"
                          + "  extends Partial<__SmithyResolvedConfiguration<$T>> {", "}",
                 applicationProtocol.getOptionsType(), () -> {
-            writer.addImport("HttpHandler", "__HttpHandler", "@aws-sdk/protocol-http");
+            writer.addImport("HttpHandler", "__HttpHandler", TypeScriptDependency.PROTOCOL_HTTP.packageName);
             writer.writeDocs("The HTTP handler to use. Fetch in browser and Https in Nodejs.");
             writer.write("requestHandler?: __HttpHandler;\n");
 
@@ -262,14 +262,14 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                             + "@internal");
             writer.write("bodyLengthChecker?: __BodyLengthCalculator;\n");
 
-            writer.addImport("StreamCollector", "__StreamCollector", "@aws-sdk/types");
+            writer.addImport("StreamCollector", "__StreamCollector", TypeScriptDependency.SMITHY_TYPES.packageName);
             writer.writeDocs("A function that converts a stream into an array of bytes.\n"
                             + "@internal");
             writer.write("streamCollector?: __StreamCollector;\n");
 
             // Note: Encoder and Decoder are both used for base64 and UTF.
-            writer.addImport("Encoder", "__Encoder", "@aws-sdk/types");
-            writer.addImport("Decoder", "__Decoder", "@aws-sdk/types");
+            writer.addImport("Encoder", "__Encoder", TypeScriptDependency.SMITHY_TYPES.packageName);
+            writer.addImport("Decoder", "__Decoder", TypeScriptDependency.SMITHY_TYPES.packageName);
 
             writer.writeDocs("The function that will be used to convert a base64-encoded string to a byte array.\n"
                             + "@internal");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -41,6 +41,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/service-client-documentation-generator", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
+    SMITHY_TYPES("dependencies", "@smithy/types", "^1.0.0", true),
     AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", true),
     INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", true),
     CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", true),
@@ -83,7 +84,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM("dependencies", "@aws-sdk/middleware-apply-body-checksum", false),
 
     // Conditionally added when using an HTTP application protocol.
-    AWS_SDK_PROTOCOL_HTTP("dependencies", "@aws-sdk/protocol-http", false),
+    PROTOCOL_HTTP("dependencies", "@smithy/protocol-http", "^1.0.1", false),
     AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", false),
     AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", false),
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -70,7 +70,7 @@ public final class EndpointsV2Generator implements Runnable {
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_PARAMETERS_FILE).toString(),
             writer -> {
                 writer.addImport("EndpointParameters", "__EndpointParameters", "@aws-sdk/types");
-                writer.addImport("Provider", null, "@aws-sdk/types");
+                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES.packageName);
 
                 writer.openBlock(
                     "export interface ClientInputEndpointParameters {",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -70,7 +70,7 @@ public final class EndpointsV2Generator implements Runnable {
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_PARAMETERS_FILE).toString(),
             writer -> {
                 writer.addImport("EndpointParameters", "__EndpointParameters", "@aws-sdk/types");
-                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES.packageName);
+                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
 
                 writer.openBlock(
                     "export interface ClientInputEndpointParameters {",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -66,9 +66,9 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
             ParameterGenerator parameterGenerator = new ParameterGenerator(localKey, param);
 
             if (localKey.equals("endpoint")) {
-                writer.addImport("Endpoint", null, TypeScriptDependency.SMITHY_TYPES.packageName);
+                writer.addImport("Endpoint", null, TypeScriptDependency.SMITHY_TYPES);
                 writer.addImport("EndpointV2", null, "@aws-sdk/types");
-                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES.packageName);
+                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
             }
 
             if (writeDefaults) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeVisitor;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 
 /**
@@ -65,9 +66,9 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
             ParameterGenerator parameterGenerator = new ParameterGenerator(localKey, param);
 
             if (localKey.equals("endpoint")) {
-                writer.addImport("Endpoint", null, "@aws-sdk/types");
+                writer.addImport("Endpoint", null, TypeScriptDependency.SMITHY_TYPES.packageName);
                 writer.addImport("EndpointV2", null, "@aws-sdk/types");
-                writer.addImport("Provider", null, "@aws-sdk/types");
+                writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES.packageName);
             }
 
             if (writeDefaults) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
@@ -57,7 +57,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES.packageName);
         writer.addImport("Logger", "__Logger", TypeScriptDependency.AWS_SDK_TYPES.packageName);
 
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
@@ -57,7 +57,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("Logger", "__Logger", TypeScriptDependency.AWS_SDK_TYPES.packageName);
 
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
@@ -38,7 +38,7 @@ public class AddDefaultsModeDependency implements TypeScriptIntegration {
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER);
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_NODE);
         writer.addImport("DefaultsMode", "__DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-        writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES.packageName);
         writer.writeDocs("The {@link @aws-sdk/smithy-client#DefaultsMode} that "
                 + "will be used to determine how certain default configuration "
                 + "options are resolved in the SDK.");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
@@ -38,7 +38,7 @@ public class AddDefaultsModeDependency implements TypeScriptIntegration {
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER);
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_NODE);
         writer.addImport("DefaultsMode", "__DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
-        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
         writer.writeDocs("The {@link @aws-sdk/smithy-client#DefaultsMode} that "
                 + "will be used to determine how certain default configuration "
                 + "options are resolved in the SDK.");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -384,8 +384,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
                 ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
-        writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
-        writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
 
         Symbol serviceSymbol = symbolProvider.toSymbol(context.getService());
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
@@ -438,8 +438,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.addImport("serializeFrameworkException", null,
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
                 ProtocolGenerator.getSanitizedName(getName())).toString());
-        writer.addImport("HttpRequest", "__HttpRequest", "@aws-sdk/protocol-http");
-        writer.addImport("HttpResponse", "__HttpResponse", "@aws-sdk/protocol-http");
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
 
         final Symbol operationSymbol = symbolProvider.toSymbol(operation);
         final Symbol inputType = operationSymbol.expectProperty("inputType", Symbol.class);
@@ -650,7 +650,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
 
         // e.g., se_ES
         String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
@@ -1729,7 +1729,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
         String methodName = ProtocolGenerator.getGenericDeserFunctionName(symbol) + "Request";
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -650,7 +650,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES);
 
         // e.g., se_ES
         String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
@@ -1729,7 +1729,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES);
         String methodName = ProtocolGenerator.getGenericDeserFunctionName(symbol) + "Request";
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -256,7 +256,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateCollectBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.write("// Collect low-level response body stream to Uint8Array.");
         writer.openBlock("const collectBody = (streamBody: any = new Uint8Array(), context: __SerdeContext): "
                 + "Promise<Uint8Array> => {", "};", () -> {
@@ -278,7 +278,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateCollectBodyString(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.write("// Encode Uint8Array data into string with utf-8.");
         writer.write("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => "
                 + "collectBody(streamBody, context).then(body => context.utf8Encoder(body))");
@@ -435,8 +435,7 @@ public final class HttpProtocolGeneratorUtils {
         writer.write("let { hostname: resolvedHostname } = await context.endpoint();");
         // Check if disableHostPrefixInjection has been set to true at runtime
         writer.openBlock("if (context.disableHostPrefix !== true) {", "}", () -> {
-            writer.addImport("isValidHostname", "__isValidHostname",
-                    TypeScriptDependency.PROTOCOL_HTTP.packageName);
+            writer.addImport("isValidHostname", "__isValidHostname", TypeScriptDependency.PROTOCOL_HTTP);
             writer.write("resolvedHostname = $S + resolvedHostname;", trait.getHostPrefix().toString());
             if (operation.getInput().isPresent()) {
                 List<SmithyPattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -256,7 +256,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateCollectBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
         writer.write("// Collect low-level response body stream to Uint8Array.");
         writer.openBlock("const collectBody = (streamBody: any = new Uint8Array(), context: __SerdeContext): "
                 + "Promise<Uint8Array> => {", "};", () -> {
@@ -278,7 +278,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateCollectBodyString(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
         writer.write("// Encode Uint8Array data into string with utf-8.");
         writer.write("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => "
                 + "collectBody(streamBody, context).then(body => context.utf8Encoder(body))");
@@ -436,7 +436,7 @@ public final class HttpProtocolGeneratorUtils {
         // Check if disableHostPrefixInjection has been set to true at runtime
         writer.openBlock("if (context.disableHostPrefix !== true) {", "}", () -> {
             writer.addImport("isValidHostname", "__isValidHostname",
-                    TypeScriptDependency.AWS_SDK_PROTOCOL_HTTP.packageName);
+                    TypeScriptDependency.PROTOCOL_HTTP.packageName);
             writer.write("resolvedHostname = $S + resolvedHostname;", trait.getHostPrefix().toString());
             if (operation.getInput().isPresent()) {
                 List<SmithyPattern.Segment> prefixLabels = trait.getHostPrefix().getLabels();

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -142,7 +142,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Write a function to generate HTTP requests since they're so similar.
         SymbolReference requestType = getApplicationProtocol().getRequestType();
         writer.addUseImports(requestType);
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
         writer.openBlock("const buildHttpRpcRequest = async (\n"
                        + "  context: __SerdeContext,\n"
@@ -231,7 +231,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES);
         // e.g., se_ES
         String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
         // e.g., serializeAws_restJson1_1ExecuteStatement

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -142,7 +142,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         // Write a function to generate HTTP requests since they're so similar.
         SymbolReference requestType = getApplicationProtocol().getRequestType();
         writer.addUseImports(requestType);
-        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES.packageName);
         writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
         writer.openBlock("const buildHttpRpcRequest = async (\n"
                        + "  context: __SerdeContext,\n"
@@ -231,7 +231,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
-        writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
+        writer.addImport("Endpoint", "__Endpoint", TypeScriptDependency.SMITHY_TYPES.packageName);
         // e.g., se_ES
         String methodName = ProtocolGenerator.getSerFunctionShortName(symbol);
         // e.g., serializeAws_restJson1_1ExecuteStatement


### PR DESCRIPTION
This PR updates the generated code to use the `@smithy` scoped `types` and `protocol-http` packages that were added to the `/packages` directory. For now, generated clients will continue to depend on `@aws-sdk/types` package, but `@aws-sdk/protocol-http` is completely replaced by the package migrated to `@smithy/protocol-https`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
