### PR TITLE
Use push token on commit step

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -12,8 +12,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: secrets.PUSH_TOKEN
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -38,6 +36,7 @@ jobs:
         run: |
           git config --global user.email "github-aws-smithy-automation@amazon.com"
           git config --global user.name "Smithy Automation"
+          git remote set-url origin https://x-access-token:${{ secrets.PUSH_TOKEN }}@github.com/awslabs/smithy-typescript
           git add .
           git commit -m 'Verison NPM packages'
           git push


### PR DESCRIPTION
Moves using push token to commit step on NPM release workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
