### PR TITLE
Add updated addImport method

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -103,14 +103,29 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
     /**
      * Imports a type using an alias from a module only if necessary.
      *
+     * @deprecated Use {@link TypeScriptWriter#addImport(String, String, TypeScriptDependency)} addImport}
+     *
      * @param name Type to import.
      * @param as Alias to refer to the type as.
      * @param from Module to import the type from.
      * @return Returns the writer.
      */
+    @Deprecated
     public TypeScriptWriter addImport(String name, String as, String from) {
         getImportContainer().addImport(name, as, from);
         return this;
+    }
+
+    /**
+     * Imports a type using an alias from a module only if necessary.
+     *
+     * @param name Type to import.
+     * @param as Alias to refer to the type as.
+     * @param from TypeScriptDependency to import the type from.
+     * @return Returns the writer.
+     */
+    public TypeScriptWriter addImport(String name, String as, TypeScriptDependency from) {
+        return this.addImport(name, as, from.packageName);
     }
 
     /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -21,9 +21,11 @@ public class TypeScriptWriterTest {
         TypeScriptWriter writer = new TypeScriptWriter("foo");
         writer.write("import { Foo } from \"baz\";");
         writer.addImport("Baz", "Baz", "hello");
+        writer.addImport("Bar", "__Bar", TypeScriptDependency.AWS_SDK_TYPES);
         String result = writer.toString();
 
-        assertThat(result, equalTo(CODEGEN_INDICATOR + "import { Baz } from \"hello\";\nimport { Foo } from \"baz\";\n"));
+        assertThat(result, equalTo(CODEGEN_INDICATOR + "import { Bar as __Bar } from \"@aws-sdk/types\";\n"
+                + "import { Baz } from \"hello\";\nimport { Foo } from \"baz\";\n"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds a new `addImport` method to TypeScriptWriter, and deprecates the existing `addImport` method.

Currently, `addImport` is used like this:
```
writer.addImport("Foo", "__Foo", "@aws-sdk/foo");
```
Or like this:
```
writer.addImport("Foo", "__Foo", TypeScriptDependency.AWS_SDK_FOO.packageName);
```

The new method will allow for this simplified usage:
```
writer.addImport("Foo", "__Foo", TypeScriptDependency.AWS_SDK_FOO);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
