### PR TITLE
Handle case insensitive endpoint param types

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/ParameterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/ParameterGenerator.java
@@ -79,13 +79,15 @@ public class ParameterGenerator {
 
         switch (type.getValue()) {
             case "String":
+            case "string":
                 buffer += "\"" + paramNode.expectStringMember("default").getValue() + "\"";
                 break;
             case "Boolean":
+            case "boolean":
                 buffer += paramNode.expectBooleanMember("default").getValue() ? "true" : "false";
                 break;
             default:
-                // required by linter
+                throw new RuntimeException("Unhandled endpoint param type: " + type.getValue());
         }
 
         buffer += ",";


### PR DESCRIPTION
Currently all endpoint param types encountered by JSv3 (AWS) are capitalized, however a new feature introduced a lowercase param type "string". Checking the internal specification, this appears to be something that should be accepted.

Also added a throw on the default branch since the only specified types are string and boolean.