### PR TITLE
Add test clients to workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
 
-  build-generated-client:
+  build-generated-client-and-ssdk:
     runs-on: ubuntu-latest
-    name: Build generated client
+    name: Build generated client and ssdk packages
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -42,31 +42,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'corretto'
-      - name: Run build-test-client
+      - name: Run build-test-packages
         run: |
           yarn config set enableImmutableInstalls false
           yarn
-          yarn build-test-client
-
-  build-generated-ssdk:
-    runs-on: ubuntu-latest
-    name: Build generated ssdk
-    steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'corretto'
-      - name: Run build-test-ssdk
-        run: |
-          yarn config set enableImmutableInstalls false
-          yarn
-          yarn build-test-ssdk
+          yarn build-test-packages
 
   lint-typescript:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "stage-release": "turbo run stage-release",
     "extract:docs": "mkdir -p api-extractor-packages && turbo run extract:docs",
     "release": "yarn changeset publish",
-    "build-test-client": "./gradlew clean build && cd smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen && touch yarn.lock && yarn && yarn build",
-    "build-test-ssdk": "./gradlew clean build && cd smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/ssdk-test/typescript-ssdk-codegen && touch yarn.lock && yarn && yarn build"
+    "build-test-packages": "./gradlew clean build && yarn && yarn build --filter=weather --filter=weather-ssdk --force --concurrency=2"
   },
   "repository": {
     "type": "git",
@@ -64,7 +63,9 @@
   },
   "workspaces": [
     "packages/*",
-    "smithy-typescript-ssdk-libs/*"
+    "smithy-typescript-ssdk-libs/*",
+    "smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen",
+    "smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/ssdk-test/typescript-ssdk-codegen"
   ],
   "packageManager": "yarn@3.4.1"
 }

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -14,10 +14,11 @@
                 "typescript-ssdk-codegen": {
                     "service": "example.weather#Weather",
                     "targetNamespace": "Weather",
-                    "package": "weather",
+                    "package": "weather-ssdk",
                     "packageVersion": "0.0.1",
                     "packageJson": {
-                        "license": "Apache-2.0"
+                        "license": "Apache-2.0",
+                        "private": true
                     },
                     "disableDefaultValidation": true
                 }
@@ -31,7 +32,8 @@
             "package": "weather",
             "packageVersion": "0.0.1",
             "packageJson": {
-                "license": "Apache-2.0"
+                "license": "Apache-2.0",
+                "private": true
             }
         }
     }


### PR DESCRIPTION
This PR does the following:
* Adds generated client and SSDK packages to the workspace
* Marks client (weather) and SSDK (weather-ssdk) packages a private to prevent them from being published out of the workspace.
* Consolidates CI for building these generated packages as a single step
* Updates package.json script to run building generated packages using `yarn build` from top level.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
