### PR TITLE
Revert "Revert "Do not suppress on tagged internal enum shape member""

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/StructuredMemberWriter.java
@@ -544,7 +544,7 @@ final class StructuredMemberWriter {
                             }
                             writer.write("], [");
                             for (MemberShape member : shape.asEnumShape().get().getAllMembers().values()) {
-                                if (!member.hasTrait((InternalTrait.class)) && !member.hasTag("internal")) {
+                                if (!member.hasTrait((InternalTrait.class))) {
                                     writer.write("$S,", member.expectTrait(EnumValueTrait.class).expectStringValue());
                                 }
                             }


### PR DESCRIPTION
This reverts commit cbe312126a55bc993d96640a7a33feb734fbc930.

This PR re-introduces the change that was temporarily reverted in https://github.com/awslabs/smithy-typescript/pull/765.

This will allow https://github.com/aws/aws-sdk-js-v3 to upgrade to the latest version of smithy (currently 1.33.0).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
