### PR TITLE
Add retry to runtime extension

### DIFF
--- a/.changeset/chilled-lies-care.md
+++ b/.changeset/chilled-lies-care.md
@@ -1,0 +1,6 @@
+---
+"@smithy/smithy-client": minor
+"@smithy/types": minor
+---
+
+Add retry to runtime extension

--- a/packages/smithy-client/src/extensions/defaultExtensionConfiguration.ts
+++ b/packages/smithy-client/src/extensions/defaultExtensionConfiguration.ts
@@ -1,11 +1,13 @@
 import type { DefaultExtensionConfiguration } from "@smithy/types";
 
 import { getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
+import { getRetryConfiguration, resolveRetryRuntimeConfig } from "./retry";
 
 /**
  * @internal
  */
-export type DefaultExtensionConfigType = Parameters<typeof getChecksumConfiguration>[0];
+export type DefaultExtensionConfigType = Parameters<typeof getChecksumConfiguration>[0] &
+  Parameters<typeof getRetryConfiguration>[0];
 
 /**
  * @internal
@@ -15,6 +17,7 @@ export type DefaultExtensionConfigType = Parameters<typeof getChecksumConfigurat
 export const getDefaultExtensionConfiguration = (runtimeConfig: DefaultExtensionConfigType) => {
   return {
     ...getChecksumConfiguration(runtimeConfig),
+    ...getRetryConfiguration(runtimeConfig),
   };
 };
 
@@ -34,5 +37,6 @@ export const getDefaultClientConfiguration = getDefaultExtensionConfiguration;
 export const resolveDefaultRuntimeConfig = (config: DefaultExtensionConfiguration) => {
   return {
     ...resolveChecksumRuntimeConfig(config),
+    ...resolveRetryRuntimeConfig(config),
   };
 };

--- a/packages/smithy-client/src/extensions/retry.ts
+++ b/packages/smithy-client/src/extensions/retry.ts
@@ -1,0 +1,27 @@
+import { Provider, RetryStrategy, RetryStrategyConfiguration, RetryStrategyV2 } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const getRetryConfiguration = (
+  runtimeConfig: Partial<{ retryStrategy: Provider<RetryStrategyV2 | RetryStrategy> }>
+) => {
+  return {
+    _retryStrategy: runtimeConfig.retryStrategy!,
+    setRetryStrategy(retryStrategy: Provider<RetryStrategyV2 | RetryStrategy>): void {
+      this._retryStrategy = retryStrategy;
+    },
+    retryStrategy(): Provider<RetryStrategyV2 | RetryStrategy> {
+      return this._retryStrategy;
+    },
+  };
+};
+
+/**
+ * @internal
+ */
+export const resolveRetryRuntimeConfig = (retryStrategyConfiguration: RetryStrategyConfiguration) => {
+  const runtimeConfig: Partial<Record<string, Provider<RetryStrategyV2 | RetryStrategy>>> = {};
+  runtimeConfig.retryStrategy = retryStrategyConfiguration.retryStrategy();
+  return runtimeConfig;
+};

--- a/packages/types/src/extensions/defaultExtensionConfiguration.ts
+++ b/packages/types/src/extensions/defaultExtensionConfiguration.ts
@@ -1,10 +1,9 @@
 import { ChecksumConfiguration } from "./checksum";
+import { RetryStrategyConfiguration } from "./retry";
 
 /**
  * @internal
  *
  * Default extension configuration consisting various configurations for modifying a service client
  */
-export interface DefaultExtensionConfiguration extends ChecksumConfiguration {}
-
-type GetDefaultConfigurationType = (runtimeConfig: any) => DefaultExtensionConfiguration;
+export interface DefaultExtensionConfiguration extends ChecksumConfiguration, RetryStrategyConfiguration {}

--- a/packages/types/src/extensions/index.ts
+++ b/packages/types/src/extensions/index.ts
@@ -1,3 +1,4 @@
 export * from "./defaultClientConfiguration";
 export * from "./defaultExtensionConfiguration";
 export { AlgorithmId, ChecksumAlgorithm, ChecksumConfiguration } from "./checksum";
+export { RetryStrategyConfiguration } from "./retry";

--- a/packages/types/src/extensions/retry.ts
+++ b/packages/types/src/extensions/retry.ts
@@ -1,0 +1,10 @@
+import { RetryStrategyV2 } from "../retry";
+import { Provider, RetryStrategy } from "../util";
+
+/**
+ * @internal
+ */
+export interface RetryStrategyConfiguration {
+  setRetryStrategy(retryStrategy: Provider<RetryStrategyV2 | RetryStrategy>): void;
+  retryStrategy(): Provider<RetryStrategyV2 | RetryStrategy>;
+}


### PR DESCRIPTION
This PR adds retry component to the runtime extensions. 

Using S3 as an example:
```
export class CustomRetryExtension implements RuntimeExtension {
    configure(extensionConfiguration: S3ExtensionConfiguration): void {
       extensionConfiguration.setRetryStrategy(...);
    }
}

// extensions can be passed via the client constructor object
S3Client({
  ...
  extensions: [CustomRetryExtension()]
})
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
