### PR TITLE
Bump node-http-handler

### DIFF
--- a/.changeset/famous-walls-explain.md
+++ b/.changeset/famous-walls-explain.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-http-handler": patch
+---
+
+Rejoin main promise when error is thrown in writeRequestBody


### PR DESCRIPTION
Bumps versions on node-http-handler and related packages following change in https://github.com/awslabs/smithy-typescript/pull/794

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
