### PR TITLE
feat(experimentalIdentityAndAuth): add more auth traits to generic client tests

### DIFF
--- a/smithy-typescript-codegen-test/build.gradle.kts
+++ b/smithy-typescript-codegen-test/build.gradle.kts
@@ -47,4 +47,5 @@ dependencies {
     implementation(project(":smithy-typescript-ssdk-codegen-test-utils"))
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add more auth traits to generic client tests.

Note that the `smithy-aws-traits` dependency is added for including
`@aws.auth#sigv4`, which will have generic client support. This should
not affect packaging of `smithy-typescript-codegen` since these tests
are in `smithy-typescript-codegen-test`.

Also, simplify `AddHttpApiKeyAuthPlugin` control path for computing whether `@httpApiKeyAuth` is supported on a service and operation.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
