### PR TITLE
fix: fix a typo in disableHostPrefix docstring

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -292,7 +292,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                             + "@internal");
             writer.write("runtime?: string;\n");
 
-            writer.writeDocs("Disable dyanamically changing the endpoint of the client based on the hostPrefix \n"
+            writer.writeDocs("Disable dynamically changing the endpoint of the client based on the hostPrefix \n"
                     + "trait of an operation.");
             writer.write("disableHostPrefix?: boolean;\n");
 


### PR DESCRIPTION
*Description of changes:*
There's a typo in `disableHostPrefix` docstring that found its way to many ([8.9k according to Github](https://github.com/search?q=%22Disable+dyanamically%22&type=code)) lines of code, including https://github.com/aws/aws-sdk-js-v3. This PR fixes the typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
