### PR TITLE
Move vitest config to js

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
@@ -31,7 +31,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 final class PackageJsonGenerator {
 
     public static final String PACKAGE_JSON_FILENAME = "package.json";
-    public static final String VITEST_CONFIG_FILENAME = "vite.config.ts";
+    public static final String VITEST_CONFIG_FILENAME = "vite.config.js";
 
     private PackageJsonGenerator() {}
 
@@ -56,7 +56,7 @@ final class PackageJsonGenerator {
             node = node.withMember(depEntry.getKey(), builder.build());
         }
 
-        // Add test script and vite.config.ts if specs and their devDependency on vitest has been generated.
+        // Add test script and vite.config.js if specs and their devDependency on vitest has been generated.
         ObjectNode devDeps = node.getObjectMember("devDependencies").orElse(Node.objectNode());
         if (devDeps.containsMember(TypeScriptDependency.VITEST.packageName)) {
             ObjectNode scripts = node.getObjectMember("scripts").orElse(Node.objectNode());

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/vite.config.js
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/vite.config.js
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 
 export default defineConfig({


### PR DESCRIPTION
Move vitest.config.ts to vitest.config.js to avoid this file getting built and included in the `dist-*` outputs.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
