### PR TITLE
move extensions runtime code to smithy-client

### DIFF
--- a/.changeset/long-apricots-end.md
+++ b/.changeset/long-apricots-end.md
@@ -1,0 +1,6 @@
+---
+"@smithy/smithy-client": patch
+"@smithy/types": patch
+---
+
+move extensions code to smithy-client

--- a/packages/smithy-client/src/extensions/checksum.ts
+++ b/packages/smithy-client/src/extensions/checksum.ts
@@ -1,8 +1,9 @@
-import { ChecksumConstructor } from "../checksum";
-import { HashConstructor } from "../crypto";
+import type { ChecksumConstructor, HashConstructor } from "@smithy/types";
 
 /**
  * @internal
+ *
+ * @deprecated will be imported from types.
  */
 export enum AlgorithmId {
   MD5 = "md5",
@@ -14,6 +15,8 @@ export enum AlgorithmId {
 
 /**
  * @internal
+ *
+ * @deprecated will be imported from types.
  */
 export interface ChecksumAlgorithm {
   algorithmId(): AlgorithmId;
@@ -22,32 +25,18 @@ export interface ChecksumAlgorithm {
 
 /**
  * @internal
+ *
+ * @deprecated will be imported from types.
  */
 export interface ChecksumConfiguration {
   addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
   checksumAlgorithms(): ChecksumAlgorithm[];
-
-  /**
-   * @deprecated unused.
-   */
-  [other: string | number]: any;
 }
 
 /**
- * @deprecated will be removed for implicit type.
- */
-type GetChecksumConfigurationType = (
-  runtimeConfig: Partial<{
-    sha256: ChecksumConstructor | HashConstructor;
-    md5: ChecksumConstructor | HashConstructor;
-  }>
-) => ChecksumConfiguration;
-
-/**
  * @internal
- * @deprecated will be moved to smithy-client.
  */
-export const getChecksumConfiguration: GetChecksumConfigurationType = (
+export const getChecksumConfiguration = (
   runtimeConfig: Partial<{
     sha256: ChecksumConstructor | HashConstructor;
     md5: ChecksumConstructor | HashConstructor;
@@ -81,17 +70,10 @@ export const getChecksumConfiguration: GetChecksumConfigurationType = (
 };
 
 /**
- * @deprecated will be removed for implicit type.
- */
-type ResolveChecksumRuntimeConfigType = (clientConfig: ChecksumConfiguration) => any;
-
-/**
  * @internal
- *
- * @deprecated will be moved to smithy-client.
  */
-export const resolveChecksumRuntimeConfig: ResolveChecksumRuntimeConfigType = (clientConfig: ChecksumConfiguration) => {
-  const runtimeConfig: any = {};
+export const resolveChecksumRuntimeConfig = (clientConfig: ChecksumConfiguration) => {
+  const runtimeConfig: Partial<Record<AlgorithmId, HashConstructor | ChecksumConstructor>> = {};
 
   clientConfig.checksumAlgorithms().forEach((checksumAlgorithm) => {
     runtimeConfig[checksumAlgorithm.algorithmId()] = checksumAlgorithm.checksumConstructor();

--- a/packages/smithy-client/src/extensions/defaultClientConfiguration.ts
+++ b/packages/smithy-client/src/extensions/defaultClientConfiguration.ts
@@ -1,0 +1,30 @@
+import type { DefaultClientConfiguration } from "@smithy/types";
+
+import { getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
+
+/**
+ * @internal
+ */
+export type DefaultExtensionConfigType = Parameters<typeof getChecksumConfiguration>[0];
+
+/**
+ * @internal
+ *
+ * Helper function to resolve default client configuration from runtime config
+ */
+export const getDefaultClientConfiguration = (runtimeConfig: DefaultExtensionConfigType) => {
+  return {
+    ...getChecksumConfiguration(runtimeConfig),
+  };
+};
+
+/**
+ * @internal
+ *
+ * Helper function to resolve runtime config from default client configuration
+ */
+export const resolveDefaultRuntimeConfig = (config: DefaultClientConfiguration) => {
+  return {
+    ...resolveChecksumRuntimeConfig(config),
+  };
+};

--- a/packages/smithy-client/src/extensions/index.ts
+++ b/packages/smithy-client/src/extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./defaultClientConfiguration";

--- a/packages/types/src/extensions/defaultClientConfiguration.ts
+++ b/packages/types/src/extensions/defaultClientConfiguration.ts
@@ -7,12 +7,17 @@ import { ChecksumConfiguration, getChecksumConfiguration, resolveChecksumRuntime
  */
 export interface DefaultClientConfiguration extends ChecksumConfiguration {}
 
+/**
+ * @deprecated will be removed for implicit type.
+ */
 type GetDefaultConfigurationType = (runtimeConfig: any) => DefaultClientConfiguration;
 
 /**
+ * @deprecated moving to @smithy/smithy-client.
  * @internal
  *
  * Helper function to resolve default client configuration from runtime config
+ *
  */
 export const getDefaultClientConfiguration: GetDefaultConfigurationType = (runtimeConfig: any) => {
   return {
@@ -20,9 +25,13 @@ export const getDefaultClientConfiguration: GetDefaultConfigurationType = (runti
   };
 };
 
+/**
+ * @deprecated will be removed for implicit type.
+ */
 type ResolveDefaultRuntimeConfigType = (clientConfig: DefaultClientConfiguration) => any;
 
 /**
+ * @deprecated moving to @smithy/smithy-client.
  * @internal
  *
  * Helper function to resolve runtime config from default client configuration

--- a/packages/types/src/extensions/index.ts
+++ b/packages/types/src/extensions/index.ts
@@ -1,1 +1,2 @@
 export * from "./defaultClientConfiguration";
+export { AlgorithmId, ChecksumAlgorithm, ChecksumConfiguration } from "./checksum";

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["src", "package.json"],
       "outputs": ["dist-types", "dist-cjs", "dist-es"]
     },
     "test": {


### PR DESCRIPTION
- moves the runtime portions of the extensions feature to `smithy-client`, out of `types`.
- exports extensions-related types from `types` pkg to be used in `smithy-client`.
