### PR TITLE
fix(util-body-length-node): calculateBodyLength for Readable stream with range

### DIFF
--- a/.changeset/eighty-rivers-rush.md
+++ b/.changeset/eighty-rivers-rush.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-body-length-node": minor
+---
+
+calculateBodyLength for Readable stream with range

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -14,6 +14,8 @@ export const calculateBodyLength = (body: any): number | undefined => {
     return body.byteLength;
   } else if (typeof body.size === "number") {
     return body.size;
+  } else if (typeof body.start === "number" && typeof body.end === "number") {
+    return body.end + 1 - body.start;
   } else if (typeof body.path === "string" || Buffer.isBuffer(body.path)) {
     // handles fs readable streams
     return lstatSync(body.path).size;


### PR DESCRIPTION
supercedes https://github.com/aws/aws-sdk-js-v3/pull/2637