### PR TITLE
feat(experimentalIdentityAndAuth): Add generic `@httpApiKeyAuth` support

### DIFF
--- a/.changeset/thirty-ants-wash.md
+++ b/.changeset/thirty-ants-wash.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+INTERNAL USE ONLY: Add `@httpApiKeyAuth` interfaces and classes

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/protocol-http": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },

--- a/packages/experimental-identity-and-auth/src/apiKeyIdentity.ts
+++ b/packages/experimental-identity-and-auth/src/apiKeyIdentity.ts
@@ -1,0 +1,13 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export interface ApiKeyIdentity extends Identity {
+  readonly apiKey: string;
+}
+
+/**
+ * @internal
+ */
+export type ApiKeyIdentityProvider = IdentityProvider<ApiKeyIdentity>;

--- a/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
@@ -1,0 +1,52 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import { HttpRequest as IHttpRequest } from "@smithy/types";
+
+import { ApiKeyIdentity } from "./apiKeyIdentity";
+import { HttpSigner } from "./HttpSigner";
+
+/**
+ * @internal
+ */
+export enum HttpApiKeyAuthLocation {
+  HEADER = "header",
+  QUERY = "query",
+}
+
+/**
+ * @internal
+ */
+export class HttpApiKeyAuthSigner implements HttpSigner {
+  public async sign(
+    httpRequest: HttpRequest,
+    identity: ApiKeyIdentity,
+    signingProperties: Record<string, any>
+  ): Promise<IHttpRequest> {
+    if (!signingProperties) {
+      throw new Error(
+        "request could not be signed with `apiKey` since the `name` and `in` signer properties are missing"
+      );
+    }
+    if (!signingProperties.name) {
+      throw new Error("request could not be signed with `apiKey` since the `name` signer property is missing");
+    }
+    if (!signingProperties.in) {
+      throw new Error("request could not be signed with `apiKey` since the `in` signer property is missing");
+    }
+    const clonedRequest = httpRequest.clone();
+    if (signingProperties.in === HttpApiKeyAuthLocation.QUERY) {
+      clonedRequest.query[signingProperties.name] = identity.apiKey;
+    } else if (signingProperties.in === HttpApiKeyAuthLocation.HEADER) {
+      clonedRequest.headers[signingProperties.name] = signingProperties.scheme
+        ? `$${signingProperties.scheme} $${identity.apiKey}`
+        : identity.apiKey;
+    } else {
+      throw new Error(
+        "request can only be signed with `apiKey` locations `query` or `header`, " +
+          "but found: `" +
+          signingProperties.in +
+          "`"
+      );
+    }
+    return clonedRequest;
+  }
+}

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -2,3 +2,5 @@ export * from "./IdentityProviderConfiguration";
 export * from "./HttpAuthScheme";
 export * from "./HttpSigner";
 export * from "./noAuth";
+export * from "./apiKeyIdentity";
+export * from "./httpApiKeyAuth";

--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -11,7 +11,7 @@ use smithy.waiters#waitable
 @fakeProtocol
 // feat(experimentalIdentityAndAuth): uncomment operations as individual
 //   auth scheme support is implemented
-// @httpApiKeyAuth(name: "X-Api-Key", in: "header")
+@httpApiKeyAuth(name: "X-Api-Key", in: "header")
 // @httpBearerAuth
 // @sigv4(name: "weather")
 // @auth([sigv4])
@@ -26,12 +26,12 @@ service Weather {
         // feat(experimentalIdentityAndAuth): uncomment operations as individual
         //   auth scheme support is implemented
         // experimentalIdentityAndAuth
-        // OnlyHttpApiKeyAuth
+        OnlyHttpApiKeyAuth
         // OnlyHttpBearerAuth
         // OnlyHttpApiKeyAndBearerAuth
         // OnlyHttpApiKeyAndBearerAuthReversed
-        // OnlyHttpApiKeyAuthOptional
-        // SameAsService
+        OnlyHttpApiKeyAuthOptional
+        SameAsService
     ]
 }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import java.util.Optional;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait.Location;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty.Type;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Support for @httpApiKeyAuth.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public Optional<HttpAuthScheme> getHttpAuthScheme() {
+        return Optional.of(HttpAuthScheme.builder()
+                .schemeId(HttpApiKeyAuthTrait.ID)
+                .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
+                .addConfigField(new ConfigField("apiKey", w -> {
+                    w.addImport("ApiKeyIdentity", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.addImport("ApiKeyIdentityProvider", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.write("ApiKeyIdentity | ApiKeyIdentityProvider");
+                }, w -> w.write("The API key to use when making requests.")))
+                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
+                    "name", Type.SIGNING, t -> w -> {
+                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                    w.write("$S", httpApiKeyAuthTrait.getName());
+                }))
+                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
+                    "in", Type.SIGNING, t -> w -> {
+                    w.addImport("HttpApiKeyAuthLocation", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                    if (httpApiKeyAuthTrait.getIn().equals(Location.HEADER)) {
+                        w.write("HttpApiKeyAuthLocation.HEADER");
+                    } else if (httpApiKeyAuthTrait.getIn().equals(Location.QUERY)) {
+                        w.write("HttpApiKeyAuthLocation.QUERY");
+                    } else {
+                        throw new CodegenException("Encountered invalid `in` property on `@httpApiKeyAuth`: "
+                        + httpApiKeyAuthTrait.getIn());
+                    }
+                }))
+                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
+                    "scheme", Type.SIGNING, t -> w -> {
+                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                    httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
+                        s -> w.write(s),
+                        () -> w.write("undefined"));
+                }))
+                .putDefaultIdentityProvider(LanguageTarget.SHARED, w -> {
+                    w.write("async () => { throw new Error(\"`apiKey` is missing\"); }");
+                })
+                .putDefaultSigner(LanguageTarget.SHARED, w -> {
+                    w.addImport("HttpApiKeyAuthSigner", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.write("new HttpApiKeyAuthSigner()");
+                })
+                .build());
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -3,6 +3,7 @@ software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
+software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddBaseServiceExceptionClass
 software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/experimental-identity-and-auth@workspace:packages/experimental-identity-and-auth"
   dependencies:
+    "@smithy/protocol-http": "workspace:^"
     "@smithy/types": "workspace:^"
     "@tsconfig/recommended": 1.0.1
     concurrently: 7.0.0


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

**NOTE: All of these are under the `experimentalIdentityAndAuth` feature flag**

**NOTE: Dependent on https://github.com/awslabs/smithy-typescript/pull/881**

- Adding config properties `apiKey`:
  ```typescript
  /**
   * The API key to use when making requests.
   */
  apiKey?: ApiKeyIdentity | ApiKeyIdentityProvider;
  ```
- `@smithy/experimental-identity-and-auth` package: add the `ApiKeyIdentity` interface and `ApiKeyIdentityProvider` type, `HttpApiKeyAuthLocation` enum, and default `HttpApiKeyAuthSigner` implementation.
- Add back operations that support `@httpApiKeyAuth` in the generic client test

*Testing:*

- `@httpApiKeyAuth` client codegen diff given the following model changes: https://gist.github.com/syall/a595c7738c380176a528ff29016f1c2c#file-httpapikeyauth-trait-client-diff
  - The existing integration generated middleware and tests in the client package, which is why there is such a large removal in the diff.
  ```diff
   @fakeProtocol
   // feat(experimentalIdentityAndAuth): uncomment operations as individual
   //   auth scheme support is implemented
  -// @httpApiKeyAuth(name: "X-Api-Key", in: "header")
  +@httpApiKeyAuth(name: "X-Api-Key", in: "header")
   // @httpBearerAuth
   // @sigv4(name: "weather")
   // @auth([sigv4])
  @@ -26,12 +26,12 @@ service Weather {
           // feat(experimentalIdentityAndAuth): uncomment operations as individual
           //   auth scheme support is implemented
           // experimentalIdentityAndAuth
  -        // OnlyHttpApiKeyAuth
  +        OnlyHttpApiKeyAuth
           // OnlyHttpBearerAuth
           // OnlyHttpApiKeyAndBearerAuth
           // OnlyHttpApiKeyAndBearerAuthReversed
  -        // OnlyHttpApiKeyAuthOptional
  -        // SameAsService
  +        OnlyHttpApiKeyAuthOptional
  +        SameAsService
       ]
   }
  ```
- No codegen diff for `aws-sdk-js-v3`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
