### PR TITLE
fix: advance types@1.x line

### DIFF
--- a/.changeset/quiet-adults-deny.md
+++ b/.changeset/quiet-adults-deny.md
@@ -1,0 +1,56 @@
+---
+"@smithy/abort-controller": minor
+"@smithy/chunked-blob-reader": minor
+"@smithy/chunked-blob-reader-native": minor
+"@smithy/config-resolver": minor
+"@smithy/credential-provider-imds": minor
+"@smithy/eventstream-codec": minor
+"@smithy/eventstream-serde-browser": minor
+"@smithy/eventstream-serde-config-resolver": minor
+"@smithy/eventstream-serde-node": minor
+"@smithy/eventstream-serde-universal": minor
+"@smithy/fetch-http-handler": minor
+"@smithy/hash-blob-browser": minor
+"@smithy/hash-node": minor
+"@smithy/hash-stream-node": minor
+"@smithy/invalid-dependency": minor
+"@smithy/is-array-buffer": minor
+"@smithy/md5-js": minor
+"@smithy/middleware-apply-body-checksum": minor
+"@smithy/middleware-content-length": minor
+"@smithy/middleware-endpoint": minor
+"@smithy/middleware-retry": minor
+"@smithy/middleware-serde": minor
+"@smithy/middleware-stack": minor
+"@smithy/node-config-provider": minor
+"@smithy/node-http-handler": minor
+"@smithy/property-provider": minor
+"@smithy/protocol-http": minor
+"@smithy/querystring-builder": minor
+"@smithy/querystring-parser": minor
+"@smithy/service-client-documentation-generator": minor
+"@smithy/service-error-classification": minor
+"@smithy/shared-ini-file-loader": minor
+"@smithy/signature-v4": minor
+"@smithy/smithy-client": minor
+"@smithy/types": minor
+"@smithy/url-parser": minor
+"@smithy/util-base64": minor
+"@smithy/util-body-length-browser": minor
+"@smithy/util-body-length-node": minor
+"@smithy/util-buffer-from": minor
+"@smithy/util-config-provider": minor
+"@smithy/util-defaults-mode-browser": minor
+"@smithy/util-defaults-mode-node": minor
+"@smithy/util-hex-encoding": minor
+"@smithy/util-middleware": minor
+"@smithy/util-retry": minor
+"@smithy/util-stream": minor
+"@smithy/util-stream-browser": minor
+"@smithy/util-stream-node": minor
+"@smithy/util-uri-escape": minor
+"@smithy/util-utf8": minor
+"@smithy/util-waiter": minor
+---
+
+set types to the 1.x line

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smithy/types",
-  "version": "2.0.0",
+  "version": "1.1.1",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
     "build:cjs": "tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
set all packages back onto the types@1.x line, and create another version of types in the 1.x line