### PR TITLE
Revert "Checkout main before push (#785)"

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -37,7 +37,6 @@ jobs:
           git config --global user.email "github-aws-smithy-automation@amazon.com"
           git config --global user.name "Smithy Automation"
           git remote set-url origin https://x-access-token:${{ secrets.PUSH_TOKEN }}@github.com/awslabs/smithy-typescript
-          git checkout main
           git add .
           git commit -m 'Verison NPM packages'
           git push


### PR DESCRIPTION
This reverts commit 9100ab1d433bcd71a94416b5343234118f3b409a.

Workflow is already on main. Do not need to checkout main again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
