### PR TITLE
widen blob payload input types, add blob payload output converter

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.HttpPayloadTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -135,10 +136,11 @@ public final class CodegenUtils {
      * Refer here for more rationales: https://github.com/aws/aws-sdk-js-v3/issues/843
      */
     static void writeClientCommandStreamingInputType(
-            TypeScriptWriter writer,
-            Symbol containerSymbol,
-            String typeName,
-            MemberShape streamingMember
+        TypeScriptWriter writer,
+        Symbol containerSymbol,
+        String typeName,
+        MemberShape streamingMember,
+        String commandName
     ) {
         String memberName = streamingMember.getMemberName();
         String optionalSuffix = streamingMember.isRequired() ? "" : "?";
@@ -149,8 +151,8 @@ public final class CodegenUtils {
                         writer.write("$1L$2L: $3T[$1S]|string|Uint8Array|Buffer;", memberName, optionalSuffix,
                                 containerSymbol);
         });
-        writer.writeDocs(String.format("This interface extends from `%1$s` interface. There are more parameters than"
-                + " `%2$s` defined in {@link %1$s}", containerSymbol.getName(), memberName));
+
+        writer.writeDocs("@public\n\nThe input for {@link " + commandName + "}.");
         writer.write("export interface $1L extends $1LType {}", typeName);
     }
 
@@ -160,23 +162,90 @@ public final class CodegenUtils {
      * stream to string, buffer or WHATWG stream API.
      */
     static void writeClientCommandStreamingOutputType(
-            TypeScriptWriter writer,
-            Symbol containerSymbol,
-            String typeName,
-            MemberShape streamingMember
+        TypeScriptWriter writer,
+        Symbol containerSymbol,
+        String typeName,
+        MemberShape streamingMember,
+        String commandName
     ) {
         String memberName = streamingMember.getMemberName();
-        String optionalSuffix = streamingMember.isRequired() ? "" : "?";
         writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.addImport("SdkStream", "__SdkStream", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.addImport("WithSdkStreamMixin", "__WithSdkStreamMixin", TypeScriptDependency.AWS_SDK_TYPES.packageName);
 
-
+        writer.writeDocs("@public\n\nThe output of {@link " + commandName + "}.");
         writer.write(
             "export interface $L extends __WithSdkStreamMixin<$T, $S>, __MetadataBearer {}",
             typeName,
             containerSymbol,
             memberName
+        );
+    }
+
+    static List<MemberShape> getBlobPayloadMembers(Model model, StructureShape shape) {
+        return shape.getAllMembers().values().stream()
+            .filter(memberShape -> {
+                Shape target = model.expectShape(memberShape.getTarget());
+                return target.isBlobShape()
+                    && memberShape.hasTrait(HttpPayloadTrait.class)
+                    && !target.hasTrait(StreamingTrait.class);
+            })
+            .collect(Collectors.toList());
+    }
+
+    static void writeClientCommandBlobPayloadInputType(
+        TypeScriptWriter writer,
+        Symbol containerSymbol,
+        String typeName,
+        MemberShape payloadMember,
+        String commandName
+    ) {
+        String memberName = payloadMember.getMemberName();
+        String optionalSuffix = payloadMember.isRequired() ? "" : "?";
+
+        writer.addImport("BlobTypes", null, TypeScriptDependency.AWS_SDK_TYPES);
+
+        writer.writeDocs("@public");
+        writer.openBlock("export type $LType = Omit<$T, $S> & {", "};",
+            typeName,
+            containerSymbol,
+            memberName,
+            () -> {
+                writer.write("$1L$2L: BlobTypes;", memberName, optionalSuffix);
+            }
+        );
+
+        writer.writeDocs("@public\n\nThe input for {@link " + commandName + "}.");
+        writer.write("export interface $1L extends $1LType {}", typeName);
+    }
+
+    static void writeClientCommandBlobPayloadOutputType(
+        TypeScriptWriter writer,
+        Symbol containerSymbol,
+        String typeName,
+        MemberShape payloadMember,
+        String commandName
+    ) {
+        String memberName = payloadMember.getMemberName();
+        String optionalSuffix = payloadMember.isRequired() ? "" : "?";
+
+        writer.addImport("Uint8ArrayBlobAdapter", null, TypeScriptDependency.UTIL_STREAM);
+        writer.addDependency(TypeScriptDependency.UTIL_STREAM);
+
+        writer.writeDocs("@public");
+        writer.openBlock("export type $LType = Omit<$T, $S> & {", "};",
+            typeName,
+            containerSymbol,
+            memberName,
+            () -> {
+                writer.write("$1L$2L: Uint8ArrayBlobAdapter;", memberName, optionalSuffix);
+            }
+        );
+
+        writer.writeDocs("@public\n\nThe output of {@link " + commandName + "}.");
+        writer.write(
+            "export interface $1L extends $1LType, __MetadataBearer {}",
+            typeName
         );
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -206,13 +206,16 @@ public final class CodegenUtils {
         writer.addImport("BlobTypes", null, TypeScriptDependency.AWS_SDK_TYPES);
 
         writer.writeDocs("@public");
-        writer.openBlock("export type $LType = Omit<$T, $S> & {", "};",
+        writer.write(
+            """
+            export type $LType = Omit<$T, $S> & {
+              $L: BlobTypes;
+            };
+            """,
             typeName,
             containerSymbol,
             memberName,
-            () -> {
-                writer.write("$1L$2L: BlobTypes;", memberName, optionalSuffix);
-            }
+            memberName + optionalSuffix
         );
 
         writer.writeDocs("@public\n\nThe input for {@link " + commandName + "}.");
@@ -233,13 +236,16 @@ public final class CodegenUtils {
         writer.addDependency(TypeScriptDependency.UTIL_STREAM);
 
         writer.writeDocs("@public");
-        writer.openBlock("export type $LType = Omit<$T, $S> & {", "};",
+        writer.write(
+            """
+            export type $LType = Omit<$T, $S> & {
+              $L: Uint8ArrayBlobAdapter;
+            };
+            """,
             typeName,
             containerSymbol,
             memberName,
-            () -> {
-                writer.write("$1L$2L: Uint8ArrayBlobAdapter;", memberName, optionalSuffix);
-            }
+            memberName + optionalSuffix
         );
 
         writer.writeDocs("@public\n\nThe output of {@link " + commandName + "}.");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -51,7 +51,6 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", true),
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
     UTIL_RETRY("dependencies", "@aws-sdk/util-retry", false),
-    UTIL_STREAM("dependencies", "@aws-sdk/util-stream", false),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
     MIDDLEWARE_ENDPOINTS_V2("dependencies", "@aws-sdk/middleware-endpoint", false),
     AWS_SDK_UTIL_ENDPOINTS("dependencies", "@aws-sdk/util-endpoints", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -51,6 +51,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", true),
     MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
     UTIL_RETRY("dependencies", "@aws-sdk/util-retry", false),
+    UTIL_STREAM("dependencies", "@aws-sdk/util-stream", false),
     MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
     MIDDLEWARE_ENDPOINTS_V2("dependencies", "@aws-sdk/middleware-endpoint", false),
     AWS_SDK_UTIL_ENDPOINTS("dependencies", "@aws-sdk/util-endpoints", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -200,7 +200,6 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
         generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
-        HttpProtocolGeneratorUtils.generateCollectBody(context);
         HttpProtocolGeneratorUtils.generateCollectBodyString(context);
         HttpProtocolGeneratorUtils.generateHttpBindingUtils(context);
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -248,25 +248,14 @@ public final class HttpProtocolGeneratorUtils {
     }
 
     /**
-     * Writes a response body stream collector. This function converts the low-level response body stream to
+     * Imports a response body stream collector. This function converts the low-level response body stream to
      * Uint8Array binary data.
      *
      * @param context The generation context.
      */
     static void generateCollectBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
-        writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.write("// Collect low-level response body stream to Uint8Array.");
-        writer.openBlock("const collectBody = (streamBody: any = new Uint8Array(), context: __SerdeContext): "
-                + "Promise<Uint8Array> => {", "};", () -> {
-            writer.openBlock("if (streamBody instanceof Uint8Array) {", "}", () -> {
-                writer.write("return Promise.resolve(streamBody);");
-            });
-            writer.write("return context.streamCollector(streamBody) || Promise.resolve(new Uint8Array());");
-        });
-
-        writer.write("");
+        writer.addImport("collectBody", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -248,25 +248,14 @@ public final class HttpProtocolGeneratorUtils {
     }
 
     /**
-     * Imports a response body stream collector. This function converts the low-level response body stream to
-     * Uint8Array binary data.
-     *
-     * @param context The generation context.
-     */
-    static void generateCollectBody(GenerationContext context) {
-        TypeScriptWriter writer = context.getWriter();
-        writer.addImport("collectBody", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
-    }
-
-    /**
      * Writes a function converting the low-level response body stream to utf-8 encoded string. It depends on
-     * response body stream collector {@link #generateCollectBody(GenerationContext)}.
+     * response body stream collector.
      *
      * @param context The generation context
      */
     static void generateCollectBodyString(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-
+        writer.addImport("collectBody", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
         writer.write("// Encode Uint8Array data into string with utf-8.");
         writer.write("const collectBodyString = (streamBody: any, context: __SerdeContext): Promise<string> => "

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -128,7 +128,6 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         generateDocumentBodyShapeSerializers(context, serializingDocumentShapes);
         generateDocumentBodyShapeDeserializers(context, deserializingDocumentShapes);
         HttpProtocolGeneratorUtils.generateMetadataDeserializer(context, getApplicationProtocol().getResponseType());
-        HttpProtocolGeneratorUtils.generateCollectBody(context);
         HttpProtocolGeneratorUtils.generateCollectBodyString(context);
 
         TypeScriptWriter writer = context.getWriter();

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-xml-stub.ts
@@ -13,7 +13,7 @@ const compareEquivalentXmlBodies = (
     ignoreDeclaration: true,
     parseTagValue: false,
     trimValues: false,
-    tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+    tagValueProcessor: (_: any, val: any) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
   };
 
   const parseXmlBody = (body: string) => {


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js-v3/issues/4786
https://github.com/aws/aws-sdk-js-v3/issues/4265


Blob types enhancements

- on the client input side, operation input members with type blob and trait HttpPayload have been widened from `Uint8Array` to `BlobTypes`, which contains common and runtime specific types.
 ```ts
export type BlobTypes = string | ArrayBuffer | ArrayBufferView | Uint8Array | RuntimeBlobTypes;

// example Node.js runtime additions
export type RuntimeBlobTypes = Readable | Buffer;
// browser additions
export type RuntimeBlobTypes = Blob | ReadableStream;
```

- on the client output side, operation output members with type blob and trait HttpPayload have been wrapped in `Uint8ArrayBlobAdapter`, which extends the `Uint8Array` native class and adds a convenient platform-specific way to convert to string. Example in the linked JSv3 PR https://github.com/aws/aws-sdk-js-v3/pull/4836.


----

This applies in general, but the user story is difficulty/inconvenience around non-streaming blob i/o, e.g. in Lambda invoke. Non-streaming blobs were treated uniformly as Uint8Array in input and output, but this does not cover the realistic use cases of _payload_ blobs.

```js
const lambda = new Lambda({
  region: "us-west-2",
});

const invoke = lambda.invoke({
  FunctionName: "echo",
  Payload: JSON.stringify({
    hello: "world",
  }), // without input widening, this would be a type error since string is not Uint8Array.
});

const payload = (await invoke).Payload;

console.log(JSON.parse(payload?.transformToString() ?? "{}")); // adapter adds the string conversion method, preserves the type extending Uint8Array.
```

- [x] JSv3 will write an e2e integration test suite for this.