### PR TITLE
feat(experimentalIdentityAndAuth): Add generic `@httpBearerAuth` support

### DIFF
--- a/.changeset/wild-years-leave.md
+++ b/.changeset/wild-years-leave.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+INTERNAL USE ONLY: Add `@httpBearerAuth` interfaces and classes

--- a/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
@@ -1,0 +1,20 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import { HttpRequest as IHttpRequest } from "@smithy/types";
+
+import { HttpSigner } from "./HttpSigner";
+import { TokenIdentity } from "./tokenIdentity";
+
+/**
+ * @internal
+ */
+export class HttpBearerAuthSigner implements HttpSigner {
+  public async sign(
+    httpRequest: HttpRequest,
+    identity: TokenIdentity,
+    signingProperties: Record<string, any>
+  ): Promise<IHttpRequest> {
+    const clonedRequest = httpRequest.clone();
+    clonedRequest.headers["Authorization"] = `Bearer ${identity.token}`;
+    return clonedRequest;
+  }
+}

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -4,3 +4,5 @@ export * from "./HttpSigner";
 export * from "./noAuth";
 export * from "./apiKeyIdentity";
 export * from "./httpApiKeyAuth";
+export * from "./httpBearerAuth";
+export * from "./tokenIdentity";

--- a/packages/experimental-identity-and-auth/src/tokenIdentity.ts
+++ b/packages/experimental-identity-and-auth/src/tokenIdentity.ts
@@ -1,0 +1,16 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export interface TokenIdentity extends Identity {
+  /**
+   * The literal token string
+   */
+  readonly token: string;
+}
+
+/**
+ * @internal
+ */
+export type TokenIdentityProvider = IdentityProvider<TokenIdentity>;

--- a/smithy-typescript-codegen-test/model/main.smithy
+++ b/smithy-typescript-codegen-test/model/main.smithy
@@ -12,7 +12,7 @@ use smithy.waiters#waitable
 // feat(experimentalIdentityAndAuth): uncomment operations as individual
 //   auth scheme support is implemented
 @httpApiKeyAuth(name: "X-Api-Key", in: "header")
-// @httpBearerAuth
+@httpBearerAuth
 // @sigv4(name: "weather")
 // @auth([sigv4])
 @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
@@ -27,10 +27,11 @@ service Weather {
         //   auth scheme support is implemented
         // experimentalIdentityAndAuth
         OnlyHttpApiKeyAuth
-        // OnlyHttpBearerAuth
-        // OnlyHttpApiKeyAndBearerAuth
-        // OnlyHttpApiKeyAndBearerAuthReversed
         OnlyHttpApiKeyAuthOptional
+        OnlyHttpBearerAuth
+        OnlyHttpBearerAuthOptional
+        OnlyHttpApiKeyAndBearerAuth
+        OnlyHttpApiKeyAndBearerAuthReversed
         SameAsService
     ]
 }
@@ -55,6 +56,11 @@ operation OnlyHttpApiKeyAndBearerAuthReversed {}
 @auth([httpApiKeyAuth])
 @optionalAuth
 operation OnlyHttpApiKeyAuthOptional {}
+
+@http(method: "GET", uri: "/OnlyHttpBearerAuthOptional")
+@auth([httpBearerAuth])
+@optionalAuth
+operation OnlyHttpBearerAuthOptional {}
 
 @http(method: "GET", uri: "/SameAsService")
 operation SameAsService {}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import java.util.Optional;
+import software.amazon.smithy.model.traits.HttpBearerAuthTrait;
+import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Support for @httpBearerAuth.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public Optional<HttpAuthScheme> getHttpAuthScheme() {
+        return Optional.of(HttpAuthScheme.builder()
+                .schemeId(HttpBearerAuthTrait.ID)
+                .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
+                .addConfigField(new ConfigField("token", w -> {
+                    w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.addImport("TokenIdentity", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.addImport("TokenIdentityProvider", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.write("TokenIdentity | TokenIdentityProvider");
+                }, w -> w.write("The token used to authenticate requests.")))
+                .putDefaultIdentityProvider(LanguageTarget.SHARED, w -> {
+                    w.write("async () => { throw new Error(\"`token` is missing\"); }");
+                })
+                .putDefaultSigner(LanguageTarget.SHARED, w -> {
+                    w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.addImport("HttpBearerAuthSigner", null,
+                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                    w.write("new HttpBearerAuthSigner()");
+                })
+                .build());
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -4,6 +4,7 @@ software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDepende
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpApiKeyAuthPlugin
+software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpBearerAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddBaseServiceExceptionClass
 software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

**NOTE: All of these are under the `experimentalIdentityAndAuth` feature flag**

**NOTE: Dependent on https://github.com/awslabs/smithy-typescript/pull/881**

- Adding config properties `token`:
  ```typescript
  /**
   * The token used to authenticate requests.
   */
  token?: TokenIdentity | TokenIdentityProvider;
  ```
- `@smithy/experimental-identity-and-auth` package: add the `TokenIdentity` interface and `TokenIdentityProvider` type (these are still only in `@aws-sdk/types` currently), and default `HttpBearerAuthSigner` implementation.
- Add back operations that support `@httpBearerAuth` in the generic client test

*Testing:*

- `@httpBearerAuth` client codegen diff given the following model changes: https://gist.github.com/syall/a595c7738c380176a528ff29016f1c2c#file-httpbearerauth-trait-client-diff
  ```diff
   // feat(experimentalIdentityAndAuth): uncomment operations as individual
   //   auth scheme support is implemented
   // @httpApiKeyAuth(name: "X-Api-Key", in: "header")
  -// @httpBearerAuth
  +@httpBearerAuth
   // @sigv4(name: "weather")
   // @auth([sigv4])
   @paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
  @@ -27,11 +27,12 @@ service Weather {
           //   auth scheme support is implemented
           // experimentalIdentityAndAuth
           // OnlyHttpApiKeyAuth
  -        // OnlyHttpBearerAuth
  +        OnlyHttpBearerAuth
           // OnlyHttpApiKeyAndBearerAuth
           // OnlyHttpApiKeyAndBearerAuthReversed
           // OnlyHttpApiKeyAuthOptional
  -        // SameAsService
  +        OnlyHttpBearerAuthOptional
  +        SameAsService
       ]
   }
  ```
- No codegen diff for `aws-sdk-js-v3`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
