### PR TITLE
Standardizes usage of addImport method

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -119,9 +119,9 @@ final class CommandGenerator implements Runnable {
         String configType = ServiceBareBonesClientGenerator.getResolvedConfigTypeName(serviceSymbol);
 
         // Add required imports.
-        writer.addImport(configType, configType, serviceSymbol.getNamespace());
-        writer.addImport("ServiceInputTypes", "ServiceInputTypes", serviceSymbol.getNamespace());
-        writer.addImport("ServiceOutputTypes", "ServiceOutputTypes", serviceSymbol.getNamespace());
+        writer.addRelativeImport(configType, null, Paths.get(".", serviceSymbol.getNamespace()));
+        writer.addRelativeImport("ServiceInputTypes", null, Paths.get(".", serviceSymbol.getNamespace()));
+        writer.addRelativeImport("ServiceOutputTypes", null, Paths.get(".", serviceSymbol.getNamespace()));
         writer.addImport("Command", "$Command", TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.addImport("FinalizeHandlerArguments", "FinalizeHandlerArguments", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("Handler", "Handler", TypeScriptDependency.SMITHY_TYPES);
@@ -236,7 +236,7 @@ final class CommandGenerator implements Runnable {
         if (!service.hasTrait(EndpointRuleSetTrait.class)) {
             return;
         }
-        writer.addImport("EndpointParameterInstructions", null, "@smithy/middleware-endpoint");
+        writer.addImport("EndpointParameterInstructions", null, TypeScriptDependency.MIDDLEWARE_ENDPOINTS_V2);
         writer.openBlock(
                 "public static getEndpointParameterInstructions(): EndpointParameterInstructions {", "}",
                 () -> {
@@ -301,8 +301,8 @@ final class CommandGenerator implements Runnable {
             if (service.hasTrait(EndpointRuleSetTrait.class)) {
                 writer.addImport(
                         "getEndpointPlugin",
-                        "getEndpointPlugin",
-                        "@smithy/middleware-endpoint");
+                        null,
+                        TypeScriptDependency.MIDDLEWARE_ENDPOINTS_V2);
                 writer.openBlock(
                         "this.middlewareStack.use(getEndpointPlugin(configuration, ",
                         "));",
@@ -329,10 +329,10 @@ final class CommandGenerator implements Runnable {
                                 if (sensitiveDataFinder.findsSensitiveDataIn(input)) {
                                     Symbol inputSymbol = symbolProvider.toSymbol(input);
                                     String filterFunctionName = inputSymbol.getName() + "FilterSensitiveLog";
-                                    writer.addImport(
+                                    writer.addRelativeImport(
                                             filterFunctionName,
-                                            filterFunctionName,
-                                            inputSymbol.getNamespace());
+                                            null,
+                                            Paths.get(".", inputSymbol.getNamespace()));
                                     writer.writeInline(filterFunctionName);
                                 } else {
                                     writer.writeInline("(_: any) => _");
@@ -346,10 +346,10 @@ final class CommandGenerator implements Runnable {
                                 if (sensitiveDataFinder.findsSensitiveDataIn(output)) {
                                     Symbol outputSymbol = symbolProvider.toSymbol(output);
                                     String filterFunctionName = outputSymbol.getName() + "FilterSensitiveLog";
-                                    writer.addImport(
+                                    writer.addRelativeImport(
                                             filterFunctionName,
-                                            filterFunctionName,
-                                            outputSymbol.getNamespace());
+                                            null,
+                                            Paths.get(".", outputSymbol.getNamespace()));
                                     writer.writeInline(filterFunctionName);
                                 } else {
                                     writer.writeInline("(_: any) => _");
@@ -488,9 +488,9 @@ final class CommandGenerator implements Runnable {
             String serdeFunctionName = isInput
                     ? ProtocolGenerator.getSerFunctionShortName(symbol)
                     : ProtocolGenerator.getDeserFunctionShortName(symbol);
-            writer.addImport(serdeFunctionName, serdeFunctionName,
+            writer.addRelativeImport(serdeFunctionName, null,
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ProtocolGenerator.PROTOCOLS_FOLDER,
-                            ProtocolGenerator.getSanitizedName(protocolGenerator.getName())).toString());
+                            ProtocolGenerator.getSanitizedName(protocolGenerator.getName())));
             writer.write("return $L($L, context);", serdeFunctionName, isInput ? "input" : "output");
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PaginationGenerator.java
@@ -86,21 +86,22 @@ final class PaginationGenerator implements Runnable {
     @Override
     public void run() {
         // Import Service Types
-        writer.addImport(operationSymbol.getName(),
+        writer.addRelativeImport(operationSymbol.getName(),
                 operationSymbol.getName(),
-                operationSymbol.getNamespace());
-        writer.addImport(inputSymbol.getName(),
+                Paths.get(".", operationSymbol.getNamespace()));
+        writer.addRelativeImport(inputSymbol.getName(),
                 inputSymbol.getName(),
-                inputSymbol.getNamespace());
-        writer.addImport(outputSymbol.getName(),
+                Paths.get(".", inputSymbol.getNamespace()));
+        writer.addRelativeImport(outputSymbol.getName(),
                 outputSymbol.getName(),
-                outputSymbol.getNamespace());
-        writer.addImport(serviceSymbol.getName(), serviceSymbol.getName(), serviceSymbol.getNamespace());
+                Paths.get(".", outputSymbol.getNamespace()));
+        writer.addRelativeImport(serviceSymbol.getName(), serviceSymbol.getName(),
+                Paths.get(".", serviceSymbol.getNamespace()));
 
         // Import Pagination types
-        writer.addImport("Paginator", "Paginator", "@smithy/types");
-        writer.addImport(paginationType, paginationType,
-            Paths.get(".", PAGINATION_INTERFACE_FILE.replace(".ts", "")).toString());
+        writer.addImport("Paginator", null, TypeScriptDependency.SMITHY_TYPES);
+        writer.addRelativeImport(paginationType, paginationType,
+            Paths.get(".", PAGINATION_INTERFACE_FILE.replace(".ts", "")));
 
         writeCommandRequest();
         writePager();
@@ -116,9 +117,8 @@ final class PaginationGenerator implements Runnable {
             Symbol service,
             TypeScriptWriter writer
     ) {
-        writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@smithy/types");
-        writer.addImport(service.getName(), service.getName(), service.getNamespace());
-
+        writer.addImport("PaginationConfiguration", null, TypeScriptDependency.SMITHY_TYPES);
+        writer.addRelativeImport(service.getName(), service.getName(), Paths.get(".", service.getNamespace()));
         writer.writeDocs("@public")
             .openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
                 "}", aggregatedClientName, () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -50,20 +50,17 @@ final class RuntimeConfigGenerator {
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_HASH_NODE);
-                writer.addImport("Hash", "Hash",
-                        TypeScriptDependency.AWS_SDK_HASH_NODE);
+                writer.addImport("Hash", null, TypeScriptDependency.AWS_SDK_HASH_NODE);
                 writer.write("Hash.bind(null, \"sha256\")");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
-                writer.addImport("calculateBodyLength", "calculateBodyLength",
-                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
+                writer.addImport("calculateBodyLength", null, TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
                 writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
-                writer.addImport("streamCollector", "streamCollector",
-                        TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
+                writer.addImport("streamCollector", null, TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                 writer.write("streamCollector");
             }
     );
@@ -76,18 +73,17 @@ final class RuntimeConfigGenerator {
             },
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
-                writer.addImport("Sha256", "Sha256", TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
+                writer.addImport("Sha256", null, TypeScriptDependency.AWS_CRYPTO_SHA256_BROWSER);
                 writer.write("Sha256");
             },
             "bodyLengthChecker", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
-                writer.addImport("calculateBodyLength", "calculateBodyLength",
-                        TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
+                writer.addImport("calculateBodyLength", null, TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_BROWSER);
                 writer.write("calculateBodyLength");
             },
             "streamCollector", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
-                writer.addImport("streamCollector", "streamCollector",
+                writer.addImport("streamCollector", null,
                         TypeScriptDependency.AWS_SDK_FETCH_HTTP_HANDLER);
                 writer.write("streamCollector");
             }
@@ -95,20 +91,20 @@ final class RuntimeConfigGenerator {
     private final Map<String, Consumer<TypeScriptWriter>> reactNativeRuntimeConfigDefaults = MapUtils.of(
             "sha256", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
-                writer.addImport("Sha256", "Sha256", TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
+                writer.addImport("Sha256", null, TypeScriptDependency.AWS_CRYPTO_SHA256_JS);
                 writer.write("Sha256");
             }
     );
     private final Map<String, Consumer<TypeScriptWriter>> sharedRuntimeConfigDefaults = MapUtils.of(
             "base64Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64);
-                writer.addImport("fromBase64", "fromBase64",
+                writer.addImport("fromBase64", null,
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.write("fromBase64");
             },
             "base64Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BASE64);
-                writer.addImport("toBase64", "toBase64",
+                writer.addImport("toBase64", null,
                         TypeScriptDependency.AWS_SDK_UTIL_BASE64);
                 writer.write("toBase64");
             },
@@ -117,19 +113,19 @@ final class RuntimeConfigGenerator {
             },
             "urlParser", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_URL_PARSER);
-                writer.addImport("parseUrl", "parseUrl",
+                writer.addImport("parseUrl", null,
                         TypeScriptDependency.AWS_SDK_URL_PARSER);
                 writer.write("parseUrl");
             },
             "utf8Decoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8);
-                writer.addImport("fromUtf8", "fromUtf8",
+                writer.addImport("fromUtf8", null,
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.write("fromUtf8");
             },
             "utf8Encoder", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_UTF8);
-                writer.addImport("toUtf8", "toUtf8",
+                writer.addImport("toUtf8", null,
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.write("toUtf8");
             }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerGenerator.java
@@ -49,7 +49,8 @@ final class ServerGenerator {
                                        Set<OperationShape> operations,
                                        TypeScriptWriter writer) {
         addCommonHandlerImports(writer);
-        writer.addImport("UnknownOperationException", "__UnknownOperationException", "@aws-smithy/server-common");
+        writer.addImport("UnknownOperationException", "__UnknownOperationException",
+            TypeScriptDependency.SERVER_COMMON);
 
         Symbol serviceSymbol = symbolProvider.toSymbol(serviceShape);
         Symbol handlerSymbol = serviceSymbol.expectProperty("handler", Symbol.class);
@@ -199,26 +200,26 @@ final class ServerGenerator {
     }
 
     private static void addCommonHandlerImports(TypeScriptWriter writer) {
-        writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
-        writer.addImport("ServiceHandler", "__ServiceHandler", "@aws-smithy/server-common");
-        writer.addImport("Mux", "__Mux", "@aws-smithy/server-common");
-        writer.addImport("OperationSerializer", "__OperationSerializer", "@aws-smithy/server-common");
-        writer.addImport("InternalFailureException", "__InternalFailureException", "@aws-smithy/server-common");
-        writer.addImport("SerializationException", "__SerializationException", "@aws-smithy/server-common");
-        writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", "@aws-smithy/server-common");
+        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ServiceHandler", "__ServiceHandler", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("Mux", "__Mux", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("OperationSerializer", "__OperationSerializer", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("InternalFailureException", "__InternalFailureException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("SerializationException", "__SerializationException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP);
         writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP);
-        writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
-        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
+        writer.addImport("ServiceException", "__ServiceException", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", TypeScriptDependency.SERVER_COMMON);
     }
 
     private static void writeHandleFunction(TypeScriptWriter writer) {
-        writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
-        writer.addImport("OperationInput", "__OperationInput", "@aws-smithy/server-common");
-        writer.addImport("OperationOutput", "__OperationOutput", "@aws-smithy/server-common");
-        writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
-        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
-        writer.addImport("isFrameworkException", "__isFrameworkException", "@aws-smithy/server-common");
+        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("OperationInput", "__OperationInput", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("OperationOutput", "__OperationOutput", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ValidationFailure", "__ValidationFailure", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("isFrameworkException", "__isFrameworkException", TypeScriptDependency.SERVER_COMMON);
 
         writer.openBlock("async function handle<S, O extends keyof S & string, Context>(",
                 "): Promise<__HttpResponse> {",
@@ -271,13 +272,13 @@ final class ServerGenerator {
     }
 
     private static void writeSerdeContextBase(TypeScriptWriter writer) {
-        writer.addImport("ServerSerdeContext", "__ServerSerdeContext", "@aws-smithy/server-common");
-        writer.addImport("NodeHttpHandler", null, "@smithy/node-http-handler");
-        writer.addImport("streamCollector", null, "@smithy/node-http-handler");
+        writer.addImport("ServerSerdeContext", "__ServerSerdeContext", TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("NodeHttpHandler", null, TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
+        writer.addImport("streamCollector", null, TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
         writer.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64);
         writer.addImport("toBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64);
-        writer.addImport("fromUtf8", null, "@smithy/util-utf8");
-        writer.addImport("toUtf8", null, "@smithy/util-utf8");
+        writer.addImport("fromUtf8", null, TypeScriptDependency.AWS_SDK_UTIL_UTF8);
+        writer.addImport("toUtf8", null, TypeScriptDependency.AWS_SDK_UTIL_UTF8);
 
         writer.openBlock("const serdeContextBase = {", "};", () -> {
             writer.write("base64Encoder: toBase64,");
@@ -294,7 +295,7 @@ final class ServerGenerator {
                                          ServiceShape service,
                                          Set<OperationShape> operations,
                                          TypeScriptWriter writer) {
-        writer.addImport("Operation", "__Operation", "@aws-smithy/server-common");
+        writer.addImport("Operation", "__Operation", TypeScriptDependency.SERVER_COMMON);
 
         String serviceInterfaceName = symbolProvider.toSymbol(service).getName();
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceAggregatedClientGenerator.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.nio.file.Paths;
 import java.util.Set;
 import java.util.TreeSet;
 import software.amazon.smithy.codegen.core.Symbol;
@@ -112,10 +113,10 @@ final class ServiceAggregatedClientGenerator implements Runnable {
 
         writer.write("");
 
-        writer.addImport(
+        writer.addRelativeImport(
             ServiceBareBonesClientGenerator.getConfigTypeName(serviceSymbol),
             null,
-            serviceSymbol.getNamespace()
+            Paths.get(".", serviceSymbol.getNamespace())
         );
 
         // Generate the client and extend from the bare-bones client.
@@ -124,7 +125,7 @@ final class ServiceAggregatedClientGenerator implements Runnable {
             aggregateClientName, serviceSymbol, aggregateClientName
         );
 
-        writer.addImport("createAggregatedClient", null, "@smithy/smithy-client");
+        writer.addImport("createAggregatedClient", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.write("createAggregatedClient(commands, $L);", aggregateClientName);
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -99,8 +99,8 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     public void run() {
         writer.addImport("Client", "__Client", TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.write("export { __Client }\n");
-        writer.addImport("getRuntimeConfig", "__getRuntimeConfig",
-            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeConfig").toString());
+        writer.addRelativeImport("getRuntimeConfig", "__getRuntimeConfig",
+            Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeConfig"));
 
         // Normalize the input and output types of the command to account for
         // things like an operation adding input where there once wasn't any
@@ -152,8 +152,9 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     }
 
     private void generateConfig() {
-        writer.addImport("SmithyConfiguration", "__SmithyConfiguration", "@smithy/smithy-client");
-        writer.addImport("SmithyResolvedConfiguration", "__SmithyResolvedConfiguration", "@smithy/smithy-client");
+        writer.addImport("SmithyConfiguration", "__SmithyConfiguration", TypeScriptDependency.AWS_SMITHY_CLIENT);
+        writer.addImport("SmithyResolvedConfiguration", "__SmithyResolvedConfiguration",
+            TypeScriptDependency.AWS_SMITHY_CLIENT);
 
         // Hook for intercepting the client configuration.
         writer.pushState(CLIENT_CONFIG_SECTION);
@@ -242,23 +243,23 @@ final class ServiceBareBonesClientGenerator implements Runnable {
             writer.writeDocs("The HTTP handler to use. Fetch in browser and Https in Nodejs.");
             writer.write("requestHandler?: __HttpHandler;\n");
 
-            writer.addImport("Hash", "__Hash", "@smithy/types");
-            writer.addImport("HashConstructor", "__HashConstructor", "@smithy/types");
+            writer.addImport("Hash", "__Hash", TypeScriptDependency.SMITHY_TYPES);
+            writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.SMITHY_TYPES);
 
-            writer.addImport("Checksum", "__Checksum", "@smithy/types");
-            writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@smithy/types");
+            writer.addImport("Checksum", "__Checksum", TypeScriptDependency.SMITHY_TYPES);
+            writer.addImport("ChecksumConstructor", "__ChecksumConstructor", TypeScriptDependency.SMITHY_TYPES);
             writer.writeDocs("A constructor for a class implementing the {@link @smithy/types#ChecksumConstructor} "
                             + "interface \n"
                             + "that computes the SHA-256 HMAC or checksum of a string or binary buffer.\n"
                             + "@internal");
             writer.write("sha256?: __ChecksumConstructor | __HashConstructor;\n");
 
-            writer.addImport("UrlParser", "__UrlParser", "@smithy/types");
+            writer.addImport("UrlParser", "__UrlParser", TypeScriptDependency.SMITHY_TYPES);
             writer.writeDocs("The function that will be used to convert strings into HTTP endpoints.\n"
                              + "@internal");
             writer.write("urlParser?: __UrlParser;\n");
 
-            writer.addImport("BodyLengthCalculator", "__BodyLengthCalculator", "@smithy/types");
+            writer.addImport("BodyLengthCalculator", "__BodyLengthCalculator", TypeScriptDependency.SMITHY_TYPES);
             writer.writeDocs("A function that can calculate the length of a request body.\n"
                             + "@internal");
             writer.write("bodyLengthChecker?: __BodyLengthCalculator;\n");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructureGenerator.java
@@ -208,7 +208,7 @@ final class StructureGenerator implements Runnable {
         writer.openBlock("export namespace $L {", "}", symbol.getName(), () -> {
             structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
-            writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+            writer.addImport("ValidationFailure", "__ValidationFailure", TypeScriptDependency.SERVER_COMMON);
             writer.writeDocs("@internal");
             List<MemberShape> blobStreamingMembers = getBlobStreamingMembers(model, shape);
             writer.writeInline("export const validate = ($L: ", objectParam);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -77,6 +77,8 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
 
     NODE_CONFIG_PROVIDER("dependencies", "@smithy/node-config-provider", "^1.0.1", false),
 
+    UUID("dependencies", "uuid", "^8.3.2", false),
+
     // Conditionally added when httpChecksumRequired trait exists
     MD5_BROWSER("dependencies", "@smithy/md5-js", "^1.0.1", false),
     STREAM_HASHER_NODE("dependencies", "@smithy/hash-stream-node", "^1.0.1", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -290,7 +290,7 @@ final class UnionGenerator implements Runnable {
 
         structuredMemberWriter.writeMemberValidatorCache(writer, "memberValidators");
 
-        writer.addImport("ValidationFailure", "__ValidationFailure", "@aws-smithy/server-common");
+        writer.addImport("ValidationFailure", "__ValidationFailure", TypeScriptDependency.SERVER_COMMON);
         writer.writeDocs("@internal");
         writer.openBlock("export const validate = ($L: $L, path: string = \"\"): __ValidationFailure[] => {", "}",
                 "obj", symbol.getName(),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/WaiterGenerator.java
@@ -38,7 +38,7 @@ import software.amazon.smithy.waiters.Waiter;
 @SmithyInternalApi
 class WaiterGenerator implements Runnable {
     static final String WAITERS_FOLDER = "waiters";
-    static final String WAITABLE_UTIL_PACKAGE = TypeScriptDependency.AWS_SDK_UTIL_WAITERS.packageName;
+    static final TypeScriptDependency WAITABLE_UTIL_PACKAGE = TypeScriptDependency.AWS_SDK_UTIL_WAITERS;
 
     private final String waiterName;
     private final Waiter waiter;
@@ -76,12 +76,11 @@ class WaiterGenerator implements Runnable {
     }
 
     private void generateWaiter() {
-
-        writer.addImport("createWaiter", "createWaiter", WAITABLE_UTIL_PACKAGE);
-        writer.addImport("WaiterResult", "WaiterResult", WAITABLE_UTIL_PACKAGE);
-        writer.addImport("WaiterState", "WaiterState", WAITABLE_UTIL_PACKAGE);
-        writer.addImport("checkExceptions", "checkExceptions", WAITABLE_UTIL_PACKAGE);
-        writer.addImport("WaiterConfiguration", "WaiterConfiguration", WAITABLE_UTIL_PACKAGE);
+        writer.addImport("createWaiter", null, WAITABLE_UTIL_PACKAGE);
+        writer.addImport("WaiterResult", null, WAITABLE_UTIL_PACKAGE);
+        writer.addImport("WaiterState", null, WAITABLE_UTIL_PACKAGE);
+        writer.addImport("checkExceptions", null, WAITABLE_UTIL_PACKAGE);
+        writer.addImport("WaiterConfiguration", null, WAITABLE_UTIL_PACKAGE);
 
         // generates (deprecated) WaitFor....
         writer.writeDocs(waiter.getDocumentation().orElse("") + " \n"

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -69,7 +69,7 @@ public final class EndpointsV2Generator implements Runnable {
         this.delegator.useFileWriter(
             Paths.get(CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER, ENDPOINT_PARAMETERS_FILE).toString(),
             writer -> {
-                writer.addImport("EndpointParameters", "__EndpointParameters", "@smithy/types");
+                writer.addImport("EndpointParameters", "__EndpointParameters", TypeScriptDependency.SMITHY_TYPES);
                 writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
 
                 writer.openBlock(
@@ -146,12 +146,12 @@ public final class EndpointsV2Generator implements Runnable {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
                 writer.addImport("EndpointParams", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
                 writer.addImport("resolveEndpoint", null, TypeScriptDependency.AWS_SDK_UTIL_ENDPOINTS);
-                writer.addImport("EndpointParameters", null,
+                writer.addRelativeImport("EndpointParameters", null,
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER,
-                        ENDPOINT_PARAMETERS_FILE.replace(".ts", "")).toString());
-                writer.addImport("ruleSet", null,
+                        ENDPOINT_PARAMETERS_FILE.replace(".ts", "")));
+                writer.addRelativeImport("ruleSet", null,
                     Paths.get(".", CodegenUtils.SOURCE_FOLDER, ENDPOINT_FOLDER,
-                        ENDPOINT_RULESET_FILE.replace(".ts", "")).toString());
+                        ENDPOINT_RULESET_FILE.replace(".ts", "")));
 
                 writer.openBlock(
                     "export const defaultEndpointResolver = ",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParametersVisitor.java
@@ -67,7 +67,7 @@ public class RuleSetParametersVisitor extends NodeVisitor.Default<Void> {
 
             if (localKey.equals("endpoint")) {
                 writer.addImport("Endpoint", null, TypeScriptDependency.SMITHY_TYPES);
-                writer.addImport("EndpointV2", null, "@smithy/types");
+                writer.addImport("EndpointV2", null, TypeScriptDependency.SMITHY_TYPES);
                 writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
             }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddChecksumRequiredDependency.java
@@ -53,18 +53,18 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
             return;
         }
 
-        writer.addImport("Readable", "Readable", "stream");
-        writer.addImport("StreamHasher", "__StreamHasher", "@smithy/types");
+        writer.addImport("Readable", null, "stream");
+        writer.addImport("StreamHasher", "__StreamHasher", TypeScriptDependency.SMITHY_TYPES);
         writer.writeDocs("A function that, given a hash constructor and a stream, calculates the \n"
                 + "hash of the streamed value.\n"
                 + "@internal");
         writer.write("streamHasher?: __StreamHasher<Readable> | __StreamHasher<Blob>;\n");
 
-        writer.addImport("Hash", "__Hash", "@smithy/types");
-        writer.addImport("HashConstructor", "__HashConstructor", "@smithy/types");
+        writer.addImport("Hash", "__Hash", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("HashConstructor", "__HashConstructor", TypeScriptDependency.SMITHY_TYPES);
 
-        writer.addImport("Checksum", "__Checksum", "@smithy/types");
-        writer.addImport("ChecksumConstructor", "__ChecksumConstructor", "@smithy/types");
+        writer.addImport("Checksum", "__Checksum", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("ChecksumConstructor", "__ChecksumConstructor", TypeScriptDependency.SMITHY_TYPES);
         writer.writeDocs("A constructor for a class implementing the {@link __checksum} interface \n"
                 + "that computes MD5 hashes.\n"
                 + "@internal");
@@ -109,7 +109,7 @@ public final class AddChecksumRequiredDependency implements TypeScriptIntegratio
                     },
                     "md5", writer -> {
                         writer.addDependency(TypeScriptDependency.MD5_BROWSER);
-                        writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER);
+                        writer.addImport("Md5", null, TypeScriptDependency.MD5_BROWSER);
                         writer.write("Md5");
                     });
             default:

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
@@ -79,7 +79,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             case SHARED:
                 return MapUtils.of(
                         "logger", writer -> {
-                            writer.addImport("NoOpLogger", null, "@smithy/smithy-client");
+                            writer.addImport("NoOpLogger", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
                             writer.write("new NoOpLogger()");
                         }
                 );
@@ -87,14 +87,12 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                 return MapUtils.of(
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.UTIL_RETRY);
-                            writer.addImport("DEFAULT_MAX_ATTEMPTS", "DEFAULT_MAX_ATTEMPTS",
-                                    TypeScriptDependency.UTIL_RETRY);
+                            writer.addImport("DEFAULT_MAX_ATTEMPTS", null, TypeScriptDependency.UTIL_RETRY);
                             writer.write("DEFAULT_MAX_ATTEMPTS");
                         },
                         "retryMode", writer -> {
                             writer.addDependency(TypeScriptDependency.UTIL_RETRY);
-                            writer.addImport("DEFAULT_RETRY_MODE", "DEFAULT_RETRY_MODE",
-                                    TypeScriptDependency.UTIL_RETRY);
+                            writer.addImport("DEFAULT_RETRY_MODE", null, TypeScriptDependency.UTIL_RETRY);
                             writer.write(
                                     "(async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE)");
                         }
@@ -105,7 +103,7 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                             writer.addDependency(TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addImport("loadConfig", "loadNodeConfig",
                                     TypeScriptDependency.NODE_CONFIG_PROVIDER);
-                            writer.addImport("NODE_MAX_ATTEMPT_CONFIG_OPTIONS", "NODE_MAX_ATTEMPT_CONFIG_OPTIONS",
+                            writer.addImport("NODE_MAX_ATTEMPT_CONFIG_OPTIONS", null,
                                     TypeScriptDependency.MIDDLEWARE_RETRY);
                             writer.write("loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS)");
                         },
@@ -114,10 +112,9 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                             writer.addImport("loadConfig", "loadNodeConfig",
                                     TypeScriptDependency.NODE_CONFIG_PROVIDER);
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
-                            writer.addImport("NODE_RETRY_MODE_CONFIG_OPTIONS", "NODE_RETRY_MODE_CONFIG_OPTIONS",
+                            writer.addImport("NODE_RETRY_MODE_CONFIG_OPTIONS", null,
                                     TypeScriptDependency.MIDDLEWARE_RETRY);
-                            writer.addImport("DEFAULT_RETRY_MODE", "DEFAULT_RETRY_MODE",
-                                    TypeScriptDependency.UTIL_RETRY);
+                            writer.addImport("DEFAULT_RETRY_MODE", null, TypeScriptDependency.UTIL_RETRY);
                             writer.openBlock("loadNodeConfig({", "})", () -> {
                                 writer.write("...NODE_RETRY_MODE_CONFIG_OPTIONS,");
                                 writer.write("default: async () => "

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEventStreamDependency.java
@@ -83,14 +83,14 @@ public final class AddEventStreamDependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
-                    writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                    writer.addImport("eventStreamSerdeProvider", null,
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_NODE);
                     writer.write("eventStreamSerdeProvider");
                 });
             case BROWSER:
                 return MapUtils.of("eventStreamSerdeProvider", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
-                    writer.addImport("eventStreamSerdeProvider", "eventStreamSerdeProvider",
+                    writer.addImport("eventStreamSerdeProvider", null,
                             TypeScriptDependency.AWS_SDK_EVENTSTREAM_SERDE_BROWSER);
                     writer.write("eventStreamSerdeProvider");
                 });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddSdkStreamMixinDependency.java
@@ -75,7 +75,7 @@ public final class AddSdkStreamMixinDependency implements TypeScriptIntegration 
         if (target == LanguageTarget.SHARED) {
            return MapUtils.of("sdkStreamMixin", writer -> {
                writer.addDependency(TypeScriptDependency.UTIL_STREAM);
-               writer.addImport("sdkStreamMixin", "sdkStreamMixin", TypeScriptDependency.UTIL_STREAM);
+               writer.addImport("sdkStreamMixin", null, TypeScriptDependency.UTIL_STREAM);
                writer.write("sdkStreamMixin");
            });
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberDeserVisitor.java
@@ -44,6 +44,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -144,43 +145,45 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public String booleanShape(BooleanShape shape) {
-        context.getWriter().addImport("expectBoolean", "__expectBoolean", "@smithy/smithy-client");
+        context.getWriter().addImport("expectBoolean", "__expectBoolean", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectBoolean(" + dataSource + ")";
     }
 
     @Override
     public String byteShape(ByteShape shape) {
-        context.getWriter().addImport("expectByte", "__expectByte", "@smithy/smithy-client");
+        context.getWriter().addImport("expectByte", "__expectByte", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectByte(" + dataSource + ")";
     }
 
     @Override
     public String shortShape(ShortShape shape) {
-        context.getWriter().addImport("expectShort", "__expectShort", "@smithy/smithy-client");
+        context.getWriter().addImport("expectShort", "__expectShort", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectShort(" + dataSource + ")";
     }
 
     @Override
     public String integerShape(IntegerShape shape) {
-        context.getWriter().addImport("expectInt32", "__expectInt32", "@smithy/smithy-client");
+        context.getWriter().addImport("expectInt32", "__expectInt32", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectInt32(" + dataSource + ")";
     }
 
     @Override
     public String longShape(LongShape shape) {
-        context.getWriter().addImport("expectLong", "__expectLong", "@smithy/smithy-client");
+        context.getWriter().addImport("expectLong", "__expectLong", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectLong(" + dataSource + ")";
     }
 
     @Override
     public String floatShape(FloatShape shape) {
-        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32", "@smithy/smithy-client");
+        context.getWriter().addImport("limitedParseFloat32", "__limitedParseFloat32",
+            TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__limitedParseFloat32(" + dataSource + ")";
     }
 
     @Override
     public String doubleShape(DoubleShape shape) {
-        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble", "@smithy/smithy-client");
+        context.getWriter().addImport("limitedParseDouble", "__limitedParseDouble",
+            TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__limitedParseDouble(" + dataSource + ")";
     }
 
@@ -201,7 +204,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
     }
 
     private String deserializeToBigJs() {
-        context.getWriter().addImport("Big", "__Big", "big.js");
+        context.getWriter().addImport("Big", "__Big", TypeScriptDependency.BIG_JS);
         return "__Big(" + dataSource + ")";
     }
 
@@ -277,7 +280,7 @@ public class DocumentMemberDeserVisitor implements ShapeVisitor<String> {
 
     @Override
     public final String unionShape(UnionShape shape) {
-        context.getWriter().addImport("expectUnion", "__expectUnion", "@smithy/smithy-client");
+        context.getWriter().addImport("expectUnion", "__expectUnion", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return getDelegateDeserializer(shape, "__expectUnion(" + dataSource + ")");
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/DocumentMemberSerVisitor.java
@@ -44,6 +44,7 @@ import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.typescript.codegen.knowledge.SerdeElisionIndex;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -170,7 +171,7 @@ public class DocumentMemberSerVisitor implements ShapeVisitor<String> {
     }
 
     private String handleFloat() {
-        context.getWriter().addImport("serializeFloat", "__serializeFloat", "@smithy/smithy-client");
+        context.getWriter().addImport("serializeFloat", "__serializeFloat", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__serializeFloat(" + dataSource + ")";
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/EventStreamGenerator.java
@@ -521,7 +521,7 @@ public class EventStreamGenerator {
                 String deserFunctionName = ProtocolGenerator.getDeserFunctionShortName(symbol);
                 boolean mayElide = serdeElisionEnabled && serdeElisionIndex.mayElide(payloadShape);
                 if (mayElide) {
-                    writer.addImport("_json", null, "@smithy/smithy-client");
+                    writer.addImport("_json", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
                     writer.write("contents.$L = $L(data);", payloadMemberName, "_json");
                 } else {
                     writer.write("contents.$L = $L(data, context);", payloadMemberName, deserFunctionName);
@@ -534,7 +534,7 @@ public class EventStreamGenerator {
             String deserFunctionName = ProtocolGenerator.getDeserFunctionShortName(symbol);
             boolean mayElide = serdeElisionEnabled && serdeElisionIndex.mayElide(event);
             if (mayElide) {
-                writer.addImport("_json", null, "@smithy/smithy-client");
+                writer.addImport("_json", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
                 writer.write("Object.assign(contents, $L(data));", "_json");
             } else {
                 writer.write("Object.assign(contents, $L(data, context));", deserFunctionName);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -163,10 +163,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     @Override
     public void generateSharedComponents(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addImport("map", null, "@smithy/smithy-client");
+        writer.addImport("map", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
 
         if (context.getSettings().generateClient()) {
-            writer.addImport("withBaseException", null, "@smithy/smithy-client");
+            writer.addImport("withBaseException", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
             SymbolReference exception = HttpProtocolGeneratorUtils.getClientBaseException(context);
             writer.write("const throwDefaultError = withBaseException($T);", exception);
         }
@@ -262,9 +262,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         HttpBindingIndex bindingIndex = HttpBindingIndex.of(context.getModel());
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", "@aws-smithy/server-common");
+        writer.addImport("SmithyFrameworkException", "__SmithyFrameworkException", TypeScriptDependency.SERVER_COMMON);
         writer.addUseImports(responseType);
-        writer.addImport("ServerSerdeContext", null, "@aws-smithy/server-common");
+        writer.addImport("ServerSerdeContext", null, TypeScriptDependency.SERVER_COMMON);
 
         writer.openBlock("export const serializeFrameworkException = async(\n"
                 + "  input: __SmithyFrameworkException,\n"
@@ -289,7 +289,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("httpbinding", null, "@aws-smithy/server-common");
+        writer.addImport("httpbinding", null, TypeScriptDependency.SERVER_COMMON);
 
         Symbol serviceSymbol = context.getSymbolProvider().toSymbol(context.getService());
 
@@ -313,7 +313,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void generateOperationMux(GenerationContext context, OperationShape operation) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("httpbinding", null, "@aws-smithy/server-common");
+        writer.addImport("httpbinding", null, TypeScriptDependency.SERVER_COMMON);
 
         writer.openBlock("const mux = new httpbinding.HttpBindingMux<$S, $S>([", "]);",
                 context.getService().getId().getName(),
@@ -379,10 +379,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         Set<OperationShape> operations = index.getContainedOperations(context.getService());
         SymbolProvider symbolProvider = context.getSymbolProvider();
 
-        writer.addImport("serializeFrameworkException", null,
+        writer.addRelativeImport("serializeFrameworkException", null,
             Paths.get(".", CodegenUtils.SOURCE_FOLDER, PROTOCOLS_FOLDER,
-                ProtocolGenerator.getSanitizedName(getName())).toString());
-        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", "@aws-smithy/server-common");
+                ProtocolGenerator.getSanitizedName(getName())));
+        writer.addImport("ValidationCustomizer", "__ValidationCustomizer", TypeScriptDependency.SERVER_COMMON);
         writer.addImport("HttpRequest", "__HttpRequest", TypeScriptDependency.PROTOCOL_HTTP);
         writer.addImport("HttpResponse", "__HttpResponse", TypeScriptDependency.PROTOCOL_HTTP);
 
@@ -403,7 +403,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.indent();
 
         generateServiceMux(context);
-        writer.addImport("ServiceException", "__ServiceException", "@aws-smithy/server-common");
+        writer.addImport("ServiceException", "__ServiceException", TypeScriptDependency.SERVER_COMMON);
         writer.openBlock("const serFn: (op: $1T) => __OperationSerializer<$2T<Context>, $1T, __ServiceException> = "
                        + "(op) => {", "};", operationsSymbol, serviceSymbol, () -> {
             writer.openBlock("switch (op) {", "}", () -> {
@@ -414,8 +414,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         });
 
         if (!context.getSettings().isDisableDefaultValidation()) {
-            writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
-            writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
+            writer.addImport("generateValidationSummary", "__generateValidationSummary",
+                TypeScriptDependency.SERVER_COMMON);
+            writer.addImport("generateValidationMessage", "__generateValidationMessage",
+                TypeScriptDependency.SERVER_COMMON);
             writer.openBlock("const customizer: __ValidationCustomizer<$T> = (ctx, failures) => {", "};",
                 operationsSymbol,
                 () -> {
@@ -461,8 +463,10 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         generateOperationMux(context, operation);
 
         if (!context.getSettings().isDisableDefaultValidation()) {
-            writer.addImport("generateValidationSummary", "__generateValidationSummary", "@aws-smithy/server-common");
-            writer.addImport("generateValidationMessage", "__generateValidationMessage", "@aws-smithy/server-common");
+            writer.addImport("generateValidationSummary", "__generateValidationSummary",
+                TypeScriptDependency.SERVER_COMMON);
+            writer.addImport("generateValidationMessage", "__generateValidationMessage",
+                TypeScriptDependency.SERVER_COMMON);
             writer.openBlock("const customizer: __ValidationCustomizer<$S> = (ctx, failures) => {", "};",
                 operationSymbol.getName(),
                 () -> {
@@ -533,7 +537,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         writer.addUseImports(responseType);
         String methodName = ProtocolGenerator.getGenericSerFunctionName(symbol) + "Response";
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
-        writer.addImport("ServerSerdeContext", null, "@aws-smithy/server-common");
+        writer.addImport("ServerSerdeContext", null, TypeScriptDependency.SERVER_COMMON);
 
         writer.openBlock("export const $L = async(\n"
                 + "  input: $T,\n"
@@ -569,7 +573,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     private void calculateContentLength(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
         writer.addDependency(TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
-        writer.addImport("calculateBodyLength", null, "@smithy/util-body-length-node");
+        writer.addImport("calculateBodyLength", null, TypeScriptDependency.AWS_SDK_UTIL_BODY_LENGTH_NODE);
         writer.openBlock("if (body && Object.keys(headers).map((str) => str.toLowerCase())"
                 + ".indexOf('content-length') === -1) {", "}", () -> {
             writer.write("const length = calculateBodyLength(body);");
@@ -589,7 +593,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.addUseImports(responseType);
         String methodName = ProtocolGenerator.getGenericSerFunctionName(symbol) + "Error";
-        writer.addImport("ServerSerdeContext", null, "@aws-smithy/server-common");
+        writer.addImport("ServerSerdeContext", null, TypeScriptDependency.SERVER_COMMON);
 
         writer.openBlock("export const $L = async(\n"
                 + "  input: $T,\n"
@@ -782,7 +786,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         // Handle any label bindings.
         if (!labelBindings.isEmpty()) {
-            writer.addImport("resolvedPath", "__resolvedPath", "@smithy/smithy-client");
+            writer.addImport("resolvedPath", "__resolvedPath", TypeScriptDependency.AWS_SMITHY_CLIENT);
 
             Model model = context.getModel();
             List<Segment> uriLabels = trait.getUri().getLabels();
@@ -834,7 +838,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 if (!queryParamsBindings.isEmpty()) {
                     SymbolProvider symbolProvider = context.getSymbolProvider();
                     String memberName = symbolProvider.toMemberName(queryParamsBindings.get(0).getMember());
-                    writer.addImport("convertMap", "convertMap", "@smithy/smithy-client");
+                    writer.addImport("convertMap", "convertMap", TypeScriptDependency.AWS_SMITHY_CLIENT);
                     writer.write("...convertMap(input.$L),", memberName);
                 }
                 // Handle any additional query bindings.
@@ -860,13 +864,13 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         String memberName = symbolProvider.toMemberName(binding.getMember());
         writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent",
-                "@smithy/smithy-client");
+                TypeScriptDependency.AWS_SMITHY_CLIENT);
 
         Shape target = model.expectShape(binding.getMember().getTarget());
 
         boolean isIdempotencyToken = binding.getMember().hasTrait(IdempotencyTokenTrait.class);
         if (isIdempotencyToken) {
-            writer.addImport("v4", "generateIdempotencyToken", "uuid");
+            writer.addImport("v4", "generateIdempotencyToken", TypeScriptDependency.UUID);
         }
         boolean isRequired = binding.getMember().isRequired();
         String idempotencyComponent = (isIdempotencyToken && !isRequired) ? " ?? generateIdempotencyToken()" : "";
@@ -880,7 +884,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             target
         );
 
-        writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
+        writer.addImport("expectNonNull", "__expectNonNull", TypeScriptDependency.AWS_SMITHY_CLIENT);
 
         if (Objects.equals("input." + memberName + memberAssertionComponent, queryValue)) {
             String value = isRequired ? "__expectNonNull($L, `" + memberName + "`)" : "$L";
@@ -1790,7 +1794,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         TypeScriptWriter writer = context.getWriter();
         writer.addImport("UnsupportedMediaTypeException",
                 "__UnsupportedMediaTypeException",
-                "@aws-smithy/server-common");
+                TypeScriptDependency.SERVER_COMMON);
         Optional<String> optionalContentType = bindingIndex.determineRequestContentType(
                 operation, getDocumentContentType());
         writer.write("const contentTypeHeaderKey: string | undefined = Object.keys(output.headers)"
@@ -1846,8 +1850,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 operation, getDocumentContentType());
         writer.addImport("NotAcceptableException",
                 "__NotAcceptableException",
-                "@aws-smithy/server-common");
-        writer.addImport("acceptMatches", "__acceptMatches", "@aws-smithy/server-common");
+                TypeScriptDependency.SERVER_COMMON);
+        writer.addImport("acceptMatches", "__acceptMatches", TypeScriptDependency.SERVER_COMMON);
         writer.write("const acceptHeaderKey: string | undefined = Object.keys(output.headers)"
                 + ".find(key => key.toLowerCase() === 'accept');");
         writer.openBlock("if (acceptHeaderKey != null) {", "};", () -> {
@@ -1906,7 +1910,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 } else {
                     writer.addImport("SerializationException",
                             "__SerializationException",
-                            "@aws-smithy/server-common");
+                            TypeScriptDependency.SERVER_COMMON);
                     writer.write("let queryValue: string;");
                     writer.openBlock("if (Array.isArray(query[$S])) {", "}",
                         binding.getLocationName(),
@@ -1952,7 +1956,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             } else {
                 writer.addImport("SerializationException",
                         "__SerializationException",
-                        "@aws-smithy/server-common");
+                        TypeScriptDependency.SERVER_COMMON);
                 writer.openBlock("if (Array.isArray(value)) {", "}",
                         () -> {
                             writer.openBlock("if (value.length === 1) {", "}",
@@ -2320,8 +2324,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         if (!documentBindings.isEmpty()) {
             // If the response has document bindings, the body can be parsed to a JavaScript object.
-            writer.addImport("expectObject", "__expectObject", "@smithy/smithy-client");
-            writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
+            writer.addImport("expectObject", "__expectObject", TypeScriptDependency.AWS_SMITHY_CLIENT);
+            writer.addImport("expectNonNull", "__expectNonNull", TypeScriptDependency.AWS_SMITHY_CLIENT);
             String bodyLocation = "(__expectObject(await parseBody(output.body, context)))";
             // Use the protocol specific error location for retrieving contents.
             if (operationOrError instanceof StructureShape) {
@@ -2398,12 +2402,12 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             writer.write("const data: any = await collectBody(output.body, context);");
         } else if (target instanceof StructureShape) {
             // If payload is a Structure, then we need to parse the string into JavaScript object.
-            writer.addImport("expectObject", "__expectObject", "@smithy/smithy-client");
+            writer.addImport("expectObject", "__expectObject", TypeScriptDependency.AWS_SMITHY_CLIENT);
             writer.write("const data: Record<string, any> | undefined "
                     + "= __expectObject(await parseBody(output.body, context));");
         } else if (target instanceof UnionShape) {
             // If payload is a Union, then we need to parse the string into JavaScript object.
-            writer.addImport("expectUnion", "__expectUnion", "@smithy/smithy-client");
+            writer.addImport("expectUnion", "__expectUnion", TypeScriptDependency.AWS_SMITHY_CLIENT);
             writer.write("const data: Record<string, any> | undefined "
                     + "= __expectUnion(await parseBody(output.body, context));");
         } else if (target instanceof StringShape || target instanceof DocumentShape) {
@@ -2541,7 +2545,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             case QUERY:
             case LABEL:
             case HEADER:
-                context.getWriter().addImport("parseBoolean", "__parseBoolean", "@smithy/smithy-client");
+                context.getWriter().addImport("parseBoolean", "__parseBoolean", TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return String.format("__parseBoolean(%s)", dataSource);
             default:
                 throw new CodegenException("Unexpected boolean binding location `" + bindingType + "`");
@@ -2657,7 +2661,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
                     if (format == Format.HTTP_DATE) {
                         TypeScriptWriter writer = context.getWriter();
-                        writer.addImport("splitEvery", "__splitEvery", "@smithy/smithy-client");
+                        writer.addImport("splitEvery", "__splitEvery", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         outputParam = "__splitEvery(" + dataSource + ", ',', 2)";
                     }
                 }
@@ -2732,28 +2736,28 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
                 switch (target.getType()) {
                     case DOUBLE:
                         context.getWriter().addImport(
-                                "strictParseDouble", "__strictParseDouble", "@smithy/smithy-client");
+                                "strictParseDouble", "__strictParseDouble", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseDouble(" + dataSource + ")";
                     case FLOAT:
                         context.getWriter().addImport(
-                                "strictParseFloat", "__strictParseFloat", "@smithy/smithy-client");
+                                "strictParseFloat", "__strictParseFloat", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseFloat(" + dataSource + ")";
                     case LONG:
                         context.getWriter().addImport(
-                                "strictParseLong", "__strictParseLong", "@smithy/smithy-client");
+                                "strictParseLong", "__strictParseLong", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseLong(" + dataSource + ")";
                     case INT_ENUM:
                     case INTEGER:
                         context.getWriter().addImport(
-                                "strictParseInt32", "__strictParseInt32", "@smithy/smithy-client");
+                                "strictParseInt32", "__strictParseInt32", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseInt32(" + dataSource + ")";
                     case SHORT:
                         context.getWriter().addImport(
-                                "strictParseShort", "__strictParseShort", "@smithy/smithy-client");
+                                "strictParseShort", "__strictParseShort", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseShort(" + dataSource + ")";
                     case BYTE:
                         context.getWriter().addImport(
-                                "strictParseByte", "__strictParseByte", "@smithy/smithy-client");
+                                "strictParseByte", "__strictParseByte", TypeScriptDependency.AWS_SMITHY_CLIENT);
                         return "__strictParseByte(" + dataSource + ")";
                     default:
                         throw new CodegenException("Unexpected number shape `" + target.getType() + "`");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpProtocolGeneratorUtils.java
@@ -84,7 +84,8 @@ public final class HttpProtocolGeneratorUtils {
             case EPOCH_SECONDS:
                 return "Math.round(" + dataSource + ".getTime() / 1000)";
             case HTTP_DATE:
-                context.getWriter().addImport("dateToUtcString", "__dateToUtcString", "@smithy/smithy-client");
+                context.getWriter().addImport("dateToUtcString", "__dateToUtcString",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return "__dateToUtcString(" + dataSource + ")";
             default:
                 throw new CodegenException("Unexpected timestamp format `" + format.toString() + "` on " + shape);
@@ -115,27 +116,30 @@ public final class HttpProtocolGeneratorUtils {
                                                  boolean isClient) {
         // This has always explicitly wrapped the dataSource in "new Date(..)", so it could never generate
         // an expression that evaluates to null. Codegen relies on this.
-        writer.addImport("expectNonNull", "__expectNonNull", "@smithy/smithy-client");
+        writer.addImport("expectNonNull", "__expectNonNull", TypeScriptDependency.AWS_SMITHY_CLIENT);
         switch (format) {
             case DATE_TIME:
                 // Clients should be able to handle offsets and normalize the datetime to an offset of zero.
                 if (isClient) {
                     writer.addImport("parseRfc3339DateTimeWithOffset", "__parseRfc3339DateTimeWithOffset",
-                        "@smithy/smithy-client");
+                        TypeScriptDependency.AWS_SMITHY_CLIENT);
                     return String.format("__expectNonNull(__parseRfc3339DateTimeWithOffset(%s))", dataSource);
                 } else {
-                    writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime", "@smithy/smithy-client");
+                    writer.addImport("parseRfc3339DateTime", "__parseRfc3339DateTime",
+                        TypeScriptDependency.AWS_SMITHY_CLIENT);
                     return String.format("__expectNonNull(__parseRfc3339DateTime(%s))", dataSource);
                 }
             case HTTP_DATE:
-                writer.addImport("parseRfc7231DateTime", "__parseRfc7231DateTime", "@smithy/smithy-client");
+                writer.addImport("parseRfc7231DateTime", "__parseRfc7231DateTime",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return String.format("__expectNonNull(__parseRfc7231DateTime(%s))", dataSource);
             case EPOCH_SECONDS:
-                writer.addImport("parseEpochTimestamp", "__parseEpochTimestamp", "@smithy/smithy-client");
+                writer.addImport("parseEpochTimestamp", "__parseEpochTimestamp",
+                    TypeScriptDependency.AWS_SMITHY_CLIENT);
                 String modifiedDataSource = dataSource;
                 if (requireNumericEpochSecondsInPayload
                         && (bindingType == Location.DOCUMENT || bindingType == Location.PAYLOAD)) {
-                    writer.addImport("expectNumber", "__expectNumber", "@smithy/smithy-client");
+                    writer.addImport("expectNumber", "__expectNumber", TypeScriptDependency.AWS_SMITHY_CLIENT);
                     modifiedDataSource = String.format("__expectNumber(%s)", dataSource);
                 }
                 return String.format("__expectNonNull(__parseEpochTimestamp(%s))", modifiedDataSource);
@@ -163,7 +167,7 @@ public final class HttpProtocolGeneratorUtils {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
-                writer.addImport("LazyJsonString", "__LazyJsonString", "@smithy/smithy-client");
+                writer.addImport("LazyJsonString", "__LazyJsonString", TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return "__LazyJsonString.fromObject(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
@@ -194,7 +198,7 @@ public final class HttpProtocolGeneratorUtils {
             String mediaType = mediaTypeTrait.get().getValue();
             if (CodegenUtils.isJsonMediaType(mediaType)) {
                 TypeScriptWriter writer = context.getWriter();
-                writer.addImport("LazyJsonString", "__LazyJsonString", "@smithy/smithy-client");
+                writer.addImport("LazyJsonString", "__LazyJsonString", TypeScriptDependency.AWS_SMITHY_CLIENT);
                 return "new __LazyJsonString(" + dataSource + ")";
             } else {
                 LOGGER.warning(() -> "Found unsupported mediatype " + mediaType + " on String shape: " + shape);
@@ -204,7 +208,7 @@ public final class HttpProtocolGeneratorUtils {
         if (!useExpect) {
             return dataSource;
         }
-        context.getWriter().addImport("expectString", "__expectString", "@smithy/smithy-client");
+        context.getWriter().addImport("expectString", "__expectString", TypeScriptDependency.AWS_SMITHY_CLIENT);
         return "__expectString(" + dataSource + ")";
     }
 
@@ -234,7 +238,7 @@ public final class HttpProtocolGeneratorUtils {
     static void generateMetadataDeserializer(GenerationContext context, SymbolReference responseType) {
         TypeScriptWriter writer = context.getWriter();
 
-        writer.addImport("ResponseMetadata", "__ResponseMetadata", "@smithy/types");
+        writer.addImport("ResponseMetadata", "__ResponseMetadata", TypeScriptDependency.SMITHY_TYPES);
         writer.openBlock("const deserializeMetadata = (output: $T): __ResponseMetadata => ({", "});", responseType,
                 () -> {
                     writer.write("httpStatusCode: output.statusCode,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -133,7 +133,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         TypeScriptWriter writer = context.getWriter();
 
         if (context.getSettings().generateClient()) {
-            writer.addImport("withBaseException", null, "@smithy/smithy-client");
+            writer.addImport("withBaseException", null, TypeScriptDependency.AWS_SMITHY_CLIENT);
             SymbolReference exception = HttpProtocolGeneratorUtils.getClientBaseException(context);
             writer.write("const throwDefaultError = withBaseException($T);", exception);
         }
@@ -142,7 +142,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         SymbolReference requestType = getApplicationProtocol().getRequestType();
         writer.addUseImports(requestType);
         writer.addImport("SerdeContext", "__SerdeContext", TypeScriptDependency.SMITHY_TYPES);
-        writer.addImport("HeaderBag", "__HeaderBag", "@smithy/types");
+        writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
         writer.openBlock("const buildHttpRpcRequest = async (\n"
                        + "  context: __SerdeContext,\n"
                        + "  headers: __HeaderBag,\n"
@@ -326,7 +326,7 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
      */
     protected void writeSharedRequestHeaders(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
-        writer.addImport("HeaderBag", "__HeaderBag", "@smithy/types");
+        writer.addImport("HeaderBag", "__HeaderBag", TypeScriptDependency.SMITHY_TYPES);
         writer.openBlock("const SHARED_HEADERS: __HeaderBag = {", "};", () -> {
             writer.write("'content-type': $S,", getDocumentContentType());
         });


### PR DESCRIPTION
Updates codegen to use `addImport` method added in https://github.com/awslabs/smithy-typescript/pull/767 and `addRelativeImport` method added in https://github.com/awslabs/smithy-typescript/pull/768.

Some `addImport` usages were also updated to set the `as` parameter to null.
For example:
`.addImport("fromBase64", "fromBase64", TypeScriptDependency.AWS_SDK_UTIL_BASE64);`
was changed to
`.addImport("fromBase64", null, TypeScriptDependency.AWS_SDK_UTIL_BASE64);`

This makes it more clear that an alias is not needed for this import.

For testing, the js-v3 clients were re-generated and there were no code differences for the generated clients, confirming that this change did not change generated code as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
