### PR TITLE
Add SSDK codegen test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ subprojects {
      * Java
      * ====================================================
      */
-    if (subproject.name != "smithy-typescript-codegen-test") {
+    if (subproject.name == "smithy-typescript-codegen") {
         apply(plugin = "java-library")
 
         java {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 rootProject.name = "smithy-typescript"
 include(":smithy-typescript-codegen")
 include(":smithy-typescript-codegen-test")
+include(":smithy-typescript-ssdk-codegen-test-utils")
 
 file(
     java.nio.file.Paths.get(rootProject.projectDir.absolutePath, "local.properties"))

--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -44,6 +44,7 @@ repositories {
 
 dependencies {
     implementation(project(":smithy-typescript-codegen"))
+    implementation(project(":smithy-typescript-ssdk-codegen-test-utils"))
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
 }

--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -8,6 +8,7 @@ use smithy.waiters#waitable
 
 /// Provides weather forecasts.
 @fakeProtocol
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
     version: "2006-03-01",
@@ -317,6 +318,7 @@ blob CityImageData
 
 @readonly
 @http(method: "GET", uri: "/cities/{cityId}/announcements")
+@tags(["client-only"])
 operation GetCityAnnouncements {
     input: GetCityAnnouncementsInput,
     output: GetCityAnnouncementsOutput,

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -1,5 +1,29 @@
 {
     "version": "1.0",
+    "projections": {
+        "ssdk-test": {
+            "transforms": [
+                {
+                    "name": "excludeShapesByTag",
+                    "args": {
+                        "tags": ["client-only"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-ssdk-codegen": {
+                    "service": "example.weather#Weather",
+                    "targetNamespace": "Weather",
+                    "package": "weather",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0"
+                    },
+                    "disableDefaultValidation": true
+                }
+            }
+        }
+    },
     "plugins": {
         "typescript-codegen": {
             "service": "example.weather#Weather",

--- a/smithy-typescript-ssdk-codegen-test-utils/build.gradle.kts
+++ b/smithy-typescript-ssdk-codegen-test-utils/build.gradle.kts
@@ -1,0 +1,32 @@
+extra["displayName"] = "Smithy :: Typescript :: SSDK :: Codegen :: Test :: Utils"
+extra["moduleName"] = "software.amazon.smithy.typescript.ssdk.codegen.test.utils"
+
+val smithyVersion: String by project
+
+buildscript {
+    val smithyVersion: String by project
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
+
+plugins {
+    val smithyGradleVersion: String by project
+
+    id("software.amazon.smithy").version(smithyGradleVersion)
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":smithy-typescript-codegen"))
+    implementation("software.amazon.smithy:smithy-model:$smithyVersion")
+}

--- a/smithy-typescript-ssdk-codegen-test-utils/src/main/java/software/amazon/smithy/typescript/ssdk/codegen/test/utils/AddProtocols.java
+++ b/smithy-typescript-ssdk-codegen-test-utils/src/main/java/software/amazon/smithy/typescript/ssdk/codegen/test/utils/AddProtocols.java
@@ -1,0 +1,19 @@
+ package software.amazon.smithy.typescript.ssdk.codegen.test.utils;
+
+ import java.util.List;
+ import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
+ import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+ import software.amazon.smithy.utils.ListUtils;
+ import software.amazon.smithy.utils.SmithyInternalApi;
+ 
+ /**
+  * Adds fake protocols.
+  */
+ @SmithyInternalApi
+ public class AddProtocols implements TypeScriptIntegration {
+ 
+     @Override
+     public List<ProtocolGenerator> getProtocolGenerators() {
+         return ListUtils.of(new FakeProtocolGenerator());
+     }
+ }

--- a/smithy-typescript-ssdk-codegen-test-utils/src/main/java/software/amazon/smithy/typescript/ssdk/codegen/test/utils/FakeProtocolGenerator.java
+++ b/smithy-typescript-ssdk-codegen-test-utils/src/main/java/software/amazon/smithy/typescript/ssdk/codegen/test/utils/FakeProtocolGenerator.java
@@ -1,0 +1,106 @@
+package software.amazon.smithy.typescript.ssdk.codegen.test.utils;
+
+import java.util.List;
+import java.util.Set;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
+import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+
+ /**
+  * Fake protocol for SSDK codegen testing.
+  */
+@SmithyInternalApi
+public class FakeProtocolGenerator extends HttpBindingProtocolGenerator {
+
+    FakeProtocolGenerator() {
+        super(true);
+    }
+
+    @Override
+    public ShapeId getProtocol() {
+        return ShapeId.from("example.weather#fakeProtocol");
+    }
+
+    @Override
+    public String getName() {
+        return "fakeProtocol";
+    }
+
+    @Override
+    protected String getDocumentContentType() {
+        return "application/json";
+    }
+
+    @Override
+    public Format getDocumentTimestampFormat() {
+        return Format.EPOCH_SECONDS;
+    }
+
+    @Override
+    public boolean requiresNumericEpochSecondsInPayload() {
+        return true;
+    }
+
+    @Override
+    public void deserializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void serializeErrorDocumentBody(
+            GenerationContext context,
+            StructureShape error,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void deserializeInputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void serializeInputDocumentBody(
+            GenerationContext context,
+            OperationShape operation,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void deserializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape error,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void serializeOutputDocumentBody(
+            GenerationContext context,
+            OperationShape error,
+            List<HttpBinding> documentBindings
+    ) {}
+
+    @Override
+    public void serializeInputEventDocumentPayload(GenerationContext context) {}
+
+    @Override
+    public void generateDocumentBodyShapeSerializers(GenerationContext context, Set<Shape> shapes) {}
+
+    @Override
+    public void generateDocumentBodyShapeDeserializers(GenerationContext context, Set<Shape> shapes) {}
+
+    @Override
+    public void writeErrorCodeParser(GenerationContext context) {}
+
+    @Override
+    public void generateProtocolTests(GenerationContext context) {}
+}

--- a/smithy-typescript-ssdk-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-ssdk-codegen-test-utils/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.typescript.ssdk.codegen.test.utils.AddProtocols


### PR DESCRIPTION
This PR adds testing of the `typescript-ssdk-codegen` plugin.

It adds the non-published `software.amazon.smithy.typescript.ssdk.codegen.test.utils` package, which includes an empty `FakeProtocolGenerator` which enables SSDK codegen to succeed since a protocol is required for an SSDK.

Currently, SSDK validation for `@streaming` union shapes is not supported, so the `GetCityAnnouncements` is removed from the generated SSDK since it uses the `@streaming` union `Announcements` shape in its output. Once support for this is added, the operation can be added back to the model.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
