### PR TITLE
Remove generated packages from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "clean": "turbo run clean --force --parallel",
     "build": "turbo run build",
     "test": "turbo run test",
-    "test:integration": "turbo run test:integration",
+    "test:integration": "yarn build-test-packages && turbo run test:integration",
     "lint": "turbo run lint",
     "format": "turbo run format --parallel",
     "stage-release": "turbo run stage-release",
     "extract:docs": "mkdir -p api-extractor-packages && turbo run extract:docs",
     "release": "yarn changeset publish",
-    "build-test-packages": "./gradlew clean build && yarn && yarn build --filter=weather --filter=weather-ssdk --force --concurrency=2"
+    "build-test-packages": "./gradlew clean build && node ./scripts/build-generated-test-packages"
   },
   "repository": {
     "type": "git",
@@ -65,8 +65,6 @@
   "workspaces": [
     "packages/*",
     "smithy-typescript-ssdk-libs/*",
-    "smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/source/typescript-codegen",
-    "smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/ssdk-test/typescript-ssdk-codegen",
     "private/*"
   ],
   "packageManager": "yarn@3.4.1"

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -1,0 +1,58 @@
+/**
+ *
+ * This script builds the generated weather and weather-ssdk test packages
+ * and copies them into node_modules for use by integration tests.
+ */
+
+const path = require("node:path");
+const { spawnProcess } = require("./utils/spawn-process");
+
+const root = path.join(__dirname, "..");
+
+const codegenTestDir = path.join(
+    root,
+    "smithy-typescript-codegen-test",
+    "build",
+    "smithyprojections",
+    "smithy-typescript-codegen-test",
+);
+
+const weatherClientDir = path.join(
+    codegenTestDir,
+    "source",
+    "typescript-codegen"
+);
+
+const weatherSsdkDir = path.join(
+    codegenTestDir,
+    "ssdk-test",
+    "typescript-ssdk-codegen"
+)
+
+const nodeModulesDir = path.join(root, "node_modules");
+
+const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir) => {
+    // Yarn detects that the generated TypeScript package is nested beneath the
+    // top-level package.json. Adding an empty lock file allows it to be treated
+    // as its own package.
+    await spawnProcess("touch", ["yarn.lock"], { cwd: codegenDir });
+    await spawnProcess("yarn", { cwd: codegenDir });
+    await spawnProcess("yarn", ["build"], { cwd: codegenDir });
+    // After building the package, its packed and copied to node_modules so that
+    // it can be used in integration tests by other packages within the monorepo.
+    await spawnProcess("yarn", ["pack"], { cwd: codegenDir });
+    await spawnProcess("rm", ["-rf", packageName], { cwd: nodeModulesDir });
+    await spawnProcess("mkdir", [packageName], { cwd: nodeModulesDir });
+    const targetPackageDir = path.join(nodeModulesDir, packageName);
+    await spawnProcess("tar", ["-xf", "package.tgz", "-C", targetPackageDir, "--strip-components", "1"], { cwd: codegenDir });
+};
+
+(async () => {
+  try {
+    await buildAndCopyToNodeModules("weather", weatherClientDir, nodeModulesDir);
+    await buildAndCopyToNodeModules("weather-ssdk", weatherSsdkDir, nodeModulesDir);
+ } catch (e) {
+    console.log(e);
+    process.exit(1);
+ }
+})();

--- a/scripts/utils/spawn-process.js
+++ b/scripts/utils/spawn-process.js
@@ -1,0 +1,18 @@
+// @ts-check
+const { spawn } = require("child_process");
+
+const spawnProcess = async (command, args = [], options = {}) => {
+  const childProcess = spawn(command, args, options);
+
+  childProcess.stdout?.pipe(process.stdout);
+  childProcess.stderr?.pipe(process.stderr);
+
+  return new Promise((resolve, reject) => {
+    childProcess.on("error", reject);
+    childProcess.on("exit", (code, signal) =>
+      code === 0 ? resolve(0) : reject(`${command} failed with { code: ${code}, signal: ${signal} }`)
+    );
+  });
+};
+
+module.exports = { spawnProcess };


### PR DESCRIPTION
This PR removes the generated test client and SSDK packages from the yarn workspace.

Previously, these packages were added to the workspace so that they could be built using yarn commands, e.g. `yarn build --filter=weather`.

This had the side-effect of different yarn.lock files, depending on whether or not the test client and SSDK packages had been generated with `./gradlew clean build`.

By removing them from the workspace, they will not influence the yarn.lock file. In order for the generated client and SSDK packages to be used in integration tests, a script is added to build, pack and copy the generated packages into node_modules.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
