### PR TITLE
fix(codegen): replace mismatch version for server-common

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -116,7 +116,7 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     UTIL_STREAM("dependencies", "@smithy/util-stream", "^1.0.1", false),
 
     // Server dependency for SSDKs
-    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.1-alpha.10", false);
+    SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.0-alpha.10", false);
 
     public static final String NORMAL_DEPENDENCY = "dependencies";
     public static final String DEV_DEPENDENCY = "devDependencies";


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Replace non-existent version with `1.0.0-alpha.10` for `@aws-smithy/server-common` package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.