### PR TITLE
feat: keepalive for fetch (browser)

### DIFF
--- a/.changeset/dull-doors-camp.md
+++ b/.changeset/dull-doors-camp.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": minor
+---
+
+add fetch http handler keepAlive option

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ smithy-typescript-integ-tests/yarn.lock
 # Issue https://github.com/awslabs/smithy-typescript/issues/425
 smithy-typescript-codegen/bin/
 smithy-typescript-ssdk-codegen-test-utils/bin/
+smithy-typescript-codegen-test/example-weather-customizations/bin/
 
 **/node_modules/
 **/*.tsbuildinfo


### PR DESCRIPTION
add keepalive option for fetch http handler

supercedes https://github.com/aws/aws-sdk-js-v3/pull/3422