### PR TITLE
Add extensions to client runtime config

### DIFF
--- a/.changeset/gold-nails-end.md
+++ b/.changeset/gold-nails-end.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+add extensions to client runtime config

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -1,0 +1,58 @@
+import {ChecksumConstructor} from "../checksum";
+import {HashConstructor} from "../crypto";
+import {DefaultClientConfiguration} from "./defaultClientConfiguration";
+
+/**
+ * @internal
+ */
+export interface ChecksumAlgorithm {
+    algorithmId(): string;
+    checksumConstructor(): ChecksumConstructor | HashConstructor;
+}
+
+/**
+ * @internal
+ */
+export const getChecksumClientConfiguration = (runtimeConfig: any) => {
+    const checksumAlgorithms: ChecksumAlgorithm[] = [];
+
+    if (runtimeConfig.sha256 !== undefined) {
+        checksumAlgorithms.push({
+            algorithmId: () => "sha256",
+            checksumConstructor: runtimeConfig.sha256
+        })
+    }
+
+    if (runtimeConfig.md5 !== undefined) {
+        checksumAlgorithms.push({
+            algorithmId: () => "md5",
+            checksumConstructor: runtimeConfig.md5
+        })
+    }
+
+    const clientConfiguration = {
+        _checksumAlgorithms: checksumAlgorithms,
+        addChecksumAlgorithm: function(algo: ChecksumAlgorithm): void {
+            this._checksumAlgorithms.push(algo);
+        },
+        checksumAlgorithms: function(): ChecksumAlgorithm[] {
+            return this._checksumAlgorithms;
+        }
+    }
+
+    return clientConfiguration;
+}
+
+/**
+ * @internal
+ */
+export const resolveChecksumRuntimeConfig = (clientConfig: DefaultClientConfiguration) => {
+    const runtimeConfig: any = {
+    };
+
+    clientConfig.checksumAlgorithms().forEach(checksumAlgorithm => {
+        runtimeConfig[checksumAlgorithm.algorithmId()] = checksumAlgorithm.checksumConstructor();
+    });
+
+    return runtimeConfig;
+}

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -1,58 +1,86 @@
-import {ChecksumConstructor} from "../checksum";
-import {HashConstructor} from "../crypto";
-import {DefaultClientConfiguration} from "./defaultClientConfiguration";
+import { ChecksumConstructor } from "../checksum";
+import { HashConstructor } from "../crypto";
+
+/**
+ * @internal
+ */
+export enum AlgorithmId {
+  MD5 = "md5",
+  CRC32 = "crc32",
+  CRC32C = "crc32c",
+  SHA1 = "sha1",
+  SHA256 = "sha256",
+}
 
 /**
  * @internal
  */
 export interface ChecksumAlgorithm {
-    algorithmId(): string;
-    checksumConstructor(): ChecksumConstructor | HashConstructor;
+  algorithmId(): AlgorithmId;
+  checksumConstructor(): ChecksumConstructor | HashConstructor;
 }
+
+export interface ChecksumConfiguration {
+  addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
+  checksumAlgorithms(): ChecksumAlgorithm[];
+
+  [other: string | number | symbol]: any;
+}
+
+type GetChecksumConfigurationType = (
+  runtimeConfig: Partial<{
+    sha256: ChecksumConstructor | HashConstructor;
+    md5: ChecksumConstructor | HashConstructor;
+  }>
+) => ChecksumConfiguration;
 
 /**
  * @internal
  */
-export const getChecksumClientConfiguration = (runtimeConfig: any) => {
-    const checksumAlgorithms: ChecksumAlgorithm[] = [];
+export const getChecksumConfiguration: GetChecksumConfigurationType = (
+  runtimeConfig: Partial<{
+    sha256: ChecksumConstructor | HashConstructor;
+    md5: ChecksumConstructor | HashConstructor;
+  }>
+) => {
+  const checksumAlgorithms: ChecksumAlgorithm[] = [];
 
-    if (runtimeConfig.sha256 !== undefined) {
-        checksumAlgorithms.push({
-            algorithmId: () => "sha256",
-            checksumConstructor: runtimeConfig.sha256
-        })
-    }
-
-    if (runtimeConfig.md5 !== undefined) {
-        checksumAlgorithms.push({
-            algorithmId: () => "md5",
-            checksumConstructor: runtimeConfig.md5
-        })
-    }
-
-    const clientConfiguration = {
-        _checksumAlgorithms: checksumAlgorithms,
-        addChecksumAlgorithm: function(algo: ChecksumAlgorithm): void {
-            this._checksumAlgorithms.push(algo);
-        },
-        checksumAlgorithms: function(): ChecksumAlgorithm[] {
-            return this._checksumAlgorithms;
-        }
-    }
-
-    return clientConfiguration;
-}
-
-/**
- * @internal
- */
-export const resolveChecksumRuntimeConfig = (clientConfig: DefaultClientConfiguration) => {
-    const runtimeConfig: any = {
-    };
-
-    clientConfig.checksumAlgorithms().forEach(checksumAlgorithm => {
-        runtimeConfig[checksumAlgorithm.algorithmId()] = checksumAlgorithm.checksumConstructor();
+  if (runtimeConfig.sha256 !== undefined) {
+    checksumAlgorithms.push({
+      algorithmId: () => AlgorithmId.SHA256,
+      checksumConstructor: () => runtimeConfig.sha256!,
     });
+  }
 
-    return runtimeConfig;
-}
+  if (runtimeConfig.md5 != undefined) {
+    checksumAlgorithms.push({
+      algorithmId: () => AlgorithmId.MD5,
+      checksumConstructor: () => runtimeConfig.md5!,
+    });
+  }
+
+  return {
+    _checksumAlgorithms: checksumAlgorithms,
+    addChecksumAlgorithm(algo: ChecksumAlgorithm): void {
+      this._checksumAlgorithms.push(algo);
+    },
+    checksumAlgorithms(): ChecksumAlgorithm[] {
+      return this._checksumAlgorithms;
+    },
+  };
+};
+
+type ResolveChecksumRuntimeConfigType = (clientConfig: ChecksumConfiguration) => any;
+
+/**
+ * @internal
+ */
+export const resolveChecksumRuntimeConfig: ResolveChecksumRuntimeConfigType = (clientConfig: ChecksumConfiguration) => {
+  const runtimeConfig: any = {};
+
+  clientConfig.checksumAlgorithms().forEach((checksumAlgorithm) => {
+    runtimeConfig[checksumAlgorithm.algorithmId()] = checksumAlgorithm.checksumConstructor();
+  });
+
+  return runtimeConfig;
+};

--- a/packages/types/src/extensions/defaultClientConfiguration.ts
+++ b/packages/types/src/extensions/defaultClientConfiguration.ts
@@ -1,37 +1,34 @@
-import {ChecksumAlgorithm, getChecksumClientConfiguration, resolveChecksumRuntimeConfig} from "./checksum";
+import { ChecksumConfiguration, getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
 
 /**
  * @internal
  *
  * Default client configuration consisting various configurations for modifying a service client
  */
-export interface DefaultClientConfiguration {
-    addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
-    checksumAlgorithms(): ChecksumAlgorithm[];
+export interface DefaultClientConfiguration extends ChecksumConfiguration {}
 
-    // TODO: add retries, identity, auth, etc
-}
+type GetDefaultConfigurationType = (runtimeConfig: any) => DefaultClientConfiguration;
 
 /**
  * @internal
  *
  * Helper function to resolve default client configuration from runtime config
  */
-export const getDefaultClientConfiguration = (runtimeConfig: any) => {
-    const defaultClientConfiguration: DefaultClientConfiguration = {
-        ...getChecksumClientConfiguration(runtimeConfig)
-    };
-    return defaultClientConfiguration;
-}
+export const getDefaultClientConfiguration: GetDefaultConfigurationType = (runtimeConfig: any) => {
+  return {
+    ...getChecksumConfiguration(runtimeConfig),
+  };
+};
+
+type ResolveDefaultRuntimeConfigType = (clientConfig: DefaultClientConfiguration) => any;
 
 /**
  * @internal
  *
  * Helper function to resolve runtime config from default client configuration
  */
-export const resolveDefaultRuntimeConfig = (clientConfig: DefaultClientConfiguration) => {
-    const runtimeConfig: any = {
-        ...resolveChecksumRuntimeConfig(clientConfig)
-    };
-    return runtimeConfig;
-}
+export const resolveDefaultRuntimeConfig: ResolveDefaultRuntimeConfigType = (config: DefaultClientConfiguration) => {
+  return {
+    ...resolveChecksumRuntimeConfig(config),
+  };
+};

--- a/packages/types/src/extensions/defaultClientConfiguration.ts
+++ b/packages/types/src/extensions/defaultClientConfiguration.ts
@@ -1,0 +1,37 @@
+import {ChecksumAlgorithm, getChecksumClientConfiguration, resolveChecksumRuntimeConfig} from "./checksum";
+
+/**
+ * @internal
+ *
+ * Default client configuration consisting various configurations for modifying a service client
+ */
+export interface DefaultClientConfiguration {
+    addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
+    checksumAlgorithms(): ChecksumAlgorithm[];
+
+    // TODO: add retries, identity, auth, etc
+}
+
+/**
+ * @internal
+ *
+ * Helper function to resolve default client configuration from runtime config
+ */
+export const getDefaultClientConfiguration = (runtimeConfig: any) => {
+    const defaultClientConfiguration: DefaultClientConfiguration = {
+        ...getChecksumClientConfiguration(runtimeConfig)
+    };
+    return defaultClientConfiguration;
+}
+
+/**
+ * @internal
+ *
+ * Helper function to resolve runtime config from default client configuration
+ */
+export const resolveDefaultRuntimeConfig = (clientConfig: DefaultClientConfiguration) => {
+    const runtimeConfig: any = {
+        ...resolveChecksumRuntimeConfig(clientConfig)
+    };
+    return runtimeConfig;
+}

--- a/packages/types/src/extensions/index.ts
+++ b/packages/types/src/extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./defaultClientConfiguration";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export * from "./encode";
 export * from "./endpoint";
 export * from "./endpoints";
 export * from "./eventStream";
+export * from "./extensions";
 export * from "./http";
 export * from "./identity";
 export * from "./logger";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ClientConfigurationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ClientConfigurationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ClientConfigurationGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ClientConfigurationGenerator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+
+public class ClientConfigurationGenerator {
+
+    private static final String CLIENT_CONFIGURATION_TEMPLATE = "clientConfiguration.template";
+    private static final String FILENAME = "clientConfiguration.ts";
+
+    private final Model model;
+    private final ServiceShape service;
+    private final SymbolProvider symbolProvider;
+    private final TypeScriptDelegator delegator;
+    private final List<TypeScriptIntegration> integrations;
+
+    public ClientConfigurationGenerator(
+        Model model,
+        ServiceShape service,
+        SymbolProvider symbolProvider,
+        TypeScriptDelegator delegator,
+        List<TypeScriptIntegration> integrations
+    ) {
+        this.model = model;
+        this.service = service;
+        this.symbolProvider = symbolProvider;
+        this.delegator = delegator;
+        this.integrations = integrations;
+    }
+
+    void generate() {
+        Map<String, Dependency> interfaces = new HashMap<>();
+
+        for (TypeScriptIntegration integration : integrations) {
+            integration.getClientConfigurationInterfaces().forEach(configurationInterface -> {
+                interfaces.put(configurationInterface.name(),
+                        configurationInterface.dependency());
+            });
+        }
+
+        String clientName = symbolProvider.toSymbol(service).getName();
+
+        String clientConfigurationContent = TypeScriptUtils
+            .loadResourceAsString(CLIENT_CONFIGURATION_TEMPLATE)
+            .replace("${clientConfigName}", clientName + "Configuration")
+            .replace("${clientConfigInterfaces}", String.join(", ", interfaces.keySet()));
+
+        delegator.useFileWriter(Paths.get(CodegenUtils.SOURCE_FOLDER, FILENAME).toString(), writer -> {
+            interfaces.entrySet().forEach(entry -> {
+                writer.addDependency(entry.getValue());
+                writer.addImport(entry.getKey(), null, entry.getValue());
+            });
+            writer.write(clientConfigurationContent);
+        });
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/Dependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/Dependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/Dependency.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
+
+public interface Dependency extends PackageContainer, SymbolDependencyContainer {
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -425,6 +425,12 @@ final class DirectedTypeScriptCodegen
             }
         }
 
+        new ClientConfigurationGenerator(directive.model(), directive.service(), directive.symbolProvider(),
+                directive.context().writerDelegator(), directive.context().integrations()).generate();
+
+        new RuntimeExtensionsGenerator(directive.model(), directive.service(), directive.symbolProvider(),
+                directive.context().writerDelegator(), directive.context().integrations()).generate();
+
         // Generate index for client.
         BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory =
             directive.context().writerDelegator()::useFileWriter;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -128,6 +128,9 @@ final class RuntimeConfigGenerator {
                 writer.addImport("toUtf8", null,
                         TypeScriptDependency.AWS_SDK_UTIL_UTF8);
                 writer.write("toUtf8");
+            },
+            "extensions", writer -> {
+                writer.write("[]");
             }
     );
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeExtensionsGenerator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.nio.file.Paths;
+import java.util.List;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+
+public class RuntimeExtensionsGenerator {
+
+    private static final String TEMPLATE_1 = "runtimeExtensions1.template";
+    private static final String TEMPLATE_2 = "runtimeExtensions2.template";
+    private static final String FILENAME = "runtimeExtensions.ts";
+
+    private final Model model;
+    private final ServiceShape service;
+    private final SymbolProvider symbolProvider;
+    private final TypeScriptDelegator delegator;
+    private final List<TypeScriptIntegration> integrations;
+
+    public RuntimeExtensionsGenerator(
+        Model model, ServiceShape service,
+        SymbolProvider symbolProvider,
+        TypeScriptDelegator delegator,
+        List<TypeScriptIntegration> integrations
+    ) {
+        this.model = model;
+        this.service = service;
+        this.symbolProvider = symbolProvider;
+        this.delegator = delegator;
+        this.integrations = integrations;
+    }
+
+    void generate() {
+        String clientName = symbolProvider.toSymbol(service).getName();
+
+        String template1Contents = TypeScriptUtils.loadResourceAsString(TEMPLATE_1)
+            .replace("${clientConfigName}", clientName + "Configuration")
+            .replace("$", "$$") // sanitize template place holders.
+            .replace("$${getPartialClientConfigurations}", "${L@getPartialClientConfigurations}");
+
+        String template2Contents = TypeScriptUtils.loadResourceAsString(TEMPLATE_2)
+            .replace("$", "$$") // sanitize template place holders.
+            .replace("$${resolvePartialRuntimeConfigs}", "${L@resolvePartialRuntimeConfigs}");
+
+        delegator.useFileWriter(Paths.get(CodegenUtils.SOURCE_FOLDER, FILENAME).toString(), writer -> {
+            for (TypeScriptIntegration integration : integrations) {
+                integration.getClientConfigurationInterfaces().forEach(configurationInterface -> {
+                    writer.addDependency(configurationInterface.dependency());
+                    writer.addImport(configurationInterface.getClientConfigurationFn(), null,
+                            configurationInterface.dependency());
+                    writer.addImport(configurationInterface.resolveRuntimeConfigFn(), null,
+                            configurationInterface.dependency());
+                });
+            }
+
+            writer.indent().onSection("getPartialClientConfigurations", original -> {
+                for (TypeScriptIntegration integration : integrations) {
+                    integration.getClientConfigurationInterfaces().forEach(configurationInterface -> {
+                        writer.indent(2).write("...asPartial($L(runtimeConfig)),",
+                                configurationInterface.getClientConfigurationFn());
+                        writer.dedent(2);
+                    });
+                }
+            });
+            writer.dedent().write(template1Contents, "");
+
+            writer.indent().onSection("resolvePartialRuntimeConfigs", original -> {
+                for (TypeScriptIntegration integration : integrations) {
+                    integration.getClientConfigurationInterfaces().forEach(configurationInterface -> {
+                        writer.indent(2).write("...$L(clientConfiguration),",
+                                configurationInterface.resolveRuntimeConfigFn());
+                        writer.dedent(2);
+                    });
+                }
+            });
+            writer.dedent().write(template2Contents, "");
+        });
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -152,6 +152,8 @@ final class ServiceBareBonesClientGenerator implements Runnable {
     }
 
     private void generateConfig() {
+        writer.addRelativeImport("RuntimeExtensionsConfig", null,
+                Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeExtensions"));
         writer.addImport("SmithyConfiguration", "__SmithyConfiguration", TypeScriptDependency.AWS_SMITHY_CLIENT);
         writer.addImport("SmithyResolvedConfiguration", "__SmithyResolvedConfiguration",
             TypeScriptDependency.AWS_SMITHY_CLIENT);
@@ -202,6 +204,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
         writer.write("export type $LType = __SmithyResolvedConfiguration<$T>",
                      resolvedConfigType, applicationProtocol.getOptionsType());
         writer.write("  & Required<ClientDefaults>");
+        writer.write("  & RuntimeExtensionsConfig");
 
         if (!inputTypes.isEmpty()) {
             writer.indent();
@@ -373,6 +376,14 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                                  additionalParamsString);
                 }
             }
+
+            writer.addRelativeImport("resolveRuntimeExtensions", null,
+                Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeExtensions"));
+
+            configVariable++;
+            writer.write("let $L = resolveRuntimeExtensions($L, configuration.extensions);",
+                generateConfigVariable(configVariable),
+                generateConfigVariable(configVariable - 1));
 
             writer.write("super($L);", generateConfigVariable(configVariable));
             writer.write("this.config = $L;", generateConfigVariable(configVariable));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -381,7 +381,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                 Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeExtensions"));
 
             configVariable++;
-            writer.write("let $L = resolveRuntimeExtensions($L, configuration.extensions);",
+            writer.write("let $L = resolveRuntimeExtensions($L, configuration?.extensions || []);",
                 generateConfigVariable(configVariable),
                 generateConfigVariable(configVariable - 1));
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -30,14 +30,13 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolDependency;
-import software.amazon.smithy.codegen.core.SymbolDependencyContainer;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * An enum of all of the built-in dependencies managed by this package.
  */
 @SmithyUnstableApi
-public enum TypeScriptDependency implements PackageContainer, SymbolDependencyContainer {
+public enum TypeScriptDependency implements Dependency {
 
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", "^2.0.0", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/ClientConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/ClientConfigurationInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 package software.amazon.smithy.typescript.codegen.extensions;
 
 import software.amazon.smithy.typescript.codegen.Dependency;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * An interface class for defining the service client configuration.
  */
+@SmithyInternalApi
 public interface ClientConfigurationInterface {
     /**
      * Define the dependency package where the interface and its related functions are defined in.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/ClientConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/ClientConfigurationInterface.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.extensions;
+
+import software.amazon.smithy.typescript.codegen.Dependency;
+
+/**
+ * An interface class for defining the service client configuration.
+ */
+public interface ClientConfigurationInterface {
+    /**
+     * Define the dependency package where the interface and its related functions are defined in.
+     *
+     * @return Returns a dependency instance
+     */
+    Dependency dependency();
+
+    /**
+     * Define the interface name.
+     *
+     * @return Returns an interface name
+     */
+    String name();
+
+    /**
+     * Define a function that returns an object instance that implements the interface.
+     *
+     * <pre>{@code
+     * interface TimeoutClientConfiguration {
+     *   setTimeout(timeout: number): void;
+     *   timeout(): timeout;
+     * }
+     *
+     * const getTimeoutClientConfigurationFn = (runtimeConfig: any) => {
+     *     let timeout: number = 100;
+     *     if (runtimeConfig.timeout !== undefined) {
+     *         timeout = runtimeConfig.timeout;
+     *     }
+     *
+     *     const clientConfiguration: TimeoutClientConfiguration = {
+     *         _timeout: timeout,
+     *         setTimeout: function(timeout: number): void {
+     *             this._timeout = timeout;
+     *         },
+     *         timeout: function(): number {
+     *             return this._timeout;
+     *         }
+     *     }
+     *
+     *     return clientConfiguration;
+     * }
+     *
+     * }</pre>
+     *
+     * @return Returns a typescript function name
+     */
+    String getClientConfigurationFn();
+
+    /**
+     * Define a function that returns an object instance that implements the interface.
+     *
+     * <pre>{@code
+     * interface TimeoutClientConfiguration {
+     *   setTimeout(timeout: number): void;
+     *   timeout(): timeout;
+     * }
+     *
+     * export const resolveTimeoutRuntimeConfigFn = (clientConfig: TimeoutClientConfiguration) => {
+     *     const runtimeConfig: any = {
+     *        timeout: clientConfig.timeout()
+     *     };
+     *
+     *     return runtimeConfig;
+     * }
+     *
+     * }</pre>
+     *
+     * @return Returns a typescript function name
+     */
+    String resolveRuntimeConfigFn();
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/DefaultClientConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/DefaultClientConfigurationInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/DefaultClientConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/extensions/DefaultClientConfigurationInterface.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.typescript.codegen.extensions;
+
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+
+public class DefaultClientConfigurationInterface implements ClientConfigurationInterface {
+    @Override
+    public TypeScriptDependency dependency() {
+        return TypeScriptDependency.SMITHY_TYPES;
+    }
+
+    @Override
+    public String name() {
+        return "DefaultClientConfiguration";
+    }
+
+    @Override
+    public String getClientConfigurationFn() {
+        return "getDefaultClientConfiguration";
+    }
+
+    @Override
+    public String resolveRuntimeConfigFn() {
+        return "resolveDefaultRuntimeConfig";
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddClientRuntimeConfig.java
@@ -5,15 +5,20 @@
 
 package software.amazon.smithy.typescript.codegen.integration;
 
+import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.extensions.ClientConfigurationInterface;
+import software.amazon.smithy.typescript.codegen.extensions.DefaultClientConfigurationInterface;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -66,6 +71,10 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
                 .write("retryMode?: string | __Provider<string>;\n");
         writer.writeDocs("Optional logger for logging debug/info/warn/error.")
                 .write("logger?: __Logger;\n");
+        writer.addRelativeImport("RuntimeExtension", null,
+                Paths.get(".", CodegenUtils.SOURCE_FOLDER, "runtimeExtensions"));
+        writer.writeDocs("Optional extensions")
+                .write("extensions: RuntimeExtension[];\n");
     }
 
     @Override
@@ -125,5 +134,10 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
         default:
                 return Collections.emptyMap();
         }
+    }
+
+    @Override
+    public List<ClientConfigurationInterface> getClientConfigurationInterfaces() {
+        return List.of(new DefaultClientConfigurationInterface());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.extensions.ClientConfigurationInterface;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -206,5 +207,36 @@ public interface TypeScriptIntegration
             LanguageTarget target
     ) {
          return Collections.emptyMap();
+    }
+
+    /**
+     * Define a list of client configuration interfaces
+     *
+     * A client configuration interface contains settings that modify a service client.
+     * (User should be able to configure timeouts, retry strategy, etc for the client.)
+     *
+     * Multiple interfaces are used to define the client configuration. For example:
+     *
+     * <pre>{@code
+     * interface ChecksumConfig {
+     *   addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
+     *   checksumAlgorithms(): ChecksumAlgorithm[];
+     * }
+     *
+     * interface RetryConfig {
+     *   setRetryStrategy(algo: RetryStrategy): void;
+     *   retryStrategy(): RetryStrategy;
+     * }
+     *
+     * interface ServiceClientConfiguration extends ChecksumConfig, RetryConfig {
+     * }
+     * }</pre>
+     *
+     * During code-generation, smithy-typescript will aggregate the interfaces and create a single client configuration.
+     *
+     * @return list of client configuration interface
+     */
+    default List<ClientConfigurationInterface> getClientConfigurationInterfaces() {
+        return Collections.emptyList();
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -213,7 +213,7 @@ public interface TypeScriptIntegration
      * Define a list of client configuration interfaces
      *
      * A client configuration interface contains settings that modify a service client.
-     * (User should be able to configure timeouts, retry strategy, etc for the client.)
+     *  The client configuration interface enables configuring timeouts, retry strategy, etc for the client.
      *
      * Multiple interfaces are used to define the client configuration. For example:
      *

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/clientConfiguration.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/clientConfiguration.template
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export interface ${clientConfigName} extends ${clientConfigInterfaces} {}

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions1.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions1.template
@@ -1,0 +1,30 @@
+import { ${clientConfigName} } from "./clientConfiguration";
+
+/**
+ * @public
+ */
+export interface RuntimeExtension {
+    configureClient(clientConfiguration: ${clientConfigName}): void;
+}
+
+/**
+ * @public
+ */
+export interface RuntimeExtensionsConfig {
+    extensions: RuntimeExtension[]
+}
+
+const asPartial = <T extends Partial<${clientConfigName}>>(t: T) => t;
+
+/**
+ * @internal
+ */
+export const resolveRuntimeExtensions = (
+    runtimeConfig: any,
+    extensions: RuntimeExtension[]
+) => {
+  const clientConfiguration: ${clientConfigName} = {
+${getPartialClientConfigurations}
+  };
+
+  extensions.forEach(extension => extension.configureClient(clientConfiguration));

--- a/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions2.template
+++ b/smithy-typescript-codegen/src/main/resources/software/amazon/smithy/typescript/codegen/runtimeExtensions2.template
@@ -1,0 +1,5 @@
+  return {
+    ...runtimeConfig,
+${resolvePartialRuntimeConfigs}
+  };
+}


### PR DESCRIPTION
*Description of changes:*
This PR adds `extensions: RuntimeExtension[]` to client runtime config.

```
interface S3ClientConfiguration extends DefaultClientConfiguration,  AwsClientConfiguration, ... {
}

interface RuntimeExtension {
    configureClient(clientConfiguration: S3ClientConfiguration): void;
}
```

The service client can be configured by implementing the `RuntimeExtension` interface. `*ClientConfiguration` is an interface that includes settings that can be modified on the service client. Because services have different configuration, each service has a code-generated ClientConfiguration interface implementation. Service owner can compose multiple client configurations by implementing `TypeScriptIntegration.getClientConfigurationInterfaces`

Using S3 as an example:

``` 
export class CustomChecksumExtension implements RuntimeExtension {
    configureClient(clientConfiguration: S3ClientConfiguration): void {
       clientConfiguration.addChecksumAlgorithm(...);
    }
}

// extensions can be passed via the client constructor object
S3Client({
  retryStrategy: new AdaptiveRetryStrategy(params),
  sha256: Hash.bind(null, "sha256")
  ...
  extensions: [CustomChecksumExtension()]
})
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
