### PR TITLE
Remove AbortError from the list of transient error codes

### DIFF
--- a/.changeset/curvy-roses-walk.md
+++ b/.changeset/curvy-roses-walk.md
@@ -2,4 +2,4 @@
 "@smithy/service-error-classification": patch
 ---
 
-removing "AbortError" from the list of transient(retryable) error codes
+Remove AbortError from the list of transient error codes

--- a/.changeset/curvy-roses-walk.md
+++ b/.changeset/curvy-roses-walk.md
@@ -1,5 +1,5 @@
 ---
-"@smithy/service-error-classification": major
+"@smithy/service-error-classification": patch
 ---
 
 removing "AbortError" from the list of transient(retryable) error codes

--- a/.changeset/curvy-roses-walk.md
+++ b/.changeset/curvy-roses-walk.md
@@ -1,0 +1,5 @@
+---
+"@smithy/service-error-classification": major
+---
+
+removing "AbortError" from the list of transient(retryable) error codes

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -39,7 +39,7 @@ export const THROTTLING_ERROR_CODES = [
 /**
  * Error codes that indicate transient issues
  */
-export const TRANSIENT_ERROR_CODES = ["AbortError", "TimeoutError", "RequestTimeout", "RequestTimeoutException"];
+export const TRANSIENT_ERROR_CODES = ["TimeoutError", "RequestTimeout", "RequestTimeoutException"];
 
 /**
  * Error codes that indicate transient issues


### PR DESCRIPTION
### Issue

Fixes: [#4871](https://github.com/aws/aws-sdk-js-v3/issues/4871)
Fixes: [#4872 ](https://github.com/aws/aws-sdk-js-v3/issues/4872)

### Description
AbortError is defined as a transient error, which defeats the purposes of aborting mid execution. This causes the retry middleware, to retry even after abort singal was sent. 
This does not affect sending the request itself, as the signal is evaluated by the request handler at invocation time.

### Testing
Existing Implementation without the change demonstrating retries happening, finally the handler throws abortError.
```js
import { Lambda } from "@aws-sdk/client-lambda";
import { StandardRetryStrategy } from "@aws-sdk/util-retry";

const abortSignal = AbortSignal.timeout(1_000);

const lambdaClient = new Lambda({
    region: 'us-west-2',
    retryStrategy: new StandardRetryStrategy(7),
    requestHandler: {
        async handle(_, { abortSignal } = {}) {
          await new Promise((r) => setTimeout(r, 2000));
  
          if (abortSignal?.aborted) {
            const abortError = new Error("Request aborted");
            abortError.name = "AbortError";
            console.log("throwing abort error");
            throw abortError;
          }
  
          return {
            response: new HttpResponse({
              statusCode: 429,
            }),
          };
        },
      },
  });

const beforeCall = performance.now();
try {
  await lambdaClient.invoke({ FunctionName: "test-delay-2s" }, { abortSignal });
  console.log("Request completed successfully.");
} catch (error) {
  console.log("Time to error: ", performance.now() - beforeCall);
  console.error({ error });
}
```

Result without the change:

```console
throwing abort error
throwing abort error
throwing abort error
throwing abort error
throwing abort error
throwing abort error
throwing abort error
Time to error:  17345.45187497139
{
  error: Error [AbortError]: Request aborted
      at Object.handle (file:///Users/rvaknin/test_folder/4871/sample.mjs:14:32)
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:5:26
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-signing/dist-cjs/awsAuthMiddleware.js:14:20
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-retry/dist-cjs/retryMiddleware.js:27:46
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
      at async file:///Users/rvaknin/test_folder/4871/sample.mjs:31:3 {
    '$metadata': { attempts: 7, totalRetryDelay: 3297 }
  }
}
```

Result after change:

```console
$ node sample.mjs
throwing abort error
Time to error:  2022.6821250915527
{
  error: Error [AbortError]: Request aborted
      at Object.handle (file:///Users/rvaknin/test_folder/4871/sample.mjs:14:32)
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:5:26
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-signing/dist-cjs/awsAuthMiddleware.js:14:20
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-retry/dist-cjs/retryMiddleware.js:27:46
      at async /Users/rvaknin/test_folder/4871/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
      at async file:///Users/rvaknin/test_folder/4871/sample.mjs:31:3 {
    '$metadata': { attempts: 1, totalRetryDelay: 0 }
  }
}
```

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
