### PR TITLE
Add `matchSettings()` to `RuntimeClientPlugin`s

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -92,8 +92,12 @@ final class DirectedTypeScriptCodegen
         directive.integrations().forEach(integration -> {
             LOGGER.info(() -> "Adding TypeScriptIntegration: " + integration.getClass().getName());
             integration.getClientPlugins().forEach(runtimePlugin -> {
-                LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
-                runtimePlugins.add(runtimePlugin);
+                if (runtimePlugin.matchesSettings(directive.model(), directive.service(), directive.settings())) {
+                    LOGGER.info(() -> "Adding TypeScript runtime plugin: " + runtimePlugin);
+                    runtimePlugins.add(runtimePlugin);
+                } else {
+                    LOGGER.info(() -> "Skipping TypeScript runtime plugin based on settings: " + runtimePlugin);
+                }
             });
         });
 

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/RuntimeClientPluginTest.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 
 public class RuntimeClientPluginTest {
     @Test
@@ -66,6 +66,25 @@ public class RuntimeClientPluginTest {
         assertThat(plugin.matchesService(model, service2), equalTo(false));
         assertThat(plugin.matchesOperation(model, service1, operation), equalTo(false));
         assertThat(plugin.matchesOperation(model, service2, operation), equalTo(false));
+    }
+
+    @Test
+    public void allowsConfigurableSettingsPredicate() {
+        ServiceShape service = ServiceShape.builder().id("a.b#C").version("123").build();
+        Model model = Model.assembler()
+                .addShapes(service)
+                .assemble()
+                .unwrap();
+        RuntimeClientPlugin createDefaultReadmeFlagPlugin = RuntimeClientPlugin.builder()
+                .settingsPredicate((m, s, settings) -> settings.createDefaultReadme())
+                .build();
+
+        TypeScriptSettings createDefaultReadmeTrueSettings = new TypeScriptSettings();
+        createDefaultReadmeTrueSettings.setCreateDefaultReadme(true);
+        assertThat(createDefaultReadmeFlagPlugin.matchesSettings(model, service, createDefaultReadmeTrueSettings), equalTo(true));
+
+        TypeScriptSettings createDefaultReadmeFalseSettings = new TypeScriptSettings();
+        assertThat(createDefaultReadmeFlagPlugin.matchesSettings(model, service, createDefaultReadmeFalseSettings), equalTo(false));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Enable `RuntimeClientPlugin`s to be filtered based on settings, and filter at the top-level of `DirectedTypeScriptCodegen`.

See previously closed PR: awslabs/smithy-typescript#684

*Testing:*

1. smithy-typescript: `./gradlew clean build check` builds successfully
2. aws-sdk-js-v3: `yarn generate-clients` builds successfully and produces no codegen diff.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
