### PR TITLE
Add back missing dependency

### DIFF
--- a/.changeset/red-rocks-judge.md
+++ b/.changeset/red-rocks-judge.md
@@ -1,0 +1,5 @@
+---
+"@smithy/hash-blob-browser": patch
+---
+
+Added missing chunked-blob-reader-native dependency

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/chunked-blob-reader": "workspace:^",
+    "@smithy/chunked-blob-reader-native": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,7 +1649,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@smithy/chunked-blob-reader-native@workspace:packages/chunked-blob-reader-native":
+"@smithy/chunked-blob-reader-native@workspace:^, @smithy/chunked-blob-reader-native@workspace:packages/chunked-blob-reader-native":
   version: 0.0.0-use.local
   resolution: "@smithy/chunked-blob-reader-native@workspace:packages/chunked-blob-reader-native"
   dependencies:
@@ -1852,6 +1852,7 @@ __metadata:
   dependencies:
     "@aws-crypto/sha256-js": 3.0.0
     "@smithy/chunked-blob-reader": "workspace:^"
+    "@smithy/chunked-blob-reader-native": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/util-hex-encoding": "workspace:^"
     "@tsconfig/recommended": 1.0.1


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-js-v3/issues/4631

*Description of changes:*

Adds back the chunked-blob-reader-native dependency. It was removed in https://github.com/aws/aws-sdk-js-v3/pull/4571 because it wasn't being used in the TS code anywhere, but it is depended on in the package.json [here](https://github.com/aws/aws-sdk-js-v3/blob/797001ffd8bd81595049c6271167891e01b419c1/packages/hash-blob-browser/package.json#L38)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
