### PR TITLE
fix: pagination return type

### DIFF
--- a/.changeset/lazy-days-jam.md
+++ b/.changeset/lazy-days-jam.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix paginator type

--- a/packages/types/src/pagination.ts
+++ b/packages/types/src/pagination.ts
@@ -5,7 +5,7 @@ import { Client } from "./client";
  *
  * Expected type definition of a paginator.
  */
-export type Paginator<T> = AsyncGenerator<T, T, unknown>;
+export type Paginator<T> = AsyncGenerator<T, undefined, unknown>;
 
 /**
  * @public


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/2610
the paginators generate with an undefined return type, not `T`.

supercedes https://github.com/aws/aws-sdk-js-v3/pull/2611
supercedes https://github.com/awslabs/smithy-typescript/pull/389
