### PR TITLE
Limit concurrency when staging release

### DIFF
--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -50,10 +50,15 @@ jobs:
           npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=SMITHY_PUBLISH_npmToken --query SecretString --output text --profile token)
           echo "::add-mask::$npm_token"
           echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
+      - name: Stage Release
+        id: stage
+        if: steps.token.outcome == 'success'
+        run: |
+          yarn stage-release --concurrency=1
       - name: Release
         id: release
         uses: changesets/action@v1
-        if: steps.token.outcome == 'success'
+        if: steps.stage.outcome == 'success'
         with:
           publish: yarn release
         env:

--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -33,10 +33,15 @@ jobs:
           npm_token=$(aws secretsmanager get-secret-value --region us-west-2 --secret-id=SMITHY_PUBLISH_npmToken --query SecretString --output text --profile token)
           echo "::add-mask::$npm_token"
           echo "NPM_TOKEN=$npm_token" >> $GITHUB_ENV
+      - name: Stage Release
+        id: stage
+        if: steps.token.outcome == 'success'
+        run: |
+          yarn stage-release --concurrency=1
       - name: Release
         id: release
         uses: changesets/action@v1
-        if: steps.token.outcome == 'success'
+        if: steps.stage.outcome == 'success'
         with:
           publish: yarn release
         env:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "turbo run lint",
     "format": "turbo run format --parallel",
     "stage-release": "turbo run stage-release",
-    "release": "yarn stage-release && yarn changeset publish"
+    "release": "yarn changeset publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the GitHub workflows to limit concurrency when staging the NPM packages for release.

`turbo run stage-release` and `turbo run build` will both be invoked with concurrency limited to `1` to avoid overwhelming the GitHub Action runner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
