### PR TITLE
Fix @smithy/protocol-http import in HttpApiKeyAuth spec

### DIFF
--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from "smithy/protocol-http";
+import { HttpRequest } from "@smithy/protocol-http";
 import { MiddlewareStack } from "@smithy/types";
 
 import {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this fix, building the generated SSDK fails:

```
$ concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'
$ tsc -p tsconfig.es.json
$ tsc -p tsconfig.types.json
$ tsc -p tsconfig.cjs.json
[build:types] src/middleware/HttpApiKeyAuth/index.spec.ts(4,29): error TS2307: Cannot find module 'smithy/protocol-http' or its corresponding type declarations.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[build:types] yarn run build:types exited with code 2
[build:es] src/middleware/HttpApiKeyAuth/index.spec.ts(4,29): error TS2307: Cannot find module 'smithy/protocol-http' or its corresponding type declarations.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[build:cjs] src/middleware/HttpApiKeyAuth/index.spec.ts(4,29): error TS2307: Cannot find module 'smithy/protocol-http' or its corresponding type declarations.
[build:es] yarn run build:es exited with code 2
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[build:cjs] yarn run build:cjs exited with code 2
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: /Users/jhecking/.nvm/versions/node/v16.19.0/bin/node
Arguments: /opt/homebrew/Cellar/yarn/1.22.19/libexec/lib/cli.js run build
Directory: /Users/jhecking/path/to/project
Output:
```

Smithy version used:
```
smithyVersion=1.33.0
smithyTypeScriptVersion=0.17.0
smithyGradleVersion=0.7.0
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
