### PR TITLE
Externalize provider errors

### DIFF
--- a/.changeset/shaggy-avocados-serve.md
+++ b/.changeset/shaggy-avocados-serve.md
@@ -1,0 +1,5 @@
+---
+"@smithy/property-provider": patch
+---
+
+Expose provider Errors to be officially available for error handling.

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,8 +1,8 @@
 import { ProviderError } from "./ProviderError";
 
 /**
- *
  * @public
+ *
  * An error representing a failure of an individual credential provider.
  *
  * This error class has special meaning to the {@link chain} method. If a

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -2,6 +2,7 @@ import { ProviderError } from "./ProviderError";
 
 /**
  *
+ * @public
  * An error representing a failure of an individual credential provider.
  *
  * This error class has special meaning to the {@link chain} method. If a

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,7 +1,6 @@
 import { ProviderError } from "./ProviderError";
 
 /**
- * @internal
  *
  * An error representing a failure of an individual credential provider.
  *

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,4 +1,5 @@
 /**
+ * @public
  *
  * An error representing a failure of an individual provider.
  *

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,5 +1,4 @@
 /**
- * @internal
  *
  * An error representing a failure of an individual provider.
  *

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @public
  *
  * An error representing a failure of an individual token provider.
  *

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,7 +1,6 @@
 import { ProviderError } from "./ProviderError";
 
 /**
- * @internal
  *
  * An error representing a failure of an individual token provider.
  *


### PR DESCRIPTION
*Issue #, if available:*
fixes https://github.com/awslabs/smithy-typescript/pull/815
*Description of changes:*
adding `@public` annotation to externalize errors, as removing `@internal` wasnt enough.