### PR TITLE
docs: set public release tags on client config interface components

### DIFF
--- a/.changeset/ten-frogs-help.md
+++ b/.changeset/ten-frogs-help.md
@@ -1,0 +1,11 @@
+---
+"@smithy/eventstream-serde-config-resolver": patch
+"@smithy/middleware-apply-body-checksum": patch
+"@smithy/middleware-endpoint": patch
+"@smithy/middleware-retry": patch
+"@smithy/config-resolver": patch
+"@smithy/smithy-client": patch
+"@smithy/types": patch
+---
+
+add release tag public to client init interface components

--- a/packages/config-resolver/api-extractor.json
+++ b/packages/config-resolver/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -11,7 +11,8 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "jest"
+    "test": "jest",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
@@ -4,7 +4,7 @@ import { normalizeProvider } from "@smithy/util-middleware";
 import { EndpointsInputConfig, EndpointsResolvedConfig } from "./resolveEndpointsConfig";
 
 /**
- * @internal
+ * @public
  */
 export interface CustomEndpointsInputConfig extends EndpointsInputConfig {
   /**

--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -4,7 +4,7 @@ import { normalizeProvider } from "@smithy/util-middleware";
 import { getEndpointFromRegion } from "./utils/getEndpointFromRegion";
 
 /**
- * @internal
+ * @public
  */
 export interface EndpointsInputConfig {
   /**

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
@@ -4,7 +4,7 @@ import { getRealRegion } from "./getRealRegion";
 import { isFipsRegion } from "./isFipsRegion";
 
 /**
- * @internal
+ * @public
  */
 export interface RegionInputConfig {
   /**

--- a/packages/eventstream-serde-config-resolver/api-extractor.json
+++ b/packages/eventstream-serde-config-resolver/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -11,7 +11,8 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "jest"
+    "test": "jest",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
+++ b/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
@@ -1,7 +1,7 @@
 import { EventStreamMarshaller, EventStreamSerdeProvider } from "@smithy/types";
 
 /**
- * @internal
+ * @public
  */
 export interface EventStreamSerdeInputConfig {}
 

--- a/packages/middleware-apply-body-checksum/src/md5Configuration.ts
+++ b/packages/middleware-apply-body-checksum/src/md5Configuration.ts
@@ -1,5 +1,8 @@
 import { ChecksumConstructor, Encoder, HashConstructor, StreamHasher } from "@smithy/types";
 
+/**
+ * @public
+ */
 export interface Md5BodyChecksumInputConfig {}
 interface PreviouslyResolved {
   md5: ChecksumConstructor | HashConstructor;

--- a/packages/middleware-endpoint/api-extractor.json
+++ b/packages/middleware-endpoint/api-extractor.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../api-extractor.packages.json",
+  "mainEntryPointFilePath": "./dist-types/index.d.ts"
+}

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -11,7 +11,8 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "extract:docs": "api-extractor run --local"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/middleware-endpoint/src/index.ts
+++ b/packages/middleware-endpoint/src/index.ts
@@ -10,9 +10,6 @@ export * from "./endpointMiddleware";
  * @internal
  */
 export * from "./getEndpointPlugin";
-/**
- * @internal
- */
 export * from "./resolveEndpointConfig";
 /**
  * @internal

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -4,7 +4,7 @@ import { normalizeProvider } from "@smithy/util-middleware";
 import { toEndpointV1 } from "./adaptors/toEndpointV1";
 
 /**
- * @internal
+ * @public
  *
  * Endpoint config interfaces and resolver for Endpoint v2. They live in separate package to allow per-service onboarding.
  * When all services onboard Endpoint v2, the resolver in config-resolver package can be removed.

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -34,6 +34,9 @@ export const NODE_MAX_ATTEMPT_CONFIG_OPTIONS: LoadedConfigSelectors<number> = {
   default: DEFAULT_MAX_ATTEMPTS,
 };
 
+/**
+ * @public
+ */
 export interface RetryInputConfig {
   /**
    * The maximum number of times requests that encounter retryable failures should be attempted.

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -2,7 +2,7 @@ import { constructStack } from "@smithy/middleware-stack";
 import { Client as IClient, Command, MetadataBearer, MiddlewareStack, RequestHandler } from "@smithy/types";
 
 /**
- * @internal
+ * @public
  */
 export interface SmithyConfiguration<HandlerOptions> {
   requestHandler: RequestHandler<any, any, HandlerOptions>;

--- a/packages/smithy-client/src/defaults-mode.ts
+++ b/packages/smithy-client/src/defaults-mode.ts
@@ -38,7 +38,7 @@ export const loadConfigsForDefaultMode = (mode: ResolvedDefaultsMode): DefaultsM
  * * `"auto"`: <p>The AUTO mode is an experimental mode that builds on the standard mode. The SDK will attempt to discover the execution environment to determine the appropriate settings automatically.</p><p>Note that the auto detection is heuristics-based and does not guarantee 100% accuracy. STANDARD mode will be used if the execution environment cannot be determined. The auto detection might query <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">EC2 Instance Metadata service</a>, which might introduce latency. Therefore we recommend choosing an explicit defaults_mode instead if startup latency is critical to your application</p>
  * * `"legacy"`: <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
  *
- * @default "legacy"
+ * @defaultValue "legacy"
  */
 export type DefaultsMode = "standard" | "in-region" | "cross-region" | "mobile" | "auto" | "legacy";
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -33,7 +33,7 @@ export interface InvokeFunction<
 }
 
 /**
- * @internal
+ * @public
  *
  * Signature that appears on aggregated clients' methods.
  */

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -1,5 +1,5 @@
 /**
- * @internal
+ * @public
  */
 export interface ResponseMetadata {
   /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.PaginatedTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.waiters.WaitableTrait;
@@ -104,6 +105,11 @@ final class IndexGenerator {
         // Write export statement for aggregated client.
         String aggregatedClientName = symbol.getName().replace("Client", "");
         writer.write("export * from \"./$L\";", aggregatedClientName);
+
+        // export endpoints config interface
+        if (service.hasTrait(EndpointRuleSetTrait.class)) {
+            writer.write("export { ClientInputEndpointParameters } from \"./endpoint/EndpointParameters\";");
+        }
 
         // Write export statement for commands.
         writer.write("export * from \"./commands\";");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/EndpointsV2Generator.java
@@ -72,6 +72,7 @@ public final class EndpointsV2Generator implements Runnable {
                 writer.addImport("EndpointParameters", "__EndpointParameters", TypeScriptDependency.SMITHY_TYPES);
                 writer.addImport("Provider", null, TypeScriptDependency.SMITHY_TYPES);
 
+                writer.writeDocs("@public");
                 writer.openBlock(
                     "export interface ClientInputEndpointParameters {",
                     "}",


### PR DESCRIPTION
for types that comprise the client initialization api, set the release tag to `@public` so that the api doc pages for JSv3 include them.

merge with: https://github.com/aws/aws-sdk-js-v3/pull/5018