### PR TITLE
feat(experimentalIdentityAndAuth): add codegen and TS integration points for `config`

### DIFF
--- a/.changeset/gentle-days-develop.md
+++ b/.changeset/gentle-days-develop.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+INTERNAL USE ONLY: Add experimental package for `experimentalIdentityAndAuth` types and implementations.

--- a/packages/experimental-identity-and-auth/.gitignore
+++ b/packages/experimental-identity-and-auth/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/experimental-identity-and-auth/CHANGELOG.md
+++ b/packages/experimental-identity-and-auth/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/experimental-identity-and-auth/LICENSE
+++ b/packages/experimental-identity-and-auth/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/experimental-identity-and-auth/README.md
+++ b/packages/experimental-identity-and-auth/README.md
@@ -1,0 +1,13 @@
+# @smithy/experimental-identity-and-auth
+
+[![NPM version](https://img.shields.io/npm/v/@smithy/experimental-identity-and-auth/latest.svg)](https://www.npmjs.com/package/@smithy/experimental-identity-and-auth)
+[![NPM downloads](https://img.shields.io/npm/dm/@smithy/experimental-identity-and-auth.svg)](https://www.npmjs.com/package/@smithy/experimental-identity-and-auth)
+
+## Usage
+
+**WARNING: This package should NOT be consumed directly in any way.**
+
+This package is experimental for the development of `experimentalIdentityAndAuth`.
+
+See [experimental features](https://github.com/awslabs/smithy-typescript/blob/main/CONTRIBUTING.md#experimental-features)
+for more information.

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@smithy/experimental-identity-and-auth",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
+    "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
+    "test": "tsc -p tsconfig.test.json"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "author": {
+    "name": "AWS Smithy Team",
+    "email": "",
+    "url": "https://smithy.io"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@smithy/types": "workspace:^",
+    "tslib": "^2.5.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*/**"
+  ],
+  "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/experimental-identity-and-auth",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/awslabs/smithy-typescript.git",
+    "directory": "packages/experimental-identity-and-auth"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "jest": "28.1.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.23.23",
+    "typescript": "~4.9.5"
+  },
+  "typedoc": {
+    "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
+  }
+}

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -1,0 +1,39 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+import { HttpSigner } from "./HttpSigner";
+
+/**
+ * ID for {@link HttpAuthScheme}
+ * @internal
+ */
+export type HttpAuthSchemeId = string;
+
+/**
+ * Interface that defines an HttpAuthScheme
+ * @internal
+ */
+export interface HttpAuthScheme {
+  /**
+   * ID for an HttpAuthScheme, typically the absolute shape ID of a Smithy auth trait.
+   */
+  schemeId: HttpAuthSchemeId;
+  /**
+   * IdentityProvider corresponding to an HttpAuthScheme.
+   */
+  identityProvider: IdentityProvider<Identity>;
+  /**
+   * HttpSigner corresponding to an HttpAuthScheme.
+   */
+  signer: HttpSigner;
+}
+
+/**
+ * Interface that defines the identity and signing properties when selecting
+ * an HttpAuthScheme.
+ * @internal
+ */
+export interface HttpAuthOption {
+  schemeId: HttpAuthSchemeId;
+  identityProperties?: Record<string, unknown>;
+  signingProperties?: Record<string, unknown>;
+}

--- a/packages/experimental-identity-and-auth/src/HttpSigner.ts
+++ b/packages/experimental-identity-and-auth/src/HttpSigner.ts
@@ -1,0 +1,16 @@
+import { HttpRequest, Identity } from "@smithy/types";
+
+/**
+ * Interface to sign identity and signing properties.
+ * @internal
+ */
+export interface HttpSigner {
+  /**
+   * Signs an HttpRequest with an identity and signing properties.
+   * @param httpRequest request to sign
+   * @param identity identity to sing the request with
+   * @param signingProperties property bag for signing
+   * @returns signed request in a promise
+   */
+  sign(httpRequest: HttpRequest, identity: Identity, signingProperties: Record<string, unknown>): Promise<HttpRequest>;
+}

--- a/packages/experimental-identity-and-auth/src/IdentityProviderConfiguration.ts
+++ b/packages/experimental-identity-and-auth/src/IdentityProviderConfiguration.ts
@@ -1,0 +1,51 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+import { HttpAuthScheme, HttpAuthSchemeId } from "./HttpAuthScheme";
+
+/**
+ * Interface to get an IdentityProvider for a specified HttpAuthScheme
+ * @internal
+ */
+export interface IdentityProviderConfiguration {
+  /**
+   * Get the IdentityProvider for a specified HttpAuthScheme.
+   * @param schemeId schemeId of the HttpAuthScheme
+   * @returns IdentityProvider or undefined if HttpAuthScheme is not found
+   */
+  getIdentityProvider(schemeId: HttpAuthSchemeId): IdentityProvider<Identity> | undefined;
+
+  /**
+   * Gets the configured HttpAuthSchemes.
+   * @returns all configured HttpAuthSchemes
+   */
+  getAuthSchemes(): Map<HttpAuthSchemeId, HttpAuthScheme>;
+}
+
+/**
+ * Default implementation of IdentityProviderConfiguration
+ * @internal
+ */
+export class DefaultIdentityProviderConfiguration implements IdentityProviderConfiguration {
+  private authSchemes: Map<HttpAuthSchemeId, HttpAuthScheme> = new Map();
+
+  /**
+   * Creates an IdentityProviderConfiguration with a list of HttpAuthSchemes.
+   *
+   * HttpAuthSchemes that have the same schemeId will be deduped, where the
+   * HttpAuthScheme later in the list will have priority.
+   * @param authSchemes auth schemes to configure
+   */
+  constructor(authSchemes: HttpAuthScheme[]) {
+    for (const authScheme of authSchemes) {
+      this.authSchemes.set(authScheme.schemeId, authScheme);
+    }
+  }
+
+  public getIdentityProvider(schemeId: HttpAuthSchemeId): IdentityProvider<Identity> | undefined {
+    return this.authSchemes.get(schemeId)?.identityProvider;
+  }
+
+  public getAuthSchemes(): Map<HttpAuthSchemeId, HttpAuthScheme> {
+    return this.authSchemes;
+  }
+}

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./IdentityProviderConfiguration";
+export * from "./HttpAuthScheme";
+export * from "./HttpSigner";
+export * from "./noAuth";

--- a/packages/experimental-identity-and-auth/src/noAuth.ts
+++ b/packages/experimental-identity-and-auth/src/noAuth.ts
@@ -1,0 +1,17 @@
+import { HttpRequest, Identity } from "@smithy/types";
+
+import { HttpSigner } from "./HttpSigner";
+
+/**
+ * Signer for the synthetic @smithy.api#noAuth auth scheme.
+ * @internal
+ */
+export class NoAuthSigner implements HttpSigner {
+  async sign(
+    httpRequest: HttpRequest,
+    identity: Identity,
+    signingProperties: Record<string, unknown>
+  ): Promise<HttpRequest> {
+    return httpRequest;
+  }
+}

--- a/packages/experimental-identity-and-auth/tsconfig.cjs.json
+++ b/packages/experimental-identity-and-auth/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/experimental-identity-and-auth/tsconfig.es.json
+++ b/packages/experimental-identity-and-auth/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom"],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/experimental-identity-and-auth/tsconfig.test.json
+++ b/packages/experimental-identity-and-auth/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"],
+  "exclude": []
+}

--- a/packages/experimental-identity-and-auth/tsconfig.types.json
+++ b/packages/experimental-identity-and-auth/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -9,10 +9,12 @@ use smithy.waiters#waitable
 
 /// Provides weather forecasts.
 @fakeProtocol
-@httpApiKeyAuth(name: "X-Api-Key", in: "header")
-@httpBearerAuth
-@sigv4(name: "weather")
-@auth([sigv4])
+// feat(experimentalIdentityAndAuth): uncomment operations as individual
+//   auth scheme support is implemented
+// @httpApiKeyAuth(name: "X-Api-Key", in: "header")
+// @httpBearerAuth
+// @sigv4(name: "weather")
+// @auth([sigv4])
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
 service Weather {
     version: "2006-03-01"
@@ -21,13 +23,15 @@ service Weather {
         GetCurrentTime
         // util-stream.integ.spec.ts
         Invoke
+        // feat(experimentalIdentityAndAuth): uncomment operations as individual
+        //   auth scheme support is implemented
         // experimentalIdentityAndAuth
-        OnlyHttpApiKeyAuth
-        OnlyHttpBearerAuth
-        OnlyHttpApiKeyAndBearerAuth
-        OnlyHttpApiKeyAndBearerAuthReversed
-        OnlyHttpApiKeyAuthOptional
-        SameAsService
+        // OnlyHttpApiKeyAuth
+        // OnlyHttpBearerAuth
+        // OnlyHttpApiKeyAndBearerAuth
+        // OnlyHttpApiKeyAndBearerAuthReversed
+        // OnlyHttpApiKeyAuthOptional
+        // SameAsService
     ]
 }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen;
+
+import java.util.function.Consumer;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Definition of a Config field.
+ *
+ * Currently used to populate the ClientDefaults interface in `experimentalIdentityAndAuth`.
+ *
+ * @param name name of the config field
+ * @param source writer for the type of the config field
+ * @param docs writer for the docs of the config field
+ */
+@SmithyUnstableApi
+public final record ConfigField(
+    String name,
+    Consumer<TypeScriptWriter> source,
+    Consumer<TypeScriptWriter> docs
+) {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -15,14 +15,25 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import software.amazon.smithy.build.SmithyBuildException;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeProviderGenerator;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -41,6 +52,7 @@ final class RuntimeConfigGenerator {
     private final SymbolProvider symbolProvider;
     private final TypeScriptDelegator delegator;
     private final List<TypeScriptIntegration> integrations;
+    private final ApplicationProtocol applicationProtocol;
     private final Map<String, Consumer<TypeScriptWriter>> nodeRuntimeConfigDefaults = MapUtils.of(
             "requestHandler", writer -> {
                 writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
@@ -139,7 +151,8 @@ final class RuntimeConfigGenerator {
             Model model,
             SymbolProvider symbolProvider,
             TypeScriptDelegator delegator,
-            List<TypeScriptIntegration> integrations
+            List<TypeScriptIntegration> integrations,
+            ApplicationProtocol applicationProtocol
     ) {
         this.settings = settings;
         this.model = model;
@@ -147,6 +160,7 @@ final class RuntimeConfigGenerator {
         this.symbolProvider = symbolProvider;
         this.delegator = delegator;
         this.integrations = integrations;
+        this.applicationProtocol = applicationProtocol;
     }
 
     void generate(LanguageTarget target) {
@@ -169,6 +183,12 @@ final class RuntimeConfigGenerator {
                 for (TypeScriptIntegration integration : integrations) {
                     configs.putAll(integration.getRuntimeConfigWriters(settings, model, symbolProvider, target));
                 }
+                // feat(experimentalIdentityAndAuth): add config writers for httpAuthScheme and httpAuthSchemes
+                // Needs a separate integration point since not all the information is accessible in
+                // {@link TypeScriptIntegration#getRuntimeConfigWriters()}
+                if (applicationProtocol.isHttpProtocol() && settings.getExperimentalIdentityAndAuth()) {
+                    generateHttpAuthSchemeConfig(configs, writer, target);
+                }
                 int indentation = target.equals(LanguageTarget.SHARED) ? 1 : 2;
                 configs.forEach((key, value) -> {
                     writer.indent(indentation).disableNewlines().openBlock("$1L: config?.$1L ?? ", ",\n", key,
@@ -180,6 +200,72 @@ final class RuntimeConfigGenerator {
             });
             writer.dedent();
             writer.write(contents, "");
+        });
+    }
+
+    private void generateHttpAuthSchemeConfig(
+        Map<String, Consumer<TypeScriptWriter>> configs,
+        TypeScriptWriter writer,
+        LanguageTarget target
+    ) {
+        // feat(experimentalIdentityAndAuth): gather HttpAuthSchemes to generate
+        SupportedHttpAuthSchemesIndex index = new SupportedHttpAuthSchemesIndex(integrations);
+        ServiceIndex serviceIndex = ServiceIndex.of(model);
+        Map<ShapeId, Trait> authSchemeTraits = serviceIndex.getAuthSchemes(service);
+        Map<ShapeId, HttpAuthScheme> authSchemes = authSchemeTraits.entrySet().stream()
+            .filter(entry -> index.getHttpAuthScheme(entry.getKey()) != null)
+            .collect(Collectors.toMap(
+                entry -> entry.getKey(),
+                entry -> index.getHttpAuthScheme(entry.getKey())));
+        // feat(experimentalIdentityAndAuth): can be removed after changing to NO_AUTH_AWARE schemes
+        // The default set of HttpAuthSchemes is @smithy.api#noAuth on the shared runtime config
+        authSchemes.put(AuthUtils.NO_AUTH_ID, index.getHttpAuthScheme(AuthUtils.NO_AUTH_ID));
+        boolean shouldGenerateHttpAuthSchemes = index.getSupportedHttpAuthSchemes().values().stream().anyMatch(value ->
+            // If either an default identity or signer is configured for the target, generate auth schemes
+            value.getDefaultIdentityProviders().containsKey(target) || value.getDefaultSigners().containsKey(target));
+        if (!shouldGenerateHttpAuthSchemes) {
+            return;
+        }
+        // feat(experimentalIdentityAndAuth): write the default imported HttpAuthSchemeProvider
+        configs.put("httpAuthSchemeProvider", w -> {
+            String providerName = "default" + service.toShapeId().getName() + "HttpAuthSchemeProvider";
+            w.addRelativeImport(providerName, null, Paths.get(".", CodegenUtils.SOURCE_FOLDER,
+                HttpAuthSchemeProviderGenerator.HTTP_AUTH_FOLDER,
+                HttpAuthSchemeProviderGenerator.HTTP_AUTH_SCHEME_RESOLVER_MODULE));
+            w.write(providerName);
+        });
+        // feat(experimentalIdentityAndAuth): write the default IdentityProviderConfiguration with configured
+        // HttpAuthSchemes
+        configs.put("httpAuthSchemes", w -> {
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addImport("DefaultIdentityProviderConfiguration", null,
+                TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.openBlock("new DefaultIdentityProviderConfiguration([", "])", () -> {
+                Iterator<Entry<ShapeId, HttpAuthScheme>> iter = authSchemes.entrySet().iterator();
+                while (iter.hasNext()) {
+                    Entry<ShapeId, HttpAuthScheme> entry = iter.next();
+                    // Default IdentityProvider or HttpSigner, otherwise write {@code never} to force a TypeScript
+                    // compilation failure.
+                    Consumer<TypeScriptWriter> defaultIdentityProvider = entry.getValue()
+                        .getDefaultIdentityProviders()
+                        .getOrDefault(target, AuthUtils.DEFAULT_NEVER_WRITER);
+                    Consumer<TypeScriptWriter> defaultSigner = entry.getValue()
+                        .getDefaultSigners()
+                        .getOrDefault(target, AuthUtils.DEFAULT_NEVER_WRITER);
+                    w.write("""
+                        {
+                          schemeId: $S,
+                          identityProvider: $C,
+                          signer: $C,
+                        }""",
+                        entry.getKey(),
+                        defaultIdentityProvider,
+                        defaultSigner);
+                    if (iter.hasNext()) {
+                        w.writeInline(", ");
+                    }
+                }
+            });
         });
     }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -114,6 +114,9 @@ public enum TypeScriptDependency implements Dependency {
     @Deprecated UTIL_STREAM_BROWSER("dependencies", "@smithy/util-stream-browser", "^2.0.5", false),
     UTIL_STREAM("dependencies", "@smithy/util-stream", "^2.0.5", false),
 
+    // Conditionally added dependencies for `experimentalIdentityAndAuth`.
+    EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", "~0.0.1", false),
+
     // Conditionally added when specs have been generated.
     VITEST("devDependencies", "vitest", "^0.33.0", false),
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -114,7 +114,8 @@ public enum TypeScriptDependency implements Dependency {
     @Deprecated UTIL_STREAM_BROWSER("dependencies", "@smithy/util-stream-browser", "^2.0.5", false),
     UTIL_STREAM("dependencies", "@smithy/util-stream", "^2.0.5", false),
 
-    // Conditionally added dependencies for `experimentalIdentityAndAuth`.
+    // feat(experimentalIdentityAndAuth): Conditionally added dependencies for `experimentalIdentityAndAuth`.
+    // This package should never have a major version, and should only use minor and patch versions in development.
     EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", "~0.0.1", false),
 
     // Conditionally added when specs have been generated.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth;
+
+import java.util.function.Consumer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Auth utility methods needed across Java packages.
+ */
+@SmithyInternalApi
+public final class AuthUtils {
+    /**
+     * Writes out `never`, which will make TypeScript compilation fail if used as a value.
+     */
+    public static final Consumer<TypeScriptWriter> DEFAULT_NEVER_WRITER = w -> w.write("never");
+
+    /**
+     * Should be replaced when the synthetic NoAuthTrait is released in Smithy.
+     */
+    public static final ShapeId NO_AUTH_ID = ShapeId.from("smithy.api#noAuth");
+
+    private AuthUtils() {}
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Definition of an HttpAuthOptionProperty.
+ *
+ * @param name name of the auth option property
+ * @param type the type of {@link Type}
+ * @param source a function that provides the auth trait to a writer, and writes
+ *  properties from the trait or from {@code authParameters}.
+ */
+@SmithyUnstableApi
+public final record HttpAuthOptionProperty(
+    String name,
+    Type type,
+    Function<Trait, Consumer<TypeScriptWriter>> source
+) {
+    /**
+     * Defines the type of the auth option property.
+     */
+    public enum Type {
+        /**
+         * Specifies the property should be included in {@code identityProperties}.
+         */
+        IDENTITY,
+        /**
+         * Specifies the property should be included in {@code signingProperties}.
+         */
+        SIGNING
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty.Type;
+import software.amazon.smithy.utils.BuilderRef;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+/**
+ * feat(experimentalIdentityAndAuth): Defines an HttpAuthScheme used in code generation.
+ *
+ * HttpAuthScheme defines everything needed to generate an HttpAuthSchemeProvider,
+ * HttpAuthOptions, and registered HttpAuthSchemes in the IdentityProviderConfiguration.
+ */
+@SmithyUnstableApi
+public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
+    private final ShapeId schemeId;
+    private final ApplicationProtocol applicationProtocol;
+    private final Map<LanguageTarget, Consumer<TypeScriptWriter>> defaultIdentityProviders;
+    private final Map<LanguageTarget, Consumer<TypeScriptWriter>> defaultSigners;
+    private final List<ConfigField> configFields;
+    private final List<HttpAuthSchemeParameter> httpAuthSchemeParameters;
+    private final List<HttpAuthOptionProperty> httpAuthOptionProperties;
+
+    private HttpAuthScheme(Builder builder) {
+        this.schemeId = SmithyBuilder.requiredState(
+            "schemeId", builder.schemeId);
+        this.applicationProtocol = SmithyBuilder.requiredState(
+            "applicationProtocol", builder.applicationProtocol);
+        this.defaultIdentityProviders = SmithyBuilder.requiredState(
+            "defaultIdentityProviders", builder.defaultIdentityProviders.copy());
+        this.defaultSigners = SmithyBuilder.requiredState(
+            "defaultSigners", builder.defaultSigners.copy());
+        this.configFields = SmithyBuilder.requiredState(
+            "configFields", builder.configFields.copy());
+        this.httpAuthSchemeParameters = SmithyBuilder.requiredState(
+            "httpAuthSchemeParameters", builder.httpAuthSchemeParameters.copy());
+        this.httpAuthOptionProperties = SmithyBuilder.requiredState(
+            "httpAuthOptionProperties", builder.httpAuthOptionProperties.copy());
+    }
+
+    /**
+     * Gets the scheme ID.
+     * @return schemeId
+     */
+    public ShapeId getSchemeId() {
+        return schemeId;
+    }
+
+    /**
+     * Gets the application protocol.
+     * @return applicationProtocol
+     */
+    public ApplicationProtocol getApplicationProtocol() {
+        return applicationProtocol;
+    }
+
+    /**
+     * Gets the map of default {@code IdentityProvider}s for an auth scheme.
+     * @return defaultIdentityProviders
+     */
+    public Map<LanguageTarget, Consumer<TypeScriptWriter>> getDefaultIdentityProviders() {
+        return defaultIdentityProviders;
+    }
+
+    /**
+     * Gets the map of default {@code HttpSigner}s for an auth scheme.
+     * @return defaultSigners
+     */
+    public Map<LanguageTarget, Consumer<TypeScriptWriter>> getDefaultSigners() {
+        return defaultSigners;
+    }
+
+    /**
+     * Gets the list of config fields for an auth scheme.
+     * @return configFields
+     */
+    public List<ConfigField> getConfigFields() {
+        return configFields;
+    }
+
+    /**
+     * Gets the list of auth scheme parameters for an auth scheme.
+     * @return httpAuthSchemeParameters
+     */
+    public List<HttpAuthSchemeParameter> getHttpAuthSchemeParameters() {
+        return httpAuthSchemeParameters;
+    }
+
+    /**
+     * Gets the list of auth option properties for an auth scheme.
+     * @return httpAuthOptionProperties
+     */
+    public List<HttpAuthOptionProperty> getHttpAuthOptionProperties() {
+        return httpAuthOptionProperties;
+    }
+
+    /**
+     * Gets the list of auth option properties by type for an auth scheme.
+     * @param type type of auth option property
+     * @return httpAuthOptionProperties filtered by type
+     */
+    public List<HttpAuthOptionProperty> getAuthSchemeOptionParametersByType(Type type) {
+        return httpAuthOptionProperties.stream().filter(p -> p.type().equals(type)).toList();
+    }
+
+    /**
+     * Creates a {@link Builder}.
+     * @return a builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Converts an HttpAuthScheme to a {@link Builder}.
+     * @return a builder
+     */
+    @Override
+    public Builder toBuilder() {
+        return builder()
+            .schemeId(schemeId)
+            .applicationProtocol(applicationProtocol)
+            .defaultIdentityProviders(defaultIdentityProviders)
+            .defaultSigners(defaultSigners)
+            .configFields(configFields)
+            .httpAuthSchemeParameters(httpAuthSchemeParameters)
+            .httpAuthOptionProperties(httpAuthOptionProperties);
+    }
+
+    /**
+     * Builder for {@link HttpAuthScheme}.
+     */
+    public static final class Builder implements SmithyBuilder<HttpAuthScheme> {
+        private ShapeId schemeId;
+        private ApplicationProtocol applicationProtocol;
+        private BuilderRef<Map<LanguageTarget, Consumer<TypeScriptWriter>>> defaultIdentityProviders =
+            BuilderRef.forOrderedMap();
+        private BuilderRef<Map<LanguageTarget, Consumer<TypeScriptWriter>>> defaultSigners =
+            BuilderRef.forOrderedMap();
+        private BuilderRef<List<ConfigField>> configFields =
+            BuilderRef.forList();
+        private BuilderRef<List<HttpAuthSchemeParameter>> httpAuthSchemeParameters =
+            BuilderRef.forList();
+        private BuilderRef<List<HttpAuthOptionProperty>> httpAuthOptionProperties =
+            BuilderRef.forList();
+
+        private Builder() {}
+
+        @Override
+        public HttpAuthScheme build() {
+            return new HttpAuthScheme(this);
+        }
+
+        /**
+         * Sets the schemeId.
+         * @param schemeId scheme ID to set
+         * @return the builder
+         */
+        public Builder schemeId(ShapeId schemeId) {
+            this.schemeId = schemeId;
+            return this;
+        }
+
+        /**
+         * Sets the applicationProtocol.
+         * @param applicationProtocol application protocol to set
+         * @return the builder
+         */
+        public Builder applicationProtocol(ApplicationProtocol applicationProtocol) {
+            this.applicationProtocol = applicationProtocol;
+            return this;
+        }
+
+        /**
+         * Sets the defaultIdentityProviders.
+         * @param defaultIdentityProviders IdentityProviders to set
+         * @return the builder
+         */
+        public Builder defaultIdentityProviders(
+            Map<LanguageTarget, Consumer<TypeScriptWriter>> defaultIdentityProviders) {
+            this.defaultIdentityProviders.clear();
+            this.defaultIdentityProviders.get().putAll(defaultIdentityProviders);
+            return this;
+        }
+
+        /**
+         * Puts a single default identityProvider for a language target.
+         * @param languageTarget target to add identityProvider to
+         * @param identityProvider identityProvider to add
+         * @return the builder
+         */
+        public Builder putDefaultIdentityProvider(
+            LanguageTarget languageTarget,
+            Consumer<TypeScriptWriter> identityProvider
+        ) {
+            this.defaultIdentityProviders.get().put(languageTarget, identityProvider);
+            return this;
+        }
+
+        /**
+         * Removes a single default identityProvider for a language target.
+         * @param languageTarget target to remove the identityProvider from
+         * @return the builder
+         */
+        public Builder removeDefaultIdentityProvider(LanguageTarget languageTarget) {
+            this.defaultIdentityProviders.get().remove(languageTarget);
+            return this;
+        }
+
+        /**
+         * Sets the defaultSigners.
+         * @param defaultSigners HttpSigners to set
+         * @return the builder
+         */
+        public Builder defaultSigners(
+            Map<LanguageTarget, Consumer<TypeScriptWriter>> defaultSigners) {
+            this.defaultSigners.clear();
+            this.defaultSigners.get().putAll(defaultSigners);
+            return this;
+        }
+
+        /**
+         * Puts a single default signer for a language target.
+         * @param languageTarget target to add signer to
+         * @param signer signer to add
+         * @return the builder
+         */
+        public Builder putDefaultSigner(
+            LanguageTarget languageTarget,
+            Consumer<TypeScriptWriter> signer
+        ) {
+            this.defaultSigners.get().put(languageTarget, signer);
+            return this;
+        }
+
+        /**
+         * Removes a single default signer for a language target.
+         * @param languageTarget target to remove the signer from
+         * @return the builder
+         */
+        public Builder removeDefaultSigner(LanguageTarget languageTarget) {
+            this.defaultSigners.get().remove(languageTarget);
+            return this;
+        }
+
+        /**
+         * Sets the configFields.
+         * @param configFields config fields to set
+         * @return the builder
+         */
+        public Builder configFields(List<ConfigField> configFields) {
+            this.configFields.clear();
+            this.configFields.get().addAll(configFields);
+            return this;
+        }
+
+        /**
+         * Adds a config field.
+         * @param configField config field to add
+         * @return the builder
+         */
+        public Builder addConfigField(ConfigField configField) {
+            this.configFields.get().add(configField);
+            return this;
+        }
+
+        /**
+         * Sets the httpAuthSchemeParameters.
+         * @param httpAuthSchemeParameters auth scheme parameters to set
+         * @return the builder
+         */
+        public Builder httpAuthSchemeParameters(
+            List<HttpAuthSchemeParameter> httpAuthSchemeParameters) {
+            this.httpAuthSchemeParameters.clear();
+            this.httpAuthSchemeParameters.get().addAll(httpAuthSchemeParameters);
+            return this;
+        }
+
+        /**
+         * Adds a auth scheme parameter.
+         * @param httpAuthSchemeParameter parameter to add
+         * @return the builder
+         */
+        public Builder addHttpAuthSchemeParameter(HttpAuthSchemeParameter httpAuthSchemeParameter) {
+            this.httpAuthSchemeParameters.get().add(httpAuthSchemeParameter);
+            return this;
+        }
+
+        /**
+         * Sets the httpAuthOptionProperties.
+         * @param httpAuthOptionProperties properties to set
+         * @return the builder
+         */
+        public Builder httpAuthOptionProperties(
+            List<HttpAuthOptionProperty> httpAuthOptionProperties) {
+            this.httpAuthOptionProperties.clear();
+            this.httpAuthOptionProperties.get().addAll(httpAuthOptionProperties);
+            return this;
+        }
+
+        /**
+         * Adds an auth option property.
+         * @param httpAuthOptionProperty property to add
+         * @return the builder
+         */
+        public Builder addHttpAuthOptionProperty(HttpAuthOptionProperty httpAuthOptionProperty) {
+            this.httpAuthOptionProperties.get().add(httpAuthOptionProperty);
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http;
+
+import java.util.function.Consumer;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Definition of an HttpAuthSchemeParameter.
+ *
+ * Currently this is used to generate the the HttpAuthSchemeParameters interface in `experimentalIdentityAndAuth`.
+ *
+ * @param name name of the auth scheme parameter
+ * @param type writer for the type of the auth scheme parameter
+ * @param source writer for the value of the auth scheme parameter, typically from {@code context} or {@code config}
+ */
+@SmithyUnstableApi
+public final record HttpAuthSchemeParameter(
+    String name,
+    Consumer<TypeScriptWriter> type,
+    Consumer<TypeScriptWriter> source
+) {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.validation.ValidationUtils;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.TypeScriptDelegator;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty.Type;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * feat(experimentalIdentityAndAuth): Generator for {@code HttpAuthSchemeProvider} and corresponding interfaces.
+ *
+ * Code generated includes:
+ *
+ * - {@code $ServiceHttpAuthSchemeParameters}
+ * - {@code default$ServiceHttpAuthSchemeParametersProvider}
+ * - {@code create$AuthSchemeIdHttpAuthOption}
+ * - {@code $ServiceHttpAuthSchemeProvider}
+ * - {@code default$ServiceHttpAuthSchemeProvider}
+ */
+@SmithyInternalApi
+public class HttpAuthSchemeProviderGenerator implements Runnable {
+    /**
+     * Directory segment for {@code auth/}.
+     */
+    public static final String HTTP_AUTH_FOLDER = "auth";
+    /**
+     * File name segment for {@code httpAuthSchemeProvder}.
+     */
+    public static final String HTTP_AUTH_SCHEME_RESOLVER_MODULE = "httpAuthSchemeProvider";
+
+    private static final String HTTP_AUTH_SCHEME_RESOLVER_FILE =
+        HTTP_AUTH_SCHEME_RESOLVER_MODULE + ".ts";
+    private static final String HTTP_AUTH_SCHEME_RESOLVER_PATH =
+        Paths.get(CodegenUtils.SOURCE_FOLDER, HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_RESOLVER_FILE).toString();
+
+    private final TypeScriptDelegator delegator;
+    private final Model model;
+
+    private final SupportedHttpAuthSchemesIndex authIndex;
+    private final ServiceIndex serviceIndex;
+    private final ServiceShape serviceShape;
+    private final Symbol serviceSymbol;
+    private final String serviceName;
+
+    /**
+     * Create an HttpAuthSchemeProviderGenerator.
+     * @param delegator delegator
+     * @param settings settings
+     * @param model model
+     * @param symbolProvider symbolProvider
+     * @param integrations integrations
+     */
+    public HttpAuthSchemeProviderGenerator(
+        TypeScriptDelegator delegator,
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        List<TypeScriptIntegration> integrations
+    ) {
+        this.delegator = delegator;
+        this.model = model;
+
+        this.authIndex = new SupportedHttpAuthSchemesIndex(integrations);
+        this.serviceIndex = ServiceIndex.of(model);
+        this.serviceShape = settings.getService(model);
+        this.serviceSymbol = symbolProvider.toSymbol(serviceShape);
+        this.serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
+    }
+
+    @Override
+    public void run() {
+        validateAuthSchemesAreSupported();
+        generateHttpAuthSchemeParametersInterface();
+        generateDefaultHttpAuthSchemeParametersProviderFunction();
+        generateHttpAuthOptionFunctions();
+        generateHttpAuthSchemeProviderInterface();
+        generateHttpAuthSchemeProviderDefaultFunction();
+    }
+
+    private void validateAuthSchemesAreSupported() {
+        List<ShapeId> unsupportedAuthSchemes = new ArrayList<>();
+        Map<ShapeId, Trait> serviceAuthSchemes = this.serviceIndex.getAuthSchemes(serviceShape);
+        for (ShapeId authScheme : serviceAuthSchemes.keySet()) {
+            if (this.authIndex.getHttpAuthScheme(authScheme) == null) {
+                unsupportedAuthSchemes.add(authScheme);
+            }
+        }
+        if (!unsupportedAuthSchemes.isEmpty()) {
+            throw new CodegenException("Code generation is not supported for the following auth schemes: "
+                + ValidationUtils.tickedList(unsupportedAuthSchemes));
+        }
+    }
+
+    /*
+    export interface WeatherHttpAuthSchemeParameters {
+        operation?: string;
+    }
+    */
+    private void generateHttpAuthSchemeParametersInterface() {
+        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export interface $LHttpAuthSchemeParameters {""", "}",
+                serviceName,
+                () -> {
+                w.write("operation?: string;");
+                for (HttpAuthScheme authScheme : authIndex.getSupportedHttpAuthSchemes().values()) {
+                    for (HttpAuthSchemeParameter parameter : authScheme.getHttpAuthSchemeParameters()) {
+                        w.write("$L?: $C;", parameter.name(), parameter.type());
+                    }
+                }
+            });
+        });
+    }
+
+    /*
+    import { WeatherClientResolvedConfig } from "../WeatherClient";
+    import { HandlerExecutionContext } from "@smithy/types";
+
+    // ...
+
+    export async function defaultWeatherHttpAuthSchemeParametersProvider(
+        config: WeatherClientResolvedConfig,
+        context: HandlerExecutionContext
+    ): Promise<WeatherHttpAuthSchemeParameters> {
+        return {
+            operation: context.commandName,
+        };
+    };
+    */
+    private void generateDefaultHttpAuthSchemeParametersProviderFunction() {
+        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+            w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
+                Paths.get(".", serviceSymbol.getNamespace()));
+            w.addImport("HandlerExecutionContext", null, TypeScriptDependency.SMITHY_TYPES);
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export async function default$LHttpAuthSchemeParametersProvider(
+                    config: $LResolvedConfig,
+                    context: HandlerExecutionContext
+                ): Promise<$LHttpAuthSchemeParameters> {""", "};",
+                serviceName, serviceSymbol.getName(), serviceName,
+                () -> {
+                w.openBlock("return {", "};", () -> {
+                    w.write("operation: context.commandName,");
+                    for (HttpAuthScheme authScheme : authIndex.getSupportedHttpAuthSchemes().values()) {
+                        for (HttpAuthSchemeParameter parameter : authScheme.getHttpAuthSchemeParameters()) {
+                            w.write("$L: $C,", parameter.name(), parameter.source());
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    private void generateHttpAuthOptionFunctions() {
+        for (Map.Entry<ShapeId, HttpAuthScheme> entry : this.authIndex.getSupportedHttpAuthSchemes().entrySet()) {
+            if (this.serviceIndex.getAuthSchemes(serviceShape).containsKey(entry.getKey())) {
+                generateHttpAuthOptionFunction(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // Check whether to generate @smithy.api#noAuth auth option function
+        boolean shouldGenerateNoAuthOptionFunction = serviceIndex.getEffectiveAuthSchemes(serviceShape).isEmpty();
+        shouldGenerateNoAuthOptionFunction |= serviceShape.getAllOperations().stream()
+            .map(id -> model.expectShape(id, OperationShape.class))
+            .anyMatch(o -> o.hasTrait(OptionalAuthTrait.ID)
+                || serviceIndex.getEffectiveAuthSchemes(serviceShape, o).isEmpty());
+        if (shouldGenerateNoAuthOptionFunction) {
+            generateHttpAuthOptionFunction(AuthUtils.NO_AUTH_ID, HttpAuthScheme.builder()
+                .schemeId(AuthUtils.NO_AUTH_ID)
+                .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
+                .build());
+        }
+    }
+    /*
+    import { HttpAuthOption } from "@smithy/types";
+
+    // ...
+
+    function createSmithyApiHttpApiKeyAuthHttpAuthOption(authParameters: WeatherHttpAuthSchemeParameters):
+    HttpAuthOption[] {
+        return {
+            schemeId: "smithy.api#httpApiKeyAuth",
+            signingProperties: {
+                name: "Authorization",
+                in: HttpApiKeyAuthLocation.HEADER,
+                scheme: "",
+            },
+        };
+    };
+    */
+    private void generateHttpAuthOptionFunction(ShapeId shapeId, HttpAuthScheme authScheme) {
+        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+            String normalizedAuthScheme = normalizeAuthScheme(shapeId);
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addImport("HttpAuthOption", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.openBlock("""
+                function create$LHttpAuthOption(authParameters: $LHttpAuthSchemeParameters): \
+                HttpAuthOption {""", "};",
+                normalizedAuthScheme, serviceName,
+                () -> {
+                w.openBlock("return {", "};", () -> {
+                    w.write("schemeId: $S,", shapeId.toString());
+                    Trait trait = serviceShape.findTrait(shapeId).orElse(null);
+                    List<HttpAuthOptionProperty> identityProperties =
+                        authScheme.getAuthSchemeOptionParametersByType(Type.IDENTITY);
+                    if (!identityProperties.isEmpty()) {
+                        w.openBlock("identityProperties: {", "},", () -> {
+                            for (HttpAuthOptionProperty parameter : identityProperties) {
+                                w.write("$L: $C,", parameter.name(), parameter.source().apply(trait));
+                            }
+                        });
+                    }
+                    List<HttpAuthOptionProperty> signingProperties =
+                        authScheme.getAuthSchemeOptionParametersByType(Type.SIGNING);
+                    if (!signingProperties.isEmpty()) {
+                        w.openBlock("signingProperties: {", "},", () -> {
+                            for (HttpAuthOptionProperty parameter : signingProperties) {
+                                w.write("$L: $C,", parameter.name(), parameter.source().apply(trait));
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    private static String normalizeAuthScheme(ShapeId shapeId) {
+        return String.join("", Arrays
+            .asList(shapeId.toString().split("[.#]"))
+            .stream().map(StringUtils::capitalize)
+            .toList());
+    }
+
+    /*
+    export interface WeatherHttpAuthSchemeProvider {
+        (authParameters: WeatherHttpAuthSchemeParameters): HttpAuthOption[];
+    }
+    */
+    private void generateHttpAuthSchemeProviderInterface() {
+        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+            w.write("""
+            /**
+             * @internal
+             */
+            export interface $LHttpAuthSchemeProvider {
+              (authParameters: $LHttpAuthSchemeParameters): HttpAuthOption[];
+            }
+            """, serviceName, serviceName);
+        });
+    }
+
+    /*
+    export function defaultWeatherHttpAuthSchemeProvider(authParameters: WeatherHttpAuthSchemeParameters):
+    HttpAuthOption[] {
+        const options: HttpAuthOption[] = [];
+        switch (authParameters.operation) {
+            default: {
+                options.push(createSmithyApiHttpApiKeyAuthHttpAuthOption(authParameters));
+            };
+        };
+        return options;
+    };
+    */
+    private void generateHttpAuthSchemeProviderDefaultFunction() {
+        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+            w.openBlock("""
+            /**
+             * @internal
+             */
+            export function default$LHttpAuthSchemeProvider(authParameters: $LHttpAuthSchemeParameters): \
+            HttpAuthOption[] {""", "};", serviceName, serviceName, () -> {
+                w.write("const options: HttpAuthOption[] = [];");
+                w.openBlock("switch (authParameters.operation) {", "};", () -> {
+                    var serviceAuthSchemes = serviceIndex.getEffectiveAuthSchemes(serviceShape);
+                    for (ShapeId operationShapeId : serviceShape.getAllOperations()) {
+                        var operationAuthSchemes = serviceIndex.getEffectiveAuthSchemes(serviceShape, operationShapeId);
+                        Shape operationShape = this.model.expectShape(operationShapeId);
+                        if (serviceAuthSchemes.equals(operationAuthSchemes)
+                            && !operationShape.hasTrait(OptionalAuthTrait.ID)) {
+                            continue;
+                        }
+                        w.openBlock("case $S: {", "};", operationShapeId.getName(), () -> {
+                            operationAuthSchemes.keySet().forEach(shapeId -> {
+                                w.write("options.push(create$LHttpAuthOption(authParameters));",
+                                    normalizeAuthScheme(shapeId));
+                            });
+                            if (operationAuthSchemes.get(AuthUtils.NO_AUTH_ID) != null || operationAuthSchemes.isEmpty()
+                                || operationShape.hasTrait(OptionalAuthTrait.ID)) {
+                                w.write("options.push(create$LHttpAuthOption(authParameters));",
+                                    normalizeAuthScheme(AuthUtils.NO_AUTH_ID));
+                            }
+                            w.write("break;");
+                        });
+                    }
+                    w.openBlock("default: {", "};", () -> {
+                        serviceAuthSchemes.keySet().forEach(shapeId -> {
+                            w.write("options.push(create$LHttpAuthOption(authParameters));",
+                                normalizeAuthScheme(shapeId));
+                        });
+                        if (serviceAuthSchemes.get(AuthUtils.NO_AUTH_ID) != null || serviceAuthSchemes.isEmpty()) {
+                            w.write("options.push(create$LHttpAuthOption(authParameters));",
+                                normalizeAuthScheme(AuthUtils.NO_AUTH_ID));
+                        }
+                    });
+                });
+                w.write("return options;");
+            });
+        });
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Index of AuthSchemes supported in code generation through integrations.
+ *
+ * Integrations may mutate this index to customize {@link HttpAuthScheme}
+ * implementations.
+ *
+ * This class is currently under the `experimentalIdentityAgitndAuth` experimental
+ * flag, and is subject to breaking changes.
+ */
+@SmithyInternalApi
+public final class SupportedHttpAuthSchemesIndex {
+    private final Map<ShapeId, HttpAuthScheme> supportedHttpAuthSchemes = new HashMap<>();
+
+    /**
+     * Creates an index from registered {@link HttpAuthScheme}s in {@link TypeScriptIntegration}s.
+     * @param integrations list of integrations to register HttpAuthSchemes
+     */
+    public SupportedHttpAuthSchemesIndex(List<TypeScriptIntegration> integrations) {
+        for (TypeScriptIntegration integration : integrations) {
+            if (!(integration instanceof HttpAuthTypeScriptIntegration)) {
+                continue;
+            }
+            HttpAuthTypeScriptIntegration httpAuthIntegration = (HttpAuthTypeScriptIntegration) integration;
+            if (httpAuthIntegration.getHttpAuthScheme().isPresent()) {
+                HttpAuthScheme authScheme = httpAuthIntegration.getHttpAuthScheme().get();
+                this.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
+            }
+            httpAuthIntegration.customizeSupportedHttpAuthSchemes(this);
+        }
+    }
+
+    /**
+     * Registers an {@link HttpAuthScheme}.
+     * @param schemeId schemeId of authScheme
+     * @param authScheme auth scheme to put
+     * @return the auth scheme that was there previously or null
+     */
+    public HttpAuthScheme putHttpAuthScheme(ShapeId schemeId, HttpAuthScheme authScheme) {
+        return supportedHttpAuthSchemes.put(schemeId, authScheme);
+    }
+
+    /**
+     * Gets an {@link HttpAuthScheme}.
+     * @param schemeId schemeId of auth scheme to get
+     * @return the auth scheme or null if not found
+     */
+    public HttpAuthScheme getHttpAuthScheme(ShapeId schemeId) {
+        return supportedHttpAuthSchemes.get(schemeId);
+    }
+
+    /**
+     * Removes an {@link HttpAuthScheme}.
+     * @param schemeId schemeId of auth scheme to remove
+     * @return the removed auth scheme or null if nothing was previously put
+     */
+    public HttpAuthScheme removeHttpAuthScheme(ShapeId schemeId) {
+        return supportedHttpAuthSchemes.remove(schemeId);
+    }
+
+    /**
+     * Gets the map of supported {@link HttpAuthScheme}s.
+     * @return supportedHttpAuthSchemes
+     */
+    public Map<ShapeId, HttpAuthScheme> getSupportedHttpAuthSchemes() {
+        return supportedHttpAuthSchemes;
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import java.util.Optional;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add config and middleware to support the synthetic @noAuth auth scheme.
+ */
+@SmithyInternalApi
+public final class AddNoAuthPlugin implements HttpAuthTypeScriptIntegration {
+    @Override
+    public Optional<HttpAuthScheme> getHttpAuthScheme() {
+        return Optional.of(HttpAuthScheme.builder()
+            .schemeId(AuthUtils.NO_AUTH_ID)
+            .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
+            .putDefaultIdentityProvider(LanguageTarget.SHARED, w -> w.write("async () => ({})"))
+            .putDefaultSigner(LanguageTarget.SHARED, w -> {
+                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("NoAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.write("new NoAuthSigner()");
+            })
+            .build());
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import java.util.Optional;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Java SPI for customizing TypeScript code generation for `experimentalIdentityAndAuth`.
+ *
+ * This should NOT be used as it is highly susceptible to breaking changes.
+ */
+@SmithyInternalApi
+public interface HttpAuthTypeScriptIntegration extends TypeScriptIntegration {
+    /**
+     * feat(experimentalIdentityAndAuth): Register an {@link HttpAuthScheme} that is used to generate the
+     * {@code HttpAuthSchemeProvider} and corresponding config field and runtime config values.
+     * @return an empty optional.
+     */
+    default Optional<HttpAuthScheme> getHttpAuthScheme() {
+        return Optional.empty();
+    }
+
+    /**
+     * feat(experimentalIdentityAndAuth): Mutate an {@link SupportedHttpAuthSchemesIndex} to mutate registered
+     * {@link HttpAuthScheme}s, e.g. default {@code IdentityProvider}s and {@code HttpSigner}s.
+     * @param supportedHttpAuthSchemesIndex index to mutate.
+     */
+    default void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -2,6 +2,7 @@ software.amazon.smithy.typescript.codegen.integration.AddClientRuntimeConfig
 software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
+software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddBaseServiceExceptionClass
 software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGeneratorTest.java
@@ -67,7 +67,8 @@ public class RuntimeConfigGeneratorTest {
         SymbolProvider symbolProvider = new SymbolVisitor(model, settings);
         TypeScriptDelegator delegator = new TypeScriptDelegator(manifest, symbolProvider);
         RuntimeConfigGenerator generator = new RuntimeConfigGenerator(
-                settings, model, symbolProvider, delegator, integrations);
+                settings, model, symbolProvider, delegator, integrations,
+                ApplicationProtocol.createDefaultHttpApplicationProtocol());
         generator.generate(LanguageTarget.NODE);
         generator.generate(LanguageTarget.BROWSER);
         generator.generate(LanguageTarget.REACT_NATIVE);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,6 +1885,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@smithy/experimental-identity-and-auth@workspace:packages/experimental-identity-and-auth":
+  version: 0.0.0-use.local
+  resolution: "@smithy/experimental-identity-and-auth@workspace:packages/experimental-identity-and-auth"
+  dependencies:
+    "@smithy/types": "workspace:^"
+    "@tsconfig/recommended": 1.0.1
+    concurrently: 7.0.0
+    downlevel-dts: 0.10.1
+    jest: 28.1.1
+    rimraf: 3.0.2
+    tslib: ^2.5.0
+    typedoc: 0.23.23
+    typescript: ~4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@smithy/fetch-http-handler@workspace:^, @smithy/fetch-http-handler@workspace:packages/fetch-http-handler":
   version: 0.0.0-use.local
   resolution: "@smithy/fetch-http-handler@workspace:packages/fetch-http-handler"


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

**NOTE: All of these are under the `experimentalIdentityAndAuth` feature flag**

Start implementing core code generation and TypeScript package for the client `config`. This change introduces:

- Adding config properties `httpAuthSchemes` and `httpAuthSchemeProvider` and corresponding runtime config defaults
  ```typescript
  /**
   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
   * @internal
   */
  httpAuthSchemes?: IdentityProviderConfiguration;

  /**
   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
   * @internal
   */
  httpAuthSchemeProvider?: WeatherHttpAuthSchemeProvider;
  ```
- Generating the model-based `HttpAuthSchemeProvider` and interfaces per client
  - Only no auth trait clients are supported in this PR, but other auth traits support will be implemented in follow-up PRs.
- The `@smithy/experimental-identity-and-auth` package, which will be reorganized into proper packages and deprecated after feature development is complete.
  - This package should stay within `0.x.x`, and never have a major version bump.
- Temporarily removing auth traits from generic client test since they will fail codegen until the auth trait is supported

*Testing:*

- No authentication trait client codegen diff: https://gist.github.com/syall/a595c7738c380176a528ff29016f1c2c#file-no-auth-trait-client-diff
- See the following PRs example auth scheme support using this feature:
  - https://github.com/awslabs/smithy-typescript/pull/883
  - https://github.com/awslabs/smithy-typescript/pull/884
  - https://github.com/awslabs/smithy-typescript/pull/885
- No codegen diff for `aws-sdk-js-v3`


TODO:

- [x] Add javadoc
- [x] Add TypeScript documentation
- [x] Add generating documentation for config properties
- [x] Test with an AuthScheme (planned `@httpApiKeyAuth`)

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
