### PR TITLE
fix: sort query parameter values after encoding

### DIFF
--- a/.changeset/clever-spies-change.md
+++ b/.changeset/clever-spies-change.md
@@ -1,0 +1,5 @@
+---
+"@smithy/signature-v4": patch
+---
+
+fix: multiple value parameters query string signature

--- a/packages/signature-v4/src/getCanonicalQuery.spec.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.spec.ts
@@ -96,6 +96,17 @@ describe("getCanonicalQuery", () => {
     ).toBe("%F0%9F%90%8E=%F0%9F%92%A9&%F0%9F%90%8E=%F0%9F%A6%84");
   });
 
+  it("should sort URI-encode members of query param arrays", () => {
+    expect(
+      getCanonicalQuery(
+        new HttpRequest({
+          ...httpRequestOptions,
+          query: { "p": ["a", "à"] },
+        })
+      )
+    ).toBe("p=%C3%A0&p=a");
+  });
+
   it("should omit non-string, non-array values from the serialized query", () => {
     expect(
       getCanonicalQuery(

--- a/packages/signature-v4/src/getCanonicalQuery.spec.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.spec.ts
@@ -101,7 +101,7 @@ describe("getCanonicalQuery", () => {
       getCanonicalQuery(
         new HttpRequest({
           ...httpRequestOptions,
-          query: { "p": ["a", "à"] },
+          query: { p: ["a", "à"] },
         })
       )
     ).toBe("p=%C3%A0&p=a");

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -21,11 +21,11 @@ export const getCanonicalQuery = ({ query = {} }: HttpRequest): string => {
     } else if (Array.isArray(value)) {
       serialized[key] = value
         .slice(0)
-        .sort()
         .reduce(
           (encoded: Array<string>, value: string) => encoded.concat([`${escapeUri(key)}=${escapeUri(value)}`]),
           []
         )
+        .sort()
         .join("&");
     }
   }


### PR DESCRIPTION
This solves the issue #848.

As stated in the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request) on signing API requests (emphasis in mine),
> `CanonicalQueryString` – The URL-encoded query string parameters, separated by ampersands (&). Percent-encode reserved characters, including the space character. Encode names and values separately. If there are empty parameters, append the equals sign to the parameter name before encoding. **After encoding, sort the parameters alphabetically** by key name. If there is no query string, use an empty string ("").

*Description of changes:*

- sort the parameter values after encoding in `getCanonicalQuery`,
- test the associated edge case.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
