### PR TITLE
Use ASCII replacement for character 0xE2

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java
@@ -129,9 +129,9 @@ public class RuleSetParameterFinder {
     }
 
     /**
-     * The contextParam trait allows for binding a structure’s member value to a context
-     * parameter name. This trait MUST target a member shape on an operation’s input structure.
-     * The targeted endpoint parameter MUST be a type that is compatible with member’s
+     * The contextParam trait allows for binding a structure's member value to a context
+     * parameter name. This trait MUST target a member shape on an operation's input structure.
+     * The targeted endpoint parameter MUST be a type that is compatible with member's
      * shape targeted by the trait.
      */
     public Map<String, String> getContextParams(Shape operationInput) {


### PR DESCRIPTION
*Issue #, if available:*

Internal JS-4583

*Description of changes:*

Uses ASCII replacement for character 0xE2.

We started seeing build failures when attempting to build smithy-typescript on AL2023

```console
> Task :smithy-typescript-codegen:javadoc FAILED
/smithy-typescript/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/endpointsV2/RuleSetParameterFinder.java:132: error: unmappable character (0xE2) for encoding US-ASCII
     * The contextParam trait allows for binding a structure???s member value to a context
```

Verified that build is successful on AL2023 instance after this fix.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
