### PR TITLE
Set correct publishConfig directory

### DIFF
--- a/.changeset/late-poems-shop.md
+++ b/.changeset/late-poems-shop.md
@@ -1,0 +1,53 @@
+---
+"@smithy/service-client-documentation-generator": patch
+"@smithy/eventstream-serde-config-resolver": patch
+"@smithy/middleware-apply-body-checksum": patch
+"@smithy/service-error-classification": patch
+"@smithy/eventstream-serde-universal": patch
+"@smithy/chunked-blob-reader-native": patch
+"@smithy/util-defaults-mode-browser": patch
+"@smithy/eventstream-serde-browser": patch
+"@smithy/middleware-content-length": patch
+"@smithy/credential-provider-imds": patch
+"@smithy/util-body-length-browser": patch
+"@smithy/util-defaults-mode-node": patch
+"@smithy/eventstream-serde-node": patch
+"@smithy/shared-ini-file-loader": patch
+"@smithy/util-body-length-node": patch
+"@smithy/node-config-provider": patch
+"@smithy/util-config-provider": patch
+"@smithy/chunked-blob-reader": patch
+"@smithy/middleware-endpoint": patch
+"@smithy/querystring-builder": patch
+"@smithy/util-stream-browser": patch
+"@smithy/fetch-http-handler": patch
+"@smithy/invalid-dependency": patch
+"@smithy/querystring-parser": patch
+"@smithy/eventstream-codec": patch
+"@smithy/hash-blob-browser": patch
+"@smithy/node-http-handler": patch
+"@smithy/property-provider": patch
+"@smithy/util-hex-encoding": patch
+"@smithy/abort-controller": patch
+"@smithy/hash-stream-node": patch
+"@smithy/middleware-retry": patch
+"@smithy/middleware-serde": patch
+"@smithy/middleware-stack": patch
+"@smithy/util-buffer-from": patch
+"@smithy/util-stream-node": patch
+"@smithy/config-resolver": patch
+"@smithy/is-array-buffer": patch
+"@smithy/util-middleware": patch
+"@smithy/util-uri-escape": patch
+"@smithy/smithy-client": patch
+"@smithy/signature-v4": patch
+"@smithy/util-base64": patch
+"@smithy/util-waiter": patch
+"@smithy/url-parser": patch
+"@smithy/util-retry": patch
+"@smithy/hash-node": patch
+"@smithy/util-utf8": patch
+"@smithy/md5-js": patch
+---
+
+Set correct publishConfig directory

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -52,5 +52,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -51,5 +51,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -65,5 +65,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -74,5 +74,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -74,5 +74,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -59,5 +59,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -59,5 +59,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -52,5 +52,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -63,5 +63,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -60,5 +60,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -62,5 +62,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -54,5 +54,8 @@
     "type": "git",
     "url": "https://github.com/awslabs/smithy-typescript.git",
     "directory": "packages/client-documentation-generator"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -52,5 +52,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -65,5 +65,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -53,5 +53,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -65,5 +65,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -52,5 +52,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -56,5 +56,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -58,5 +58,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -55,5 +55,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -61,5 +61,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -63,5 +63,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -54,5 +54,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -54,5 +54,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -64,5 +64,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -57,5 +57,8 @@
   },
   "typedoc": {
     "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
   }
 }


### PR DESCRIPTION
Sets the correct publishConfig directory in each package.json so that the packed package is released to NPM after running `yarn stage-release`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
