### PR TITLE
fix endpoint parameter name conflict

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -244,6 +244,7 @@ final class CommandGenerator implements Runnable {
                                 Set<String> paramNames = new HashSet<>();
 
                                 parameterFinder.getStaticContextParamValues(operation).forEach((name, value) -> {
+                                    paramNames.add(name);
                                     writer.write(
                                             "$L: { type: \"staticContextParams\", value: $L },",
                                             name, value);
@@ -251,9 +252,12 @@ final class CommandGenerator implements Runnable {
 
                                 Shape operationInput = model.getShape(operation.getInputShape()).get();
                                 parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
+                                    if (!paramNames.contains(name)) {
                                     writer.write(
                                             "$L: { type: \"contextParams\", name: \"$L\" },",
                                             name, name);
+                                    }
+                                    paramNames.add(name);
                                 });
 
                                 parameterFinder.getClientContextParams().forEach((name, type) -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -253,7 +253,7 @@ final class CommandGenerator implements Runnable {
                                 Shape operationInput = model.getShape(operation.getInputShape()).get();
                                 parameterFinder.getContextParams(operationInput).forEach((name, type) -> {
                                     if (!paramNames.contains(name)) {
-                                    writer.write(
+                                        writer.write(
                                             "$L: { type: \"contextParams\", name: \"$L\" },",
                                             name, name);
                                     }


### PR DESCRIPTION
if a static context param is already using a name, avoid writing it for subsequent lower priority params.

This was already in place for context, client, and built-ins, just missed for static context to context.

For context, no current AWS SDK models have this collision, it was noticed in a feature under development.