### PR TITLE
Use token for push permissions

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: secrets.PUSH_TOKEN
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
Adds a token to the checkout action so that the working repo is setup with the correct token and can perform authenticated git actions, including pushing a commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
