### PR TITLE
Run integration tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,6 @@ jobs:
       - name: clean and build
         run: ./gradlew clean build -Plog-tests
 
-  build-generated-client-and-ssdk:
-    runs-on: ubuntu-latest
-    name: Build generated client and ssdk packages
-    steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'corretto'
-      - name: Run build-test-packages
-        run: |
-          yarn config set enableImmutableInstalls false
-          yarn
-          yarn build-test-packages
-
   lint-typescript:
     runs-on: ubuntu-latest
     name: TypeScript Lint
@@ -69,12 +49,22 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
       - name: Install dependencies
         run: yarn
       - name: Build packages
         run: yarn build --concurrency=2
-      - name: Run tests
+      - name: Run unit tests
         run: yarn workspaces foreach --exclude smithy-typescript  -v run test
+      - name: Run integration tests
+        run: |
+          yarn config set enableImmutableInstalls false
+          yarn test:integration
 
   ensure-typescript-formatted:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates CI to run integration tests.

The separate `build-generated-client-and-ssdk` job is removed. That job exercised `yarn build-test-packages`, which is now run before integration tests since those those tests rely on the generated package.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
