### PR TITLE
Bump webpack to 5.76.0

### DIFF
--- a/.changeset/beige-moons-glow.md
+++ b/.changeset/beige-moons-glow.md
@@ -1,0 +1,7 @@
+---
+"@smithy/fetch-http-handler": patch
+"@smithy/hash-blob-browser": patch
+"@smithy/util-stream": patch
+---
+
+Bump webpack to 5.76.0

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "28.0.5",
     "turbo": "latest",
     "typescript": "~4.9.5",
-    "webpack": "5.73.0",
+    "webpack": "5.76.0",
     "webpack-cli": "4.10.0",
     "yarn": "1.22.10"
   },

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -53,7 +53,7 @@
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
     "typescript": "~4.9.5",
-    "webpack": "5.73.0",
+    "webpack": "5.76.0",
     "webpack-cli": "4.10.0"
   },
   "typesVersions": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -51,7 +51,7 @@
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
     "typescript": "~4.9.5",
-    "webpack": "5.73.0",
+    "webpack": "5.76.0",
     "webpack-cli": "4.10.0"
   },
   "react-native": {

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -53,7 +53,7 @@
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
     "typescript": "~4.9.5",
-    "webpack": "5.73.0",
+    "webpack": "5.76.0",
     "webpack-cli": "4.10.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,7 +1841,7 @@ __metadata:
     tslib: ^2.5.0
     typedoc: 0.23.23
     typescript: ~4.9.5
-    webpack: 5.73.0
+    webpack: 5.76.0
     webpack-cli: 4.10.0
   languageName: unknown
   linkType: soft
@@ -1877,7 +1877,7 @@ __metadata:
     tslib: ^2.5.0
     typedoc: 0.23.23
     typescript: ~4.9.5
-    webpack: 5.73.0
+    webpack: 5.76.0
     webpack-cli: 4.10.0
   languageName: unknown
   linkType: soft
@@ -2552,7 +2552,7 @@ __metadata:
     tslib: ^2.5.0
     typedoc: 0.23.23
     typescript: ~4.9.5
-    webpack: 5.73.0
+    webpack: 5.76.0
     webpack-cli: 4.10.0
   languageName: unknown
   linkType: soft
@@ -3313,12 +3313,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.8.2":
+"acorn@npm:^8.1.0, acorn@npm:^8.5.0, acorn@npm:^8.8.2":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
     acorn: bin/acorn
   checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.7.1":
+  version: 8.10.0
+  resolution: "acorn@npm:8.10.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 538ba38af0cc9e5ef983aee196c4b8b4d87c0c94532334fa7e065b2c8a1f85863467bb774231aae91613fcda5e68740c15d97b1967ae3394d20faddddd8af61d
   languageName: node
   linkType: hard
 
@@ -5000,7 +5009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.9.3":
+"enhanced-resolve@npm:^5.10.0":
   version: 5.15.0
   resolution: "enhanced-resolve@npm:5.15.0"
   dependencies:
@@ -9542,7 +9551,7 @@ __metadata:
     ts-jest: 28.0.5
     turbo: latest
     typescript: ~4.9.5
-    webpack: 5.73.0
+    webpack: 5.76.0
     webpack-cli: 4.10.0
     yarn: 1.22.10
   languageName: unknown
@@ -10718,7 +10727,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.3.1":
+"watchpack@npm:^2.4.0":
   version: 2.4.0
   resolution: "watchpack@npm:2.4.0"
   dependencies:
@@ -10810,20 +10819,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.73.0":
-  version: 5.73.0
-  resolution: "webpack@npm:5.73.0"
+"webpack@npm:5.76.0":
+  version: 5.76.0
+  resolution: "webpack@npm:5.76.0"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^0.0.51
     "@webassemblyjs/ast": 1.11.1
     "@webassemblyjs/wasm-edit": 1.11.1
     "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.4.1
+    acorn: ^8.7.1
     acorn-import-assertions: ^1.7.6
     browserslist: ^4.14.5
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.9.3
+    enhanced-resolve: ^5.10.0
     es-module-lexer: ^0.9.0
     eslint-scope: 5.1.1
     events: ^3.2.0
@@ -10836,14 +10845,14 @@ __metadata:
     schema-utils: ^3.1.0
     tapable: ^2.1.1
     terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.3.1
+    watchpack: ^2.4.0
     webpack-sources: ^3.2.3
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: aa434a241bad6176b68e1bf0feb1972da4dcbf27cb3d94ae24f6eb31acc37dceb9c4aae55e068edca75817bfe91f13cd20b023ac55d9b1b2f8b66a4037c9468f
+  checksum: e897b3b34068222fe910d8894837cbf39f5e66b4772fe8d24dfc0090cd13e19337a3a757a97bc185be6c64d9d5a7b1ae372821b65a6079ce8c7ceba606edb409
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump webpack to 5.76.0.

See https://github.com/awslabs/smithy-typescript/pull/779.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
