### PR TITLE
Remove symbol as an index from ChecksumConfiguration interface in @smithy/types

### DIFF
--- a/.changeset/empty-eyes-remember.md
+++ b/.changeset/empty-eyes-remember.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+Remove symbol as an index from ChecksumConfiguration interface in @smithy/types

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -24,7 +24,7 @@ export interface ChecksumConfiguration {
   addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
   checksumAlgorithms(): ChecksumAlgorithm[];
 
-  [other: string | number | symbol]: any;
+  [other: string | number]: any;
 }
 
 type GetChecksumConfigurationType = (


### PR DESCRIPTION
Address issue https://github.com/awslabs/smithy-typescript/issues/865 
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
