### PR TITLE
fix(property-provider): adding back @public annotation to expose errors

### DIFF
--- a/.changeset/kind-moles-lie.md
+++ b/.changeset/kind-moles-lie.md
@@ -1,0 +1,5 @@
+---
+"@smithy/property-provider": minor
+---
+
+adding @public annotation to errors

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @public
  *
  * An error representing a failure of an individual credential provider.
  *

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,4 +1,5 @@
 /**
+ * @public
  *
  * An error representing a failure of an individual provider.
  *

--- a/packages/property-provider/src/TokenProviderError.ts
+++ b/packages/property-provider/src/TokenProviderError.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "./ProviderError";
 
 /**
+ * @public
  *
  * An error representing a failure of an individual token provider.
  *


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/smithy-typescript/pull/815

*Description of changes:*
adding back `@public` annotation after removing `@internal` to expose errors