### PR TITLE
Add PackageContainer interface

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageContainer.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageContainer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+/**
+ * A container for packages.
+ */
+public interface PackageContainer {
+    /**
+     * Gets the name of the contained package.
+     *
+     * @return Returns the name of the package.
+     */
+    String getPackageName();
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -37,7 +37,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * An enum of all of the built-in dependencies managed by this package.
  */
 @SmithyUnstableApi
-public enum TypeScriptDependency implements SymbolDependencyContainer {
+public enum TypeScriptDependency implements PackageContainer, SymbolDependencyContainer {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", "^1.0.1", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
@@ -171,6 +171,11 @@ public enum TypeScriptDependency implements SymbolDependencyContainer {
     @Override
     public List<SymbolDependency> getDependencies() {
         return Collections.singletonList(dependency);
+    }
+
+    @Override
+    public String getPackageName() {
+        return this.packageName;
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -122,11 +122,11 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
      *
      * @param name Type to import.
      * @param as Alias to refer to the type as.
-     * @param from TypeScriptDependency to import the type from.
+     * @param from PackageContainer to import the type from.
      * @return Returns the writer.
      */
-    public TypeScriptWriter addImport(String name, String as, TypeScriptDependency from) {
-        return this.addImport(name, as, from.packageName);
+    public TypeScriptWriter addImport(String name, String as, PackageContainer from) {
+        return this.addImport(name, as, from.getPackageName());
     }
 
     /**


### PR DESCRIPTION
This PR adds a `PackageContainer` interface and updates TypeScriptWriter's `addImport` method to use it.

This will allow downstream Dependency classes to implement `PackageContainer` for better `addImport` usage without passing just strings.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
