### PR TITLE
Add packageDocumentation and improve interface inheritance

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -362,6 +362,9 @@ final class CommandGenerator implements Runnable {
     }
 
     private void addInputAndOutputTypes() {
+        writer.writeDocs("@public");
+        writer.write("export { __MetadataBearer, $$Command };");
+
         writeInputType(inputType.getName(), operationIndex.getInput(operation), symbol.getName());
         writeOutputType(outputType.getName(), operationIndex.getOutput(operation), symbol.getName());
         writer.write("");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -45,6 +46,12 @@ final class IndexGenerator {
         ProtocolGenerator protocolGenerator,
         TypeScriptWriter writer
     ) {
+
+        writer.write("/* eslint-disable */");
+        settings.getService(model).getTrait(DocumentationTrait.class).ifPresent(trait ->
+                writer.writeDocs(trait.getValue() + "\n\n" + "@packageDocumentation"));
+
+
         if (settings.generateClient()) {
             writeClientExports(settings, model, symbolProvider, writer);
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -98,6 +98,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     @Override
     public void run() {
         writer.addImport("Client", "__Client", "@aws-sdk/smithy-client");
+        writer.write("export { __Client }\n");
         writer.addImport("getRuntimeConfig", "__getRuntimeConfig",
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeConfig").toString());
 
@@ -162,7 +163,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
         writer.writeDocs("@public");
         // The default configuration type is always just the base-level
         // Smithy configuration requirements.
-        writer.write("type $LType = Partial<__SmithyConfiguration<$T>>", configType,
+        writer.write("export type $LType = Partial<__SmithyConfiguration<$T>>", configType,
                 applicationProtocol.getOptionsType());
         writer.write("  & ClientDefaults");
 
@@ -197,7 +198,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
         // each "Input" configuration type.
         writer.write("");
         writer.writeDocs("@public");
-        writer.write("type $LType = __SmithyResolvedConfiguration<$T>",
+        writer.write("export type $LType = __SmithyResolvedConfiguration<$T>",
                      resolvedConfigType, applicationProtocol.getOptionsType());
         writer.write("  & Required<ClientDefaults>");
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
@@ -67,6 +67,9 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
                                     TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
                             writer.addImport("ServiceExceptionOptions", "__ServiceExceptionOptions",
                                     TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                            // Export ServiceException information to allow
+                            //      documentation inheritance to consume their types
+                            writer.write("export { __ServiceException, __ServiceExceptionOptions }\n");
                             writer.writeDocs("@public\n\nBase exception class for all service exceptions from "
                                     + serviceName + " service.");
                             writer.openBlock("export class $L extends __ServiceException {", serviceExceptionName);


### PR DESCRIPTION
*Description of changes:*
1. Add packageDocumentation trait with service documentation
2. Export types used in inheritance chain to allow documentation to follow the entire chain
    1.  export imported types to allow them to be inherited
    2. export default types to allow them to be inherited

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
