### PR TITLE
Add test script when specs are generated

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -115,6 +115,9 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     @Deprecated UTIL_STREAM_BROWSER("dependencies", "@smithy/util-stream-browser", "^1.0.1", false),
     UTIL_STREAM("dependencies", "@smithy/util-stream", "^1.0.1", false),
 
+    // Conditionally added when specs have been generated.
+    VITEST("devDependencies", "vitest", "^0.33.0", false),
+
     // Server dependency for SSDKs
     SERVER_COMMON("dependencies", "@aws-smithy/server-common", "1.0.0-alpha.10", false);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPlugin.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.Symbol;
-import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -145,11 +144,7 @@ public final class AddHttpApiKeyAuthPlugin implements TypeScriptIntegration {
         writerFactory.accept(
                 Paths.get(CodegenUtils.SOURCE_FOLDER, "middleware", INTEGRATION_NAME, "index.spec.ts").toString(),
                 writer -> {
-                        writer.addDependency(SymbolDependency.builder()
-                                .dependencyType("devDependencies")
-                                .packageName("@types/jest")
-                                .version("latest")
-                                .build());
+                        writer.addDependency(TypeScriptDependency.VITEST);
 
                         String source = IoUtils.readUtf8Resource(getClass(), "http-api-key-auth.spec.ts");
                         writer.write("$L$L", noTouchNoticePrefix, "http-api-key-auth.spec.ts");

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/integration/http-api-key-auth.spec.ts
@@ -1,5 +1,6 @@
 import { HttpRequest } from "@smithy/protocol-http";
 import { MiddlewareStack } from "@smithy/types";
+import { vi } from "vitest";
 
 import {
   getHttpApiKeyAuthPlugin,
@@ -28,8 +29,8 @@ describe("getHttpApiKeyAuthPlugin", () => {
       }
     );
 
-    const mockApplied = jest.fn();
-    const mockOther = jest.fn();
+    const mockApplied = vi.fn();
+    const mockOther = vi.fn();
 
     // TODO there's got to be a better way to do this mocking
     plugin.applyToStack({
@@ -52,10 +53,10 @@ describe("getHttpApiKeyAuthPlugin", () => {
 
 describe("httpApiKeyAuthMiddleware", () => {
   describe("returned middleware function", () => {
-    const mockNextHandler = jest.fn();
+    const mockNextHandler = vi.fn();
 
     beforeEach(() => {
-      jest.clearAllMocks();
+      vi.clearAllMocks();
     });
 
     it("should set the query parameter if the location is `query`", async () => {

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/vite.config.ts
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/vite.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+    globals: true
+  },
+})


### PR DESCRIPTION
This PR updates codegen to write a `test` script and vite.config.ts file when a spec has been generated.

For example, the `AddHttpApiKeyAuthPlugin` writes a generated spec file, and now adds a dependency on `vitest`. A test script and vite.config.ts are now added when this plugin is used so that the spec can easily be run with `yarn test` within the generated SSDK package.

It also converts the spec generated to use vitest, replacing jest.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
