### PR TITLE
exposing provider errors, since they should be a part of our public API

### DIFF
--- a/.changeset/shaggy-avocados-serve.md
+++ b/.changeset/shaggy-avocados-serve.md
@@ -1,0 +1,5 @@
+---
+"@smithy/property-provider": patch
+---
+
+Expose provider Errors to be officially available for error handling.

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,7 +1,6 @@
 import { ProviderError } from "./ProviderError";
 
 /**
- * @internal
  *
  * An error representing a failure of an individual credential provider.
  *

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,5 +1,4 @@
 /**
- * @internal
  *
  * An error representing a failure of an individual provider.
  *

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,7 +1,6 @@
 import { ProviderError } from "./ProviderError";
 
 /**
- * @internal
  *
  * An error representing a failure of an individual token provider.
  *


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/4907
https://github.com/aws/aws-sdk-js-v3/issues/4918

*Description of changes:*
Currently, if an error occurs within a provider and it throws an exception that is marked "internal", customers might not have a clear and stable way to identify and handle these exceptions. This can lead to challenges in ensuring that their applications behave correctly when encountering errors during the credential providing process.

Because of this, provider errors should be moved out of the "internal" state, and offered as part of our public API.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
