### PR TITLE
Include resource files in source jars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,7 @@ subprojects {
         // Set up tasks that build source and javadoc jars.
         tasks.register<Jar>("sourcesJar") {
             metaInf.with(licenseSpec)
-            from(sourceSets.main.get().allJava)
+            from(sourceSets.main.get().allSource)
             archiveClassifier.set("sources")
         }
 


### PR DESCRIPTION
Updates build.gradle.kts to include resource files in source jars.

See same change in https://github.com/smithy-lang/smithy/pull/1877.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
