### PR TITLE
Add addRelativeImport method

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.nio.file.Path;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -126,6 +127,18 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
      */
     public TypeScriptWriter addImport(String name, String as, TypeScriptDependency from) {
         return this.addImport(name, as, from.packageName);
+    }
+
+    /**
+     * Imports a type using an alias from a relative Path.
+     *
+     * @param name Type to import.
+     * @param as Alias to refer to the type as.
+     * @param from Path to import the type from.
+     * @return Returns the writer.
+     */
+    public TypeScriptWriter addRelativeImport(String name, String as, Path from) {
+        return this.addImport(name, as, from.toString());
     }
 
     /**

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static software.amazon.smithy.typescript.codegen.TypeScriptWriter.CODEGEN_INDICATOR;
 
+import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 public class TypeScriptWriterTest {
@@ -22,10 +23,13 @@ public class TypeScriptWriterTest {
         writer.write("import { Foo } from \"baz\";");
         writer.addImport("Baz", "Baz", "hello");
         writer.addImport("Bar", "__Bar", TypeScriptDependency.AWS_SDK_TYPES);
+        writer.addRelativeImport("Qux", "__Qux", Paths.get("./qux"));
         String result = writer.toString();
 
-        assertThat(result, equalTo(CODEGEN_INDICATOR + "import { Bar as __Bar } from \"@aws-sdk/types\";\n"
-                + "import { Baz } from \"hello\";\nimport { Foo } from \"baz\";\n"));
+        assertThat(result, equalTo(CODEGEN_INDICATOR + "import { Qux as __Qux } from \"./qux\";\n"
+                + "import { Bar as __Bar } from \"@aws-sdk/types\";\n"
+                + "import { Baz } from \"hello\";\n"
+                + "import { Foo } from \"baz\";\n"));
     }
 
     @Test


### PR DESCRIPTION
Additional change to go with https://github.com/awslabs/smithy-typescript/pull/767.

This adds a separate, `addRelativeImport`, method which should be used exclusively to import relative paths.

Between this method, `addRelativeImport`, and the `addImport` method added in https://github.com/awslabs/smithy-typescript/pull/767, any instances of `writer.addImport("Foo", "__Foo", "@aws-sdk/foo");` can be updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
