### PR TITLE
Update codegen for package migration

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ApplicationProtocol.java
@@ -61,7 +61,7 @@ public final class ApplicationProtocol {
         return new ApplicationProtocol(
                 "http",
                 SymbolReference.builder()
-                        .symbol(createHttpSymbol(TypeScriptDependency.AWS_SDK_TYPES, "HttpHandlerOptions"))
+                        .symbol(createHttpSymbol(TypeScriptDependency.SMITHY_TYPES, "HttpHandlerOptions"))
                         .alias("__HttpHandlerOptions")
                         .build(),
                 SymbolReference.builder()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -71,7 +71,8 @@ public final class CodegenUtils {
         // If event stream trait exists, add corresponding serde context type to the intersection type.
         EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         if (eventStreamIndex.getInputInfo(operation).isPresent()) {
-            writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext", "@aws-sdk/types");
+            writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext",
+                TypeScriptDependency.SMITHY_TYPES);
             contextInterfaceList.add("__EventStreamSerdeContext");
         }
         return String.join(" & ", contextInterfaceList);
@@ -97,12 +98,12 @@ public final class CodegenUtils {
         EventStreamIndex eventStreamIndex = EventStreamIndex.of(model);
         if (eventStreamIndex.getOutputInfo(operation).isPresent()) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext",
-                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                    TypeScriptDependency.SMITHY_TYPES);
             contextInterfaceList.add("__EventStreamSerdeContext");
         }
         if (AddSdkStreamMixinDependency.hasStreamingBlobDeser(settings, model, operation)) {
             writer.addImport("SdkStreamSerdeContext", "__SdkStreamSerdeContext",
-                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                    TypeScriptDependency.SMITHY_TYPES);
             contextInterfaceList.add("__SdkStreamSerdeContext");
         }
         return String.join(" & ", contextInterfaceList);
@@ -169,9 +170,9 @@ public final class CodegenUtils {
         String commandName
     ) {
         String memberName = streamingMember.getMemberName();
-        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.addImport("SdkStream", "__SdkStream", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-        writer.addImport("WithSdkStreamMixin", "__WithSdkStreamMixin", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("SdkStream", "__SdkStream", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("WithSdkStreamMixin", "__WithSdkStreamMixin", TypeScriptDependency.SMITHY_TYPES);
 
         writer.writeDocs("@public\n\nThe output of {@link " + commandName + "}.");
         writer.write(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -122,11 +122,11 @@ final class CommandGenerator implements Runnable {
         writer.addImport(configType, configType, serviceSymbol.getNamespace());
         writer.addImport("ServiceInputTypes", "ServiceInputTypes", serviceSymbol.getNamespace());
         writer.addImport("ServiceOutputTypes", "ServiceOutputTypes", serviceSymbol.getNamespace());
-        writer.addImport("Command", "$Command", "@aws-sdk/smithy-client");
-        writer.addImport("FinalizeHandlerArguments", "FinalizeHandlerArguments", "@aws-sdk/types");
-        writer.addImport("Handler", "Handler", "@aws-sdk/types");
-        writer.addImport("HandlerExecutionContext", "HandlerExecutionContext", "@aws-sdk/types");
-        writer.addImport("MiddlewareStack", "MiddlewareStack", "@aws-sdk/types");
+        writer.addImport("Command", "$Command", TypeScriptDependency.AWS_SMITHY_CLIENT);
+        writer.addImport("FinalizeHandlerArguments", "FinalizeHandlerArguments", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("Handler", "Handler", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("HandlerExecutionContext", "HandlerExecutionContext", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("MiddlewareStack", "MiddlewareStack", TypeScriptDependency.SMITHY_TYPES);
 
         String name = symbol.getName();
 
@@ -236,7 +236,7 @@ final class CommandGenerator implements Runnable {
         if (!service.hasTrait(EndpointRuleSetTrait.class)) {
             return;
         }
-        writer.addImport("EndpointParameterInstructions", null, "@aws-sdk/middleware-endpoint");
+        writer.addImport("EndpointParameterInstructions", null, "@smithy/middleware-endpoint");
         writer.openBlock(
                 "public static getEndpointParameterInstructions(): EndpointParameterInstructions {", "}",
                 () -> {
@@ -302,7 +302,7 @@ final class CommandGenerator implements Runnable {
                 writer.addImport(
                         "getEndpointPlugin",
                         "getEndpointPlugin",
-                        "@aws-sdk/middleware-endpoint");
+                        "@smithy/middleware-endpoint");
                 writer.openBlock(
                         "this.middlewareStack.use(getEndpointPlugin(configuration, ",
                         "));",
@@ -407,7 +407,7 @@ final class CommandGenerator implements Runnable {
     private void writeOutputType(String typeName, Optional<StructureShape> outputShape, String commandName) {
         // Output types should always be MetadataBearers, possibly in addition
         // to a defined output shape.
-        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.SMITHY_TYPES);
         if (outputShape.isPresent()) {
             StructureShape output = outputShape.get();
             List<MemberShape> blobStreamingMembers = getBlobStreamingMembers(model, output);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java
@@ -229,7 +229,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
     private void initializeWriterIfNeeded() {
         if (writer == null) {
             context.getWriterDelegator().useFileWriter(createTestCaseFilename(), writer -> this.writer = writer);
-            writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
+            writer.addDependency(TypeScriptDependency.SMITHY_TYPES);
             writer.addDependency(TypeScriptDependency.SMITHY_TYPES);
             writer.addDependency(TypeScriptDependency.PROTOCOL_HTTP);
             // Add the template to each generated test.
@@ -494,7 +494,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         if (!explicitQueryValues.isEmpty()) {
             // Use buildQueryString like the fetch handler will.
             writer.addDependency(TypeScriptDependency.AWS_SDK_QUERYSTRING_BUILDER);
-            writer.addImport("buildQueryString", "buildQueryString", "@aws-sdk/querystring-builder");
+            writer.addImport("buildQueryString", "buildQueryString", "@smithy/querystring-builder");
 
             writer.write("const queryString = buildQueryString(r.query);");
             explicitQueryValues.forEach(explicitQueryValue ->
@@ -541,7 +541,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
         if (isClientTest) {
             writer.write("const utf8Encoder = client.config.utf8Encoder;");
         } else {
-            writer.addImport("toUtf8", "__utf8Encoder", "@aws-sdk/util-utf8");
+            writer.addImport("toUtf8", "__utf8Encoder", "@smithy/util-utf8");
             writer.write("const utf8Encoder = __utf8Encoder;");
         }
 
@@ -834,7 +834,7 @@ public final class HttpProtocolTestGenerator implements Runnable {
 
             writeParamAssertions(writer, payloadBinding, () -> {
                 // TODO: replace this with a collector from the server config once it's available
-                writer.addImport("streamCollector", "__streamCollector", "@aws-sdk/node-http-handler");
+                writer.addImport("streamCollector", "__streamCollector", "@smithy/node-http-handler");
                 writer.write("const comparableBlob = await __streamCollector(r[$S]);",
                         payloadBinding.get().getMemberName());
             });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -98,7 +98,7 @@ final class PaginationGenerator implements Runnable {
         writer.addImport(serviceSymbol.getName(), serviceSymbol.getName(), serviceSymbol.getNamespace());
 
         // Import Pagination types
-        writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
+        writer.addImport("Paginator", "Paginator", "@smithy/types");
         writer.addImport(paginationType, paginationType,
             Paths.get(".", PAGINATION_INTERFACE_FILE.replace(".ts", "")).toString());
 
@@ -116,7 +116,7 @@ final class PaginationGenerator implements Runnable {
             Symbol service,
             TypeScriptWriter writer
     ) {
-        writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@aws-sdk/types");
+        writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@smithy/types");
         writer.addImport(service.getName(), service.getName(), service.getNamespace());
 
         writer.writeDocs("@public")

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -45,25 +45,25 @@ final class RuntimeConfigGenerator {
             "requestHandler", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("NodeHttpHandler", "RequestHandler",
-                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
+                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.write("new RequestHandler(defaultConfigProvider)");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_HASH_NODE);
                 writer.addImport("Hash", "Hash",
-                        TypeScriptDependency.AWS_SDK_HASH_NODE.packageName);
+                        TypeScriptDependency.AWS_SDK_HASH_NODE);
                 writer.write("Hash.bind(null, \"sha256\")");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
-                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
+                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.write("streamCollector");
             }
     );
@@ -71,33 +71,31 @@ final class RuntimeConfigGenerator {
             "requestHandler", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("FetchHttpHandler", "RequestHandler",
-                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
+                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.write("new RequestHandler(defaultConfigProvider)");
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
-                writer.addImport("Sha256", "Sha256",
-                        TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER.packageName);
+                writer.addImport("Sha256", "Sha256", TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
                 writer.write("Sha256");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.addImport("calculateBodyLength", "calculateBodyLength",
-                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER.packageName);
+                        TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.write("streamCollector");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
-                writer.addImport("Sha256", "Sha256",
-                        TypeScriptDependency.AWS_CRYPTO_SHA256_JS.packageName);
+                writer.addImport("Sha256", "Sha256", TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
                 writer.write("Sha256");
             }
     );
@@ -105,13 +103,13 @@ final class RuntimeConfigGenerator {
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.addImport("fromBase64", "fromBase64",
-                        TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.write("fromBase64");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.addImport("toBase64", "toBase64",
-                        TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.write("toBase64");
             },
             "disableHostPrefix", writer -> {
@@ -120,19 +118,19 @@ final class RuntimeConfigGenerator {
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER);
                 writer.addImport("parseUrl", "parseUrl",
-                        TypeScriptDependency.AWS_SDK_URL_PARSER.packageName);
+                        TypeScriptDependency.AWS_SDK_URL_PARSER);
                 writer.write("parseUrl");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.addImport("fromUtf8", "fromUtf8",
-                        TypeScriptDependency.AWS_SDK_UTIL_UTF8.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.write("fromUtf8");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.addImport("toUtf8", "toUtf8",
-                        TypeScriptDependency.AWS_SDK_UTIL_UTF8.packageName);
+                        TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.write("toUtf8");
             }
     );

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -206,8 +206,8 @@ final class ServerGenerator {
         writer.addImport("InternalFailureException", "__InternalFailureException", "@aws-smithy/server-common");
         writer.addImport("SerializationException", "__SerializationException", "@aws-smithy/server-common");
         writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", "@aws-smithy/server-common");
-        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
-        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP);
         writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
     }
@@ -272,12 +272,12 @@ final class ServerGenerator {
 
     private static void writeSerdeContextBase(TypeScriptWriter writer) {
         writer.addImport("ServerSerdeContext", "__ServerSerdeContext", "@aws-smithy/server-common");
-        writer.addImport("NodeHttpHandler", null, "@aws-sdk/node-http-handler");
-        writer.addImport("streamCollector", null, "@aws-sdk/node-http-handler");
-        writer.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
-        writer.addImport("toBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64.packageName);
-        writer.addImport("fromUtf8", null, "@aws-sdk/util-utf8");
-        writer.addImport("toUtf8", null, "@aws-sdk/util-utf8");
+        writer.addImport("NodeHttpHandler", null, "@smithy/node-http-handler");
+        writer.addImport("streamCollector", null, "@smithy/node-http-handler");
+        writer.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64);
+        writer.addImport("toBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64);
+        writer.addImport("fromUtf8", null, "@smithy/util-utf8");
+        writer.addImport("toUtf8", null, "@smithy/util-utf8");
 
         writer.openBlock("const serdeContextBase = {", "};", () -> {
             writer.write("base64Encoder: toBase64,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -124,7 +124,7 @@ final class ServiceAggregatedClientGenerator implements Runnable {
             aggregateClientName, serviceSymbol, aggregateClientName
         );
 
-        writer.addImport("createAggregatedClient", null, "@aws-sdk/smithy-client");
+        writer.addImport("createAggregatedClient", null, "@smithy/smithy-client");
         writer.write("createAggregatedClient(commands, $L);", aggregateClientName);
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -97,7 +97,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
 
     @Override
     public void run() {
-        writer.addImport("Client", "__Client", "@aws-sdk/smithy-client");
+        writer.addImport("Client", "__Client", TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.write("export { __Client }\n");
         writer.addImport("getRuntimeConfig", "__getRuntimeConfig",
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeConfig").toString());
@@ -113,7 +113,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
         writeInputOutputTypeUnion("ServiceOutputTypes", writer,
                 operationSymbol -> operationSymbol.getProperty("outputType", Symbol.class), writer -> {
             // Use a MetadataBearer if an operation doesn't define output.
-            writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+            writer.addImport("MetadataBearer", "__MetadataBearer", TypeScriptDependency.AWS_SDK_TYPES);
             writer.write("| __MetadataBearer");
         });
 
@@ -152,8 +152,8 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     }
 
     private void generateConfig() {
-        writer.addImport("SmithyConfiguration", "__SmithyConfiguration", "@aws-sdk/smithy-client");
-        writer.addImport("SmithyResolvedConfiguration", "__SmithyResolvedConfiguration", "@aws-sdk/smithy-client");
+        writer.addImport("SmithyConfiguration", "__SmithyConfiguration", "@smithy/smithy-client");
+        writer.addImport("SmithyResolvedConfiguration", "__SmithyResolvedConfiguration", "@smithy/smithy-client");
 
         // Hook for intercepting the client configuration.
         writer.pushState(CLIENT_CONFIG_SECTION);
@@ -238,27 +238,27 @@ final class ServiceBareBonesClientGenerator implements Runnable {
             .openBlock("export interface ClientDefaults\n"
                          + "  extends Partial<__SmithyResolvedConfiguration<$T>> {", "}",
                 applicationProtocol.getOptionsType(), () -> {
-            writer.addImport("HttpHandler", "__HttpHandler", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+            writer.addImport("HttpHandler", "__HttpHandler", TypeScriptDependency.PROTOCOL_HTTP);
             writer.writeDocs("The HTTP handler to use. Fetch in browser and Https in Nodejs.");
             writer.write("requestHandler?: __HttpHandler;\n");
 
-            writer.addImport("Hash", "__Hash", "@aws-sdk/types");
-            writer.addImport("HashConstructor", "__HashConstructor", "@aws-sdk/types");
+            writer.addImport("Hash", "__Hash", "@smithy/types");
+            writer.addImport("HashConstructor", "__HashConstructor", "@smithy/types");
 
-            writer.addImport("Checksum", "__Checksum", "@aws-sdk/types");
-            writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@aws-sdk/types");
-            writer.writeDocs("A constructor for a class implementing the {@link @aws-sdk/types#ChecksumConstructor} "
+            writer.addImport("Checksum", "__Checksum", "@smithy/types");
+            writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@smithy/types");
+            writer.writeDocs("A constructor for a class implementing the {@link @smithy/types#ChecksumConstructor} "
                             + "interface \n"
                             + "that computes the SHA-256 HMAC or checksum of a string or binary buffer.\n"
                             + "@internal");
             writer.write("sha256?: __ChecksumConstructor | __HashConstructor;\n");
 
-            writer.addImport("UrlParser", "__UrlParser", "@aws-sdk/types");
+            writer.addImport("UrlParser", "__UrlParser", "@smithy/types");
             writer.writeDocs("The function that will be used to convert strings into HTTP endpoints.\n"
                              + "@internal");
             writer.write("urlParser?: __UrlParser;\n");
 
-            writer.addImport("BodyLengthCalculator", "__BodyLengthCalculator", "@aws-sdk/types");
+            writer.addImport("BodyLengthCalculator", "__BodyLengthCalculator", "@smithy/types");
             writer.writeDocs("A function that can calculate the length of a request body.\n"
                             + "@internal");
             writer.write("bodyLengthChecker?: __BodyLengthCalculator;\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -248,7 +248,7 @@ final class StructureGenerator implements Runnable {
      * The following TypeScript is generated:
      *
      * <pre>{@code
-     * import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
+     * import { ExceptionOptionType as __ExceptionOptionType } from "@smithy/smithy-client";
      * import { FooServiceException as __BaseException } from "./FooServiceException";
      * // In server SDK:
      * // import { ServiceException as __BaseException } from "@aws-smithy/server-common";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -157,7 +157,7 @@ final class StructuredMemberWriter {
             writer.writeDocs("@internal");
         }
         writer.addImport("ExceptionOptionType", "__ExceptionOptionType",
-                TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.openBlock("constructor(opts: __ExceptionOptionType<$L, __BaseException>) {", symbol.getName());
         writer.openBlock("super({", "});", () -> {
             writer.write("name: $S,", shape.getId().getName());
@@ -178,7 +178,7 @@ final class StructuredMemberWriter {
      * Writes SENSITIVE_STRING to hide the value of sensitive members.
      */
     private void writeSensitiveString(TypeScriptWriter writer) {
-        writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@aws-sdk/smithy-client");
+        writer.addImport("SENSITIVE_STRING", "SENSITIVE_STRING", "@smithy/smithy-client");
         writer.write("SENSITIVE_STRING");
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
@@ -249,7 +249,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
         Symbol.Builder builder = createSymbolBuilder(shape, "__DocumentType");
         Symbol importSymbol = Symbol.builder()
                 .name("DocumentType")
-                .namespace(TypeScriptDependency.AWS_SDK_TYPES.packageName, "/")
+                .namespace(TypeScriptDependency.SMITHY_TYPES.packageName, "/")
                 .build();
         SymbolReference reference = SymbolReference.builder()
                 .symbol(importSymbol)
@@ -325,7 +325,7 @@ final class SymbolVisitor implements SymbolProvider, ShapeVisitor<Symbol> {
     private Symbol.Builder addSmithyUseImport(Symbol.Builder builder, String name, String as) {
         Symbol importSymbol = Symbol.builder()
                 .name(name)
-                .namespace("@aws-sdk/smithy-client", "/")
+                .namespace("@smithy/smithy-client", "/")
                 .build();
         SymbolReference reference = SymbolReference.builder()
                 .symbol(importSymbol)

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -39,82 +39,82 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public enum TypeScriptDependency implements SymbolDependencyContainer {
 
-    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@aws-sdk/service-client-documentation-generator", true),
+    AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", "^1.0.1", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
-    SMITHY_TYPES("dependencies", "@smithy/types", "^1.0.0", true),
-    AWS_SMITHY_CLIENT("dependencies", "@aws-sdk/smithy-client", true),
-    INVALID_DEPENDENCY("dependencies", "@aws-sdk/invalid-dependency", true),
-    CONFIG_RESOLVER("dependencies", "@aws-sdk/config-resolver", true),
+    SMITHY_TYPES("dependencies", "@smithy/types", "^1.1.0", true),
+    AWS_SMITHY_CLIENT("dependencies", "@smithy/smithy-client", "^1.0.3", true),
+    INVALID_DEPENDENCY("dependencies", "@smithy/invalid-dependency", "^1.0.1", true),
+    CONFIG_RESOLVER("dependencies", "@smithy/config-resolver", "^1.0.1", true),
     TYPES_NODE("devDependencies", "@types/node", "^14.14.31", true),
 
-    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@aws-sdk/middleware-content-length", true),
-    MIDDLEWARE_SERDE("dependencies", "@aws-sdk/middleware-serde", true),
-    MIDDLEWARE_RETRY("dependencies", "@aws-sdk/middleware-retry", true),
-    UTIL_RETRY("dependencies", "@aws-sdk/util-retry", false),
-    MIDDLEWARE_STACK("dependencies", "@aws-sdk/middleware-stack", true),
-    MIDDLEWARE_ENDPOINTS_V2("dependencies", "@aws-sdk/middleware-endpoint", false),
+    MIDDLEWARE_CONTENT_LENGTH("dependencies", "@smithy/middleware-content-length", "^1.0.1", true),
+    MIDDLEWARE_SERDE("dependencies", "@smithy/middleware-serde", "^1.0.1", true),
+    MIDDLEWARE_RETRY("dependencies", "@smithy/middleware-retry", "^1.0.2", true),
+    UTIL_RETRY("dependencies", "@smithy/util-retry", "^1.0.2", false),
+    MIDDLEWARE_STACK("dependencies", "@smithy/middleware-stack", "^1.0.1", true),
+    MIDDLEWARE_ENDPOINTS_V2("dependencies", "@smithy/middleware-endpoint", "^1.0.1", false),
     AWS_SDK_UTIL_ENDPOINTS("dependencies", "@aws-sdk/util-endpoints", false),
 
     AWS_CRYPTO_SHA256_BROWSER("dependencies", "@aws-crypto/sha256-browser", "3.0.0", true),
     AWS_CRYPTO_SHA256_JS("dependencies", "@aws-crypto/sha256-js", "3.0.0", true),
-    AWS_SDK_HASH_NODE("dependencies", "@aws-sdk/hash-node", true),
+    AWS_SDK_HASH_NODE("dependencies", "@smithy/hash-node", "^1.0.1", true),
 
-    AWS_SDK_URL_PARSER("dependencies", "@aws-sdk/url-parser", true),
+    AWS_SDK_URL_PARSER("dependencies", "@smithy/url-parser", "^1.0.1", true),
 
-    @Deprecated AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@aws-sdk/util-base64-browser", false),
-    @Deprecated AWS_SDK_UTIL_BASE64_NODE("dependencies", "@aws-sdk/util-base64-node", false),
-    AWS_SDK_UTIL_BASE64("dependencies", "@aws-sdk/util-base64", true),
+    @Deprecated AWS_SDK_UTIL_BASE64_BROWSER("dependencies", "@smithy/util-base64-browser", "^1.0.1", false),
+    @Deprecated AWS_SDK_UTIL_BASE64_NODE("dependencies", "@smithy/util-base64-node", "^1.0.1", false),
+    AWS_SDK_UTIL_BASE64("dependencies", "@smithy/util-base64", "^1.0.1", true),
 
-    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@aws-sdk/util-body-length-browser", true),
-    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@aws-sdk/util-body-length-node", true),
+    AWS_SDK_UTIL_BODY_LENGTH_BROWSER("dependencies", "@smithy/util-body-length-browser", "^1.0.1", true),
+    AWS_SDK_UTIL_BODY_LENGTH_NODE("dependencies", "@smithy/util-body-length-node", "^1.0.1", true),
 
-    AWS_SDK_UTIL_UTF8("dependencies", "@aws-sdk/util-utf8", true),
+    AWS_SDK_UTIL_UTF8("dependencies", "@smithy/util-utf8", "^1.0.1", true),
 
-    AWS_SDK_UTIL_WAITERS("dependencies", "@aws-sdk/util-waiter",  false),
+    AWS_SDK_UTIL_WAITERS("dependencies", "@smithy/util-waiter",  "^1.0.1", false),
 
-    AWS_SDK_UTIL_DEFAULTS_MODE_NODE("dependencies", "@aws-sdk/util-defaults-mode-node", true),
-    AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER("dependencies", "@aws-sdk/util-defaults-mode-browser", true),
+    AWS_SDK_UTIL_DEFAULTS_MODE_NODE("dependencies", "@smithy/util-defaults-mode-node", "^1.0.1", true),
+    AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER("dependencies", "@smithy/util-defaults-mode-browser", "^1.0.1", true),
 
-    NODE_CONFIG_PROVIDER("dependencies", "@aws-sdk/node-config-provider", false),
+    NODE_CONFIG_PROVIDER("dependencies", "@smithy/node-config-provider", "^1.0.1", false),
 
     // Conditionally added when httpChecksumRequired trait exists
-    MD5_BROWSER("dependencies", "@aws-sdk/md5-js", false),
-    STREAM_HASHER_NODE("dependencies", "@aws-sdk/hash-stream-node", false),
-    STREAM_HASHER_BROWSER("dependencies", "@aws-sdk/hash-blob-browser", false),
-    BODY_CHECKSUM("dependencies", "@aws-sdk/middleware-apply-body-checksum", false),
+    MD5_BROWSER("dependencies", "@smithy/md5-js", "^1.0.1", false),
+    STREAM_HASHER_NODE("dependencies", "@smithy/hash-stream-node", "^1.0.1", false),
+    STREAM_HASHER_BROWSER("dependencies", "@smithy/hash-blob-browser", "^1.0.1", false),
+    BODY_CHECKSUM("dependencies", "@smithy/middleware-apply-body-checksum", "^1.0.1", false),
 
     // Conditionally added when using an HTTP application protocol.
-    PROTOCOL_HTTP("dependencies", "@smithy/protocol-http", "^1.0.1", false),
-    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@aws-sdk/fetch-http-handler", false),
-    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@aws-sdk/node-http-handler", false),
+    PROTOCOL_HTTP("dependencies", "@smithy/protocol-http", "^1.1.0", false),
+    AWS_SDK_FETCH_HTTP_HANDLER("dependencies", "@smithy/fetch-http-handler", "^1.0.1", false),
+    AWS_SDK_NODE_HTTP_HANDLER("dependencies", "@smithy/node-http-handler", "^1.0.2", false),
 
     // Conditionally added when setting the auth middleware.
-    AWS_SDK_UTIL_MIDDLEWARE("dependencies", "@aws-sdk/util-middleware", false),
+    AWS_SDK_UTIL_MIDDLEWARE("dependencies", "@smithy/util-middleware", "^1.0.1", false),
 
     // Conditionally added if a event stream shape is found anywhere in the model
-    AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@aws-sdk/eventstream-serde-config-resolver",
-            false),
-    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@aws-sdk/eventstream-serde-node", false),
-    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@aws-sdk/eventstream-serde-browser", false),
+    AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER("dependencies", "@smithy/eventstream-serde-config-resolver",
+        "^1.0.1", false),
+    AWS_SDK_EVENTSTREAM_SERDE_NODE("dependencies", "@smithy/eventstream-serde-node", "^1.0.1", false),
+    AWS_SDK_EVENTSTREAM_SERDE_BROWSER("dependencies", "@smithy/eventstream-serde-browser", "^1.0.1", false),
 
     // Conditionally added if a big decimal shape is found in a model.
     BIG_JS("dependencies", "big.js", "^6.0.0", false),
     TYPES_BIG_JS("devDependencies", "@types/big.js", "^6.0.0", false),
 
     // Conditionally added when interacting with specific protocol test bodyMediaType values.
-    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@aws-sdk/querystring-builder", false),
+    AWS_SDK_QUERYSTRING_BUILDER("dependencies", "@smithy/querystring-builder", "^1.0.1", false),
 
     // Conditionally added when XML parser needs to be used.
     XML_PARSER("dependencies", "fast-xml-parser", "4.2.5", false),
     HTML_ENTITIES("dependencies", "entities", "2.2.0", false),
 
     // Conditionally added when streaming blob response payload exists.
-    @Deprecated UTIL_STREAM_NODE("dependencies", "@aws-sdk/util-stream-node", false),
-    @Deprecated UTIL_STREAM_BROWSER("dependencies", "@aws-sdk/util-stream-browser", false),
-    UTIL_STREAM("dependencies", "@aws-sdk/util-stream", false),
+    @Deprecated UTIL_STREAM_NODE("dependencies", "@smithy/util-stream-node", "^1.0.1", false),
+    @Deprecated UTIL_STREAM_BROWSER("dependencies", "@smithy/util-stream-browser", "^1.0.1", false),
+    UTIL_STREAM("dependencies", "@smithy/util-stream", "^1.0.1", false),
 
     // Server dependency for SSDKs
-    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.0-alpha.10", false);
+    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.1-alpha.10", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -69,7 +69,7 @@ public final class EndpointsV2Generator implements Runnable {
         this.delegator.useFileWriter(
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_PARAMETERS_FILE).toString(),
             writer -> {
-                writer.addImport("EndpointParameters", "__EndpointParameters", "@aws-sdk/types");
+                writer.addImport("EndpointParameters", "__EndpointParameters", "@smithy/types");
                 writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
 
                 writer.openBlock(
@@ -140,12 +140,12 @@ public final class EndpointsV2Generator implements Runnable {
         this.delegator.useFileWriter(
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_RESOLVER_FILE).toString(),
             writer -> {
-                writer.addImport("EndpointV2", null, "@aws-sdk/types");
-                writer.addImport("Logger", null, "@aws-sdk/types");
+                writer.addImport("EndpointV2", null, TypeScriptDependency.SMITHY_TYPES);
+                writer.addImport("Logger", null, TypeScriptDependency.SMITHY_TYPES);
 
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
-                writer.addImport("EndpointParams", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS.packageName);
-                writer.addImport("resolveEndpoint", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS.packageName);
+                writer.addImport("EndpointParams", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
+                writer.addImport("resolveEndpoint", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
                 writer.addImport("EndpointParameters", null,
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER,
                         ENDPOINT_PARAMETERS_FILE.replace(".ts", "")).toString());
@@ -184,7 +184,7 @@ public final class EndpointsV2Generator implements Runnable {
         this.delegator.useFileWriter(
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_RULESET_FILE).toString(),
             writer -> {
-                writer.addImport("RuleSetObject", null, "@aws-sdk/util-endpoints");
+                writer.addImport("RuleSetObject", null, TypeScriptDependency.SMITHY_TYPES);
                 writer.openBlock(
                     "export const ruleSet: RuleSetObject = ",
                     ";",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -67,7 +67,7 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
 
             if (localKey.equals("endpoint")) {
                 writer.addImport("Endpoint", null, TypeScriptDependency.SMITHY_TYPES);
-                writer.addImport("EndpointV2", null, "@aws-sdk/types");
+                writer.addImport("EndpointV2", null, "@smithy/types");
                 writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
             }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddBaseServiceExceptionClass.java
@@ -64,9 +64,9 @@ public final class AddBaseServiceExceptionClass implements TypeScriptIntegration
                     Paths.get(CodegenUtils.SOURCE_FOLDER, "models", serviceExceptionName + ".ts").toString(),
                     writer -> {
                             writer.addImport("ServiceException", "__ServiceException",
-                                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                                    TypeScriptDependency.AWS_SMITHY_CLIENT);
                             writer.addImport("ServiceExceptionOptions", "__ServiceExceptionOptions",
-                                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                                    TypeScriptDependency.AWS_SMITHY_CLIENT);
                             // Export ServiceException information to allow
                             //      documentation inheritance to consume their types
                             writer.write("export { __ServiceException, __ServiceExceptionOptions }\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
@@ -54,17 +54,17 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
         }
 
         writer.addImport("Readable", "Readable", "stream");
-        writer.addImport("StreamHasher", "__StreamHasher", "@aws-sdk/types");
+        writer.addImport("StreamHasher", "__StreamHasher", "@smithy/types");
         writer.writeDocs("A function that, given a hash constructor and a stream, calculates the \n"
                 + "hash of the streamed value.\n"
                 + "@internal");
         writer.write("streamHasher?: __StreamHasher<Readable> | __StreamHasher<Blob>;\n");
 
-        writer.addImport("Hash", "__Hash", "@aws-sdk/types");
-        writer.addImport("HashConstructor", "__HashConstructor", "@aws-sdk/types");
+        writer.addImport("Hash", "__Hash", "@smithy/types");
+        writer.addImport("HashConstructor", "__HashConstructor", "@smithy/types");
 
-        writer.addImport("Checksum", "__Checksum", "@aws-sdk/types");
-        writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@aws-sdk/types");
+        writer.addImport("Checksum", "__Checksum", "@smithy/types");
+        writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@smithy/types");
         writer.writeDocs("A constructor for a class implementing the {@link __checksum} interface \n"
                 + "that computes MD5 hashes.\n"
                 + "@internal");
@@ -88,15 +88,15 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                     "streamHasher", writer -> {
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_NODE);
                         writer.addImport("fileStreamHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_NODE.packageName);
+                                TypeScriptDependency.STREAM_HASHER_NODE);
                         writer.write("streamHasher");
                     },
                     "md5", writer -> {
-                            writer.addDependency(TypeScriptDependency.AWS_SDK_TYPES);
+                            writer.addDependency(TypeScriptDependency.SMITHY_TYPES);
                             writer.addImport("HashConstructor", "__HashConstructor",
-                                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                                    TypeScriptDependency.SMITHY_TYPES);
                             writer.addImport("ChecksumConstructor", "__ChecksumConstructor",
-                                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                                    TypeScriptDependency.SMITHY_TYPES);
                             writer.write("Hash.bind(null, \"md5\")");
                     });
             case BROWSER:
@@ -104,12 +104,12 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                     "streamHasher", writer -> {
                         writer.addDependency(TypeScriptDependency.STREAM_HASHER_BROWSER);
                         writer.addImport("blobHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_BROWSER.packageName);
+                                TypeScriptDependency.STREAM_HASHER_BROWSER);
                         writer.write("streamHasher");
                     },
                     "md5", writer -> {
                         writer.addDependency(TypeScriptDependency.MD5_BROWSER);
-                        writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER.packageName);
+                        writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER);
                         writer.write("Md5");
                     });
             default:

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
@@ -58,7 +58,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             TypeScriptWriter writer
     ) {
         writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
-        writer.addImport("Logger", "__Logger", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Logger", "__Logger", TypeScriptDependency.SMITHY_TYPES);
 
         writer.writeDocs("Value for how many times a request will be made at most in case of retry.")
                 .write("maxAttempts?: number | __Provider<number>;\n");
@@ -79,7 +79,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             case SHARED:
                 return MapUtils.of(
                         "logger", writer -> {
-                            writer.addImport("NoOpLogger", null, "@aws-sdk/smithy-client");
+                            writer.addImport("NoOpLogger", null, "@smithy/smithy-client");
                             writer.write("new NoOpLogger()");
                         }
                 );
@@ -88,13 +88,13 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.UTIL_RETRY);
                             writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS",
-                                    TypeScriptDependency.UTIL_RETRY.packageName);
+                                    TypeScriptDependency.UTIL_RETRY);
                             writer.write("DEFAULT_MAX_ATTEMPTS");
                         },
                         "retryMode", writer -> {
                             writer.addDependency(TypeScriptDependency.UTIL_RETRY);
                             writer.addImport("DEFAULT_RETRY_MODE", "DEFAULT_RETRY_MODE",
-                                    TypeScriptDependency.UTIL_RETRY.packageName);
+                                    TypeScriptDependency.UTIL_RETRY);
                             writer.write(
                                     "(async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE)");
                         }
@@ -104,20 +104,20 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName);
+                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("NODE_MAX_ATTEMPT_CONFIG_OPTIONS", "NODE_MAX_ATTEMPT_CONFIG_OPTIONS",
-                                    TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                                    TypeScriptDependency.MIDDLEWARE_RETRY);
                             writer.write("loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS)");
                         },
                         "retryMode", writer -> {
                             writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("loadConfig", "loadNodeConfig",
-                                    TypeScriptDependency.NODE_CONFIG_PROVIDER.packageName);
+                                    TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
                             writer.addImport("NODE_RETRY_MODE_CONFIG_OPTIONS", "NODE_RETRY_MODE_CONFIG_OPTIONS",
-                                    TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
+                                    TypeScriptDependency.MIDDLEWARE_RETRY);
                             writer.addImport("DEFAULT_RETRY_MODE", "DEFAULT_RETRY_MODE",
-                                    TypeScriptDependency.UTIL_RETRY.packageName);
+                                    TypeScriptDependency.UTIL_RETRY);
                             writer.openBlock("loadNodeConfig({", "})", () -> {
                                 writer.write("...NODE_RETRY_MODE_CONFIG_OPTIONS,");
                                 writer.write("default: async () => "

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddDefaultsModeDependency.java
@@ -37,9 +37,9 @@ public class AddDefaultsModeDependency implements TypeScriptIntegration {
         // Dependencies used in the default runtime config template.
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_BROWSER);
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_DEFAULTS_MODE_NODE);
-        writer.addImport("DefaultsMode", "__DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+        writer.addImport("DefaultsMode", "__DefaultsMode", TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
-        writer.writeDocs("The {@link @aws-sdk/smithy-client#DefaultsMode} that "
+        writer.writeDocs("The {@link @smithy/smithy-client#DefaultsMode} that "
                 + "will be used to determine how certain default configuration "
                 + "options are resolved in the SDK.");
         writer.write("defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -64,7 +64,7 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
 
         writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_CONFIG_RESOLVER);
         writer.addImport("EventStreamSerdeProvider", "__EventStreamSerdeProvider",
-                TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                TypeScriptDependency.SMITHY_TYPES);
         writer.writeDocs("The function that provides necessary utilities for generating and parsing event stream");
         writer.write("eventStreamSerdeProvider?: __EventStreamSerdeProvider;\n");
     }
@@ -84,14 +84,14 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
-                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE.packageName);
+                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
                     writer.write("eventStreamSerdeProvider");
                 });
             case BROWSER:
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                     writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
-                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER.packageName);
+                            TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                     writer.write("eventStreamSerdeProvider");
                 });
             default:

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
@@ -55,7 +55,7 @@ public final class AddSdkStreamMixinDependency implements TypeScriptIntegration 
         }
 
         writer.addImport("SdkStreamMixinInjector", "__SdkStreamMixinInjector",
-                TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                TypeScriptDependency.SMITHY_TYPES);
         writer.writeDocs("The internal function that inject utilities to runtime-specific stream to help users"
                 + " consume the data\n@internal");
         writer.write("sdkStreamMixin?: __SdkStreamMixinInjector;\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -144,43 +144,43 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String booleanShape(BooleanShape shape) {
-        context.getWriter().addImport("expectBoolean", "__expectBoolean", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectBoolean", "__expectBoolean", "@smithy/smithy-client");
         return "__expectBoolean(" + dataSource + ")";
     }
 
     @Override
     public String byteShape(ByteShape shape) {
-        context.getWriter().addImport("expectByte", "__expectByte", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectByte", "__expectByte", "@smithy/smithy-client");
         return "__expectByte(" + dataSource + ")";
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        context.getWriter().addImport("expectShort", "__expectShort", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectShort", "__expectShort", "@smithy/smithy-client");
         return "__expectShort(" + dataSource + ")";
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        context.getWriter().addImport("expectInt32", "__expectInt32", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectInt32", "__expectInt32", "@smithy/smithy-client");
         return "__expectInt32(" + dataSource + ")";
     }
 
     @Override
     public String longShape(LongShape shape) {
-        context.getWriter().addImport("expectLong", "__expectLong", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectLong", "__expectLong", "@smithy/smithy-client");
         return "__expectLong(" + dataSource + ")";
     }
 
     @Override
     public String floatShape(FloatShape shape) {
-        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32", "@smithy/smithy-client");
         return "__limitedParseFloat32(" + dataSource + ")";
     }
 
     @Override
     public String doubleShape(DoubleShape shape) {
-        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble", "@smithy/smithy-client");
         return "__limitedParseDouble(" + dataSource + ")";
     }
 
@@ -277,7 +277,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public final String unionShape(UnionShape shape) {
-        context.getWriter().addImport("expectUnion", "__expectUnion", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectUnion", "__expectUnion", "@smithy/smithy-client");
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -170,7 +170,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     }
 
     private String handleFloat() {
-        context.getWriter().addImport("serializeFloat", "__serializeFloat", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("serializeFloat", "__serializeFloat", "@smithy/smithy-client");
         return "__serializeFloat(" + dataSource + ")";
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -189,7 +189,7 @@ public class EventStreamGenerator {
         Symbol eventsUnionSymbol = getSymbol(context, eventsUnion);
         TypeScriptWriter writer = context.getWriter();
         Model model = context.getModel();
-        writer.addImport("Message", "__Message", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Message", "__Message", TypeScriptDependency.SMITHY_TYPES);
 
         writer.writeDocs(methodLongName);
         writer.openBlock("const $L = (\n"
@@ -224,7 +224,7 @@ public class EventStreamGenerator {
         String contextType = "__SerdeContext";
         if (eventsUnion.hasTrait(StreamingTrait.class)) {
             writer.addImport("EventStreamSerdeContext", "__EventStreamSerdeContext",
-                    TypeScriptDependency.AWS_SDK_TYPES.packageName);
+                    TypeScriptDependency.SMITHY_TYPES);
             contextType += " & __EventStreamSerdeContext";
         }
         return contextType;
@@ -246,7 +246,7 @@ public class EventStreamGenerator {
         String methodName = getEventSerFunctionName(context, event);
         Symbol symbol = getSymbol(context, event);
         TypeScriptWriter writer = context.getWriter();
-        writer.addImport("MessageHeaders", "__MessageHeaders", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("MessageHeaders", "__MessageHeaders", TypeScriptDependency.SMITHY_TYPES);
         writer.openBlock("const $L = (\n"
                 + "  input: $T,\n"
                 + "  context: __SerdeContext\n"
@@ -521,7 +521,7 @@ public class EventStreamGenerator {
                 String deserFunctionName = ProtocolGenerator.getDeserFunctionShortName(symbol);
                 boolean mayElide = serdeElisionEnabled && serdeElisionIndex.mayElide(payloadShape);
                 if (mayElide) {
-                    writer.addImport("_json", null, "@aws-sdk/smithy-client");
+                    writer.addImport("_json", null, "@smithy/smithy-client");
                     writer.write("contents.$L = $L(data);", payloadMemberName, "_json");
                 } else {
                     writer.write("contents.$L = $L(data, context);", payloadMemberName, deserFunctionName);
@@ -534,7 +534,7 @@ public class EventStreamGenerator {
             String deserFunctionName = ProtocolGenerator.getDeserFunctionShortName(symbol);
             boolean mayElide = serdeElisionEnabled && serdeElisionIndex.mayElide(event);
             if (mayElide) {
-                writer.addImport("_json", null, "@aws-sdk/smithy-client");
+                writer.addImport("_json", null, "@smithy/smithy-client");
                 writer.write("Object.assign(contents, $L(data));", "_json");
             } else {
                 writer.write("Object.assign(contents, $L(data, context));", deserFunctionName);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -163,10 +163,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     @Override
     public void generateSharedComponents(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addImport("map", null, "@aws-sdk/smithy-client");
+        writer.addImport("map", null, "@smithy/smithy-client");
 
         if (context.getSettings().generateClient()) {
-            writer.addImport("withBaseException", null, "@aws-sdk/smithy-client");
+            writer.addImport("withBaseException", null, "@smithy/smithy-client");
             SymbolReference exception = HttpProtocolGeneratorUtils.getClientBaseException(context);
             writer.write("const throwDefaultError = withBaseException($T);", exception);
         }
@@ -383,8 +383,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
                 ProtocolGenerator.getSanitizedName(getName())).toString());
         writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
-        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
-        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP);
 
         Symbol serviceSymbol = symbolProvider.toSymbol(context.getService());
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
@@ -437,8 +437,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.addImport("serializeFrameworkException", null,
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
                 ProtocolGenerator.getSanitizedName(getName())).toString());
-        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP.packageName);
-        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP.packageName);
+        writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP);
+        writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP);
 
         final Symbol operationSymbol = symbolProvider.toSymbol(operation);
         final Symbol inputType = operationSymbol.expectProperty("inputType", Symbol.class);
@@ -569,7 +569,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void calculateContentLength(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
-        writer.addImport("calculateBodyLength", null, "@aws-sdk/util-body-length-node");
+        writer.addImport("calculateBodyLength", null, "@smithy/util-body-length-node");
         writer.openBlock("if (body && Object.keys(headers).map((str) => str.toLowerCase())"
                 + ".indexOf('content-length') === -1) {", "}", () -> {
             writer.write("const length = calculateBodyLength(body);");
@@ -782,7 +782,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Handle any label bindings.
         if (!labelBindings.isEmpty()) {
-            writer.addImport("resolvedPath", "__resolvedPath", "@aws-sdk/smithy-client");
+            writer.addImport("resolvedPath", "__resolvedPath", "@smithy/smithy-client");
 
             Model model = context.getModel();
             List<Segment> uriLabels = trait.getUri().getLabels();
@@ -834,7 +834,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 if (!queryParamsBindings.isEmpty()) {
                     SymbolProvider symbolProvider = context.getSymbolProvider();
                     String memberName = symbolProvider.toMemberName(queryParamsBindings.get(0).getMember());
-                    writer.addImport("convertMap", "convertMap", "@aws-sdk/smithy-client");
+                    writer.addImport("convertMap", "convertMap", "@smithy/smithy-client");
                     writer.write("...convertMap(input.$L),", memberName);
                 }
                 // Handle any additional query bindings.
@@ -860,7 +860,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         String memberName = symbolProvider.toMemberName(binding.getMember());
         writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent",
-                "@aws-sdk/smithy-client");
+                "@smithy/smithy-client");
 
         Shape target = model.expectShape(binding.getMember().getTarget());
 
@@ -880,7 +880,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             target
         );
 
-        writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
+        writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
 
         if (Objects.equals("input." + memberName + memberAssertionComponent, queryValue)) {
             String value = isRequired ? "__expectNonNull($L, `" + memberName + "`)" : "$L";
@@ -2156,7 +2156,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             });
             String errorLocation = this.getErrorBodyLocation(context, outputName + ".body");
             writer.addImport("decorateServiceException", "__decorateServiceException",
-                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                    TypeScriptDependency.AWS_SMITHY_CLIENT);
             writer.write("return __decorateServiceException(exception, $L);", errorLocation);
         });
 
@@ -2320,8 +2320,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (!documentBindings.isEmpty()) {
             // If the response has document bindings, the body can be parsed to a JavaScript object.
-            writer.addImport("expectObject", "__expectObject", "@aws-sdk/smithy-client");
-            writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
+            writer.addImport("expectObject", "__expectObject", "@smithy/smithy-client");
+            writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
             String bodyLocation = "(__expectObject(await parseBody(output.body, context)))";
             // Use the protocol specific error location for retrieving contents.
             if (operationOrError instanceof StructureShape) {
@@ -2398,12 +2398,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("const data: any = await collectBody(output.body, context);");
         } else if (target instanceof StructureShape) {
             // If payload is a Structure, then we need to parse the string into JavaScript object.
-            writer.addImport("expectObject", "__expectObject", "@aws-sdk/smithy-client");
+            writer.addImport("expectObject", "__expectObject", "@smithy/smithy-client");
             writer.write("const data: Record<string, any> | undefined "
                     + "= __expectObject(await parseBody(output.body, context));");
         } else if (target instanceof UnionShape) {
             // If payload is a Union, then we need to parse the string into JavaScript object.
-            writer.addImport("expectUnion", "__expectUnion", "@aws-sdk/smithy-client");
+            writer.addImport("expectUnion", "__expectUnion", "@smithy/smithy-client");
             writer.write("const data: Record<string, any> | undefined "
                     + "= __expectUnion(await parseBody(output.body, context));");
         } else if (target instanceof StringShape || target instanceof DocumentShape) {
@@ -2541,7 +2541,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case QUERY:
             case LABEL:
             case HEADER:
-                context.getWriter().addImport("parseBoolean", "__parseBoolean", "@aws-sdk/smithy-client");
+                context.getWriter().addImport("parseBoolean", "__parseBoolean", "@smithy/smithy-client");
                 return String.format("__parseBoolean(%s)", dataSource);
             default:
                 throw new CodegenException("Unexpected boolean binding location `" + bindingType + "`");
@@ -2657,7 +2657,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                     if (format == Format.HTTP_DATE) {
                         TypeScriptWriter writer = context.getWriter();
-                        writer.addImport("splitEvery", "__splitEvery", "@aws-sdk/smithy-client");
+                        writer.addImport("splitEvery", "__splitEvery", "@smithy/smithy-client");
                         outputParam = "__splitEvery(" + dataSource + ", ',', 2)";
                     }
                 }
@@ -2732,28 +2732,28 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 switch (target.getType()) {
                     case DOUBLE:
                         context.getWriter().addImport(
-                                "strictParseDouble", "__strictParseDouble", "@aws-sdk/smithy-client");
+                                "strictParseDouble", "__strictParseDouble", "@smithy/smithy-client");
                         return "__strictParseDouble(" + dataSource + ")";
                     case FLOAT:
                         context.getWriter().addImport(
-                                "strictParseFloat", "__strictParseFloat", "@aws-sdk/smithy-client");
+                                "strictParseFloat", "__strictParseFloat", "@smithy/smithy-client");
                         return "__strictParseFloat(" + dataSource + ")";
                     case LONG:
                         context.getWriter().addImport(
-                                "strictParseLong", "__strictParseLong", "@aws-sdk/smithy-client");
+                                "strictParseLong", "__strictParseLong", "@smithy/smithy-client");
                         return "__strictParseLong(" + dataSource + ")";
                     case INT_ENUM:
                     case INTEGER:
                         context.getWriter().addImport(
-                                "strictParseInt32", "__strictParseInt32", "@aws-sdk/smithy-client");
+                                "strictParseInt32", "__strictParseInt32", "@smithy/smithy-client");
                         return "__strictParseInt32(" + dataSource + ")";
                     case SHORT:
                         context.getWriter().addImport(
-                                "strictParseShort", "__strictParseShort", "@aws-sdk/smithy-client");
+                                "strictParseShort", "__strictParseShort", "@smithy/smithy-client");
                         return "__strictParseShort(" + dataSource + ")";
                     case BYTE:
                         context.getWriter().addImport(
-                                "strictParseByte", "__strictParseByte", "@aws-sdk/smithy-client");
+                                "strictParseByte", "__strictParseByte", "@smithy/smithy-client");
                         return "__strictParseByte(" + dataSource + ")";
                     default:
                         throw new CodegenException("Unexpected number shape `" + target.getType() + "`");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -84,7 +84,7 @@ public final class HttpProtocolGeneratorUtils {
             case EPOCH_SECONDS:
                 return "Math.round(" + dataSource + ".getTime() / 1000)";
             case HTTP_DATE:
-                context.getWriter().addImport("dateToUtcString", "__dateToUtcString", "@aws-sdk/smithy-client");
+                context.getWriter().addImport("dateToUtcString", "__dateToUtcString", "@smithy/smithy-client");
                 return "__dateToUtcString(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
@@ -115,27 +115,27 @@ public final class HttpProtocolGeneratorUtils {
                                                  boolean isClient) {
         // This has always explicitly wrapped the dataSource in "new Date(..)", so it could never generate
         // an expression that evaluates to null. Codegen relies on this.
-        writer.addImport("expectNonNull", "__expectNonNull", "@aws-sdk/smithy-client");
+        writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
         switch (format) {
             case DATE_TIME:
                 // Clients should be able to handle offsets and normalize the datetime to an offset of zero.
                 if (isClient) {
                     writer.addImport("parseRfc3339DateTimeWithOffset", "__parseRfc3339DateTimeWithOffset",
-                        "@aws-sdk/smithy-client");
+                        "@smithy/smithy-client");
                     return String.format("__expectNonNull(__parseRfc3339DateTimeWithOffset(%s))", dataSource);
                 } else {
-                    writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime", "@aws-sdk/smithy-client");
+                    writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime", "@smithy/smithy-client");
                     return String.format("__expectNonNull(__parseRfc3339DateTime(%s))", dataSource);
                 }
             case HTTP_DATE:
-                writer.addImport("parseRfc7231DateTime", "__parseRfc7231DateTime", "@aws-sdk/smithy-client");
+                writer.addImport("parseRfc7231DateTime", "__parseRfc7231DateTime", "@smithy/smithy-client");
                 return String.format("__expectNonNull(__parseRfc7231DateTime(%s))", dataSource);
             case EPOCH_SECONDS:
-                writer.addImport("parseEpochTimestamp", "__parseEpochTimestamp", "@aws-sdk/smithy-client");
+                writer.addImport("parseEpochTimestamp", "__parseEpochTimestamp", "@smithy/smithy-client");
                 String modifiedDataSource = dataSource;
                 if (requireNumericEpochSecondsInPayload
                         && (bindingType == Location.DOCUMENT || bindingType == Location.PAYLOAD)) {
-                    writer.addImport("expectNumber", "__expectNumber", "@aws-sdk/smithy-client");
+                    writer.addImport("expectNumber", "__expectNumber", "@smithy/smithy-client");
                     modifiedDataSource = String.format("__expectNumber(%s)", dataSource);
                 }
                 return String.format("__expectNonNull(__parseEpochTimestamp(%s))", modifiedDataSource);
@@ -163,7 +163,7 @@ public final class HttpProtocolGeneratorUtils {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
-                writer.addImport("LazyJsonString", "__LazyJsonString", "@aws-sdk/smithy-client");
+                writer.addImport("LazyJsonString", "__LazyJsonString", "@smithy/smithy-client");
                 return "__LazyJsonString.fromObject(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
@@ -194,7 +194,7 @@ public final class HttpProtocolGeneratorUtils {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
-                writer.addImport("LazyJsonString", "__LazyJsonString", "@aws-sdk/smithy-client");
+                writer.addImport("LazyJsonString", "__LazyJsonString", "@smithy/smithy-client");
                 return "new __LazyJsonString(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
@@ -204,7 +204,7 @@ public final class HttpProtocolGeneratorUtils {
         if (!useExpect) {
             return dataSource;
         }
-        context.getWriter().addImport("expectString", "__expectString", "@aws-sdk/smithy-client");
+        context.getWriter().addImport("expectString", "__expectString", "@smithy/smithy-client");
         return "__expectString(" + dataSource + ")";
     }
 
@@ -234,7 +234,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateMetadataDeserializer(GenerationContext context, SymbolReference responseType) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("ResponseMetadata", "__ResponseMetadata", "@aws-sdk/types");
+        writer.addImport("ResponseMetadata", "__ResponseMetadata", "@smithy/types");
         writer.openBlock("const deserializeMetadata = (output: $T): __ResponseMetadata => ({", "});", responseType,
                 () -> {
                     writer.write("httpStatusCode: output.statusCode,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -133,7 +133,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
 
         if (context.getSettings().generateClient()) {
-            writer.addImport("withBaseException", null, "@aws-sdk/smithy-client");
+            writer.addImport("withBaseException", null, "@smithy/smithy-client");
             SymbolReference exception = HttpProtocolGeneratorUtils.getClientBaseException(context);
             writer.write("const throwDefaultError = withBaseException($T);", exception);
         }
@@ -142,7 +142,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         SymbolReference requestType = getApplicationProtocol().getRequestType();
         writer.addUseImports(requestType);
         writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
+        writer.addImport("HeaderBag", "__HeaderBag", "@smithy/types");
         writer.openBlock("const buildHttpRpcRequest = async (\n"
                        + "  context: __SerdeContext,\n"
                        + "  headers: __HeaderBag,\n"
@@ -326,7 +326,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      */
     protected void writeSharedRequestHeaders(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
+        writer.addImport("HeaderBag", "__HeaderBag", "@smithy/types");
         writer.openBlock("const SHARED_HEADERS: __HeaderBag = {", "};", () -> {
             writer.write("'content-type': $S,", getDocumentContentType());
         });
@@ -512,7 +512,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
                 writer.write("...deserialized");
             });
             writer.addImport("decorateServiceException", "__decorateServiceException",
-                    TypeScriptDependency.AWS_SMITHY_CLIENT.packageName);
+                    TypeScriptDependency.AWS_SMITHY_CLIENT);
             writer.write("return __decorateServiceException(exception, body);");
         });
 

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/default_readme_server.md.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/default_readme_server.md.template
@@ -21,7 +21,7 @@ Below is an example service handler created for the ${commandName} operation.
 
 ```ts
 import { createServer, IncomingMessage, ServerResponse } from "http";
-import { HttpRequest } from "@aws-sdk/protocol-http";
+import { HttpRequest } from "@smithy/protocol-http";
 import {
   ${serviceId}Service as __${serviceId}Service,
   ${commandName}Input,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
@@ -1,5 +1,5 @@
-import { HttpRequest } from "@aws-sdk/protocol-http";
-import { MiddlewareStack } from "@aws-sdk/types";
+import { HttpRequest } from "smithy/protocol-http";
+import { MiddlewareStack } from "@smithy/types";
 
 import {
   getHttpApiKeyAuthPlugin,

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.ts
@@ -1,8 +1,8 @@
 // derived from https://github.com/aws/aws-sdk-js-v3/blob/e35f78c97fa6710ff9c444351893f0f06755e771/packages/middleware-endpoint-discovery/src/endpointDiscoveryMiddleware.ts
 
-import { HttpRequest } from "@aws-sdk/protocol-http";
-import { BuildMiddleware, Pluggable, Provider, RelativeMiddlewareOptions } from "@aws-sdk/types";
-import { normalizeProvider } from "@aws-sdk/util-middleware";
+import { HttpRequest } from "@smithy/protocol-http";
+import { BuildMiddleware, Pluggable, Provider, RelativeMiddlewareOptions } from "@smithy/types";
+import { normalizeProvider } from "@smithy/util-middleware";
 
 interface HttpApiKeyAuthMiddlewareConfig {
   /**

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/protocol-test-stub.ts
@@ -1,5 +1,5 @@
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { HttpHandlerOptions, HeaderBag } from "@smithy/types";
+import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { Readable } from 'stream';
 
 /**

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.browser.ts.template
@@ -1,7 +1,7 @@
 import { ${clientConfigName} } from "${clientModuleName}";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
-import { loadConfigsForDefaultMode } from "@aws-sdk/smithy-client";
-import { resolveDefaultsModeConfig } from "@aws-sdk/util-defaults-mode-browser";
+import { loadConfigsForDefaultMode } from "@smithy/smithy-client";
+import { resolveDefaultsModeConfig } from "@smithy/util-defaults-mode-browser";
 
 /**
  * @internal

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeConfig.ts.template
@@ -1,8 +1,8 @@
 import { ${clientConfigName} } from "${clientModuleName}";
 import { getRuntimeConfig as getSharedRuntimeConfig } from "./runtimeConfig.shared";
-import { loadConfigsForDefaultMode } from "@aws-sdk/smithy-client";
-import { resolveDefaultsModeConfig } from "@aws-sdk/util-defaults-mode-node";
-import { emitWarningIfUnsupportedVersion } from "@aws-sdk/smithy-client";
+import { loadConfigsForDefaultMode } from "@smithy/smithy-client";
+import { resolveDefaultsModeConfig } from "@smithy/util-defaults-mode-node";
+import { emitWarningIfUnsupportedVersion } from "@smithy/smithy-client";
 
 /**
  * @internal

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/TypeScriptWriterTest.java
@@ -22,12 +22,12 @@ public class TypeScriptWriterTest {
         TypeScriptWriter writer = new TypeScriptWriter("foo");
         writer.write("import { Foo } from \"baz\";");
         writer.addImport("Baz", "Baz", "hello");
-        writer.addImport("Bar", "__Bar", TypeScriptDependency.AWS_SDK_TYPES);
+        writer.addImport("Bar", "__Bar", TypeScriptDependency.SMITHY_TYPES);
         writer.addRelativeImport("Qux", "__Qux", Paths.get("./qux"));
         String result = writer.toString();
 
         assertThat(result, equalTo(CODEGEN_INDICATOR + "import { Qux as __Qux } from \"./qux\";\n"
-                + "import { Bar as __Bar } from \"@aws-sdk/types\";\n"
+                + "import { Bar as __Bar } from \"@smithy/types\";\n"
                 + "import { Baz } from \"hello\";\n"
                 + "import { Foo } from \"baz\";\n"));
     }


### PR DESCRIPTION
This PR updates codegen to use the `@smithy` NPM packages that were added in https://github.com/awslabs/smithy-typescript/pull/773 and https://github.com/awslabs/smithy-typescript/pull/790.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
