### PR TITLE
docs: fix missing release tag on shape members

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java
@@ -191,7 +191,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     if (shape.getTrait(DeprecatedTrait.class).isPresent()) {
                         docs = "@deprecated\n\n" + docs;
                     }
-                    docs = writeReleaseTag(shape, docs);
+                    docs = addReleaseTag(shape, docs);
                     writeDocs(docs);
                     return true;
                 }).orElse(false);
@@ -228,7 +228,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                     if (member.getTrait(DeprecatedTrait.class).isPresent() || isTargetDeprecated(model, member)) {
                         docs = "@deprecated\n\n" + docs;
                     }
-                    writeReleaseTag(member, docs);
+                    docs = addReleaseTag(member, docs);
                     writeDocs(docs);
                     return true;
                 }).orElse(false);
@@ -240,7 +240,7 @@ public final class TypeScriptWriter extends SymbolWriter<TypeScriptWriter, Impor
                && !Prelude.isPreludeShape(member.getTarget());
     }
 
-    private String writeReleaseTag(Shape shape, String docs) {
+    private String addReleaseTag(Shape shape, String docs) {
         if (shape.getTrait(InternalTrait.class).isPresent()) {
             docs = "@internal\n" + docs;
         } else {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/UnionGenerator.java
@@ -216,6 +216,7 @@ final class UnionGenerator implements Runnable {
         }
 
         // Write out the unknown variant.
+        writer.writeDocs("@public");
         writer.openBlock("export interface $$UnknownMember {", "}", () -> {
             for (MemberShape member : shape.getAllMembers().values()) {
                 writer.write("$L?: never;", symbolProvider.toMemberName(member));


### PR DESCRIPTION
The return value of `writeReleaseTag(member, docs);` was being ignored in one instance.
I changed the (private) method name to something other than "write", so as not to imply it calls the writer itself.