### PR TITLE
Add changeset instructions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,8 @@
 
 *Description of changes:*
 
+If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
+been committed and included in this pull request. See CONTRIBUTING.md.
 
+---
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
Adds note to PR template on using `yarn changeset add` when modifying any of the NPM packages in the `/packages` directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
