### PR TITLE
Add build script for generated client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'corretto'
-      - name: Generate client
-        run: ./gradlew clean build
-      - name: Build client
+      - name: Run build-test-client
         run: |
-          cd smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen/
-          touch yarn.lock
           yarn config set enableImmutableInstalls false
           yarn
-          yarn build
+          yarn build-test-client
 
   lint-typescript:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "turbo run lint",
     "format": "turbo run format --parallel",
     "stage-release": "turbo run stage-release",
-    "release": "yarn changeset publish"
+    "release": "yarn changeset publish",
+    "build-test-client": "./gradlew clean build && cd smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen && touch yarn.lock && yarn && yarn build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a build script to package.json which runs the test client codegen and attempts to build the generated TypeScript client. 

`yarn build-test-client` will run codegen and build the resulting generated client.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
