### PR TITLE
Use util-stream package

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -109,8 +109,9 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
 
     // Conditionally added when streaming blob response payload exists.
-    UTIL_STREAM_NODE("dependencies", "@aws-sdk/util-stream-node", false),
-    UTIL_STREAM_BROWSER("dependencies", "@aws-sdk/util-stream-browser", false),
+    @Deprecated UTIL_STREAM_NODE("dependencies", "@aws-sdk/util-stream-node", false),
+    @Deprecated UTIL_STREAM_BROWSER("dependencies", "@aws-sdk/util-stream-browser", false),
+    UTIL_STREAM("dependencies", "@aws-sdk/util-stream", false),
 
     // Server dependency for SSDKs
     SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.0-alpha.10", false);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
@@ -71,23 +71,15 @@ public final class AddSdkStreamMixinDependency implements TypeScriptIntegration 
         if (!hasStreamingBlobDeser(settings, model)) {
             return Collections.emptyMap();
         }
-        switch (target) {
-            case NODE:
-                return MapUtils.of("sdkStreamMixin", writer -> {
-                    writer.addDependency(TypeScriptDependency.UTIL_STREAM_NODE);
-                    writer.addImport("sdkStreamMixin", "sdkStreamMixin",
-                            TypeScriptDependency.UTIL_STREAM_NODE.packageName);
-                    writer.write("sdkStreamMixin");
-                });
-            case BROWSER:
-                return MapUtils.of("sdkStreamMixin", writer -> {
-                    writer.addDependency(TypeScriptDependency.UTIL_STREAM_BROWSER);
-                    writer.addImport("sdkStreamMixin", "sdkStreamMixin",
-                            TypeScriptDependency.UTIL_STREAM_BROWSER.packageName);
-                    writer.write("sdkStreamMixin");
-                });
-            default:
-                return Collections.emptyMap();
+
+        if (target == LanguageTarget.SHARED) {
+           return MapUtils.of("sdkStreamMixin", writer -> {
+               writer.addDependency(TypeScriptDependency.UTIL_STREAM);
+               writer.addImport("sdkStreamMixin", "sdkStreamMixin", TypeScriptDependency.UTIL_STREAM);
+               writer.write("sdkStreamMixin");
+           });
+        } else {
+            return Collections.emptyMap();
         }
     }
 


### PR DESCRIPTION
Updates dependencies to use util-stream package instead of util-stream-node and util-stream-browser, deprecating the two.

This PR is required for ~https://github.com/aws/aws-sdk-js-v3/pull/4787~ https://github.com/aws/aws-sdk-js-v3/pull/4861, which contains more info about testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
