### PR TITLE
Add `matchSettings()` to `TypeScriptIntegration` and `TypeScriptCodegenPlugin`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -36,6 +36,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.DefaultTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -58,6 +59,7 @@ public final class TypeScriptSettings {
     private static final String PRIVATE = "private";
     private static final String PACKAGE_MANAGER = "packageManager";
     private static final String CREATE_DEFAULT_README = "createDefaultReadme";
+    private static final String EXCLUDED_INTEGRATIONS = "excludedIntegrations";
     private static final String EXPERIMENTAL_IDENTITY_AND_AUTH = "experimentalIdentityAndAuth";
 
     private String packageName;
@@ -75,6 +77,7 @@ public final class TypeScriptSettings {
         RequiredMemberMode.NULLABLE;
     private PackageManager packageManager = PackageManager.YARN;
     private boolean createDefaultReadme = false;
+    private Set<String> excludedIntegrations = Collections.emptySet();
     private boolean experimentalIdentityAndAuth = false;
 
     @Deprecated
@@ -109,6 +112,9 @@ public final class TypeScriptSettings {
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
         settings.setCreateDefaultReadme(
                 config.getBooleanMember(CREATE_DEFAULT_README).map(BooleanNode::getValue).orElse(false));
+        settings.setExcludedIntegrations(config.containsMember(EXCLUDED_INTEGRATIONS)
+            ? Set.copyOf(Node.loadArrayOfString(EXCLUDED_INTEGRATIONS, config.expectArrayMember(EXCLUDED_INTEGRATIONS)))
+            : Collections.<String>emptySet());
         settings.setExperimentalIdentityAndAuth(
                 config.getBooleanMemberOrDefault(EXPERIMENTAL_IDENTITY_AND_AUTH, false));
         settings.setPackageManager(
@@ -357,6 +363,24 @@ public final class TypeScriptSettings {
     }
 
     /**
+     * Returns the names of excluded {@link TypeScriptIntegration}s.
+     *
+     * @return the names of excluded {@link TypeScriptIntegration}s
+     */
+    public Set<String> getExcludedIntegrations() {
+        return excludedIntegrations;
+    }
+
+    /**
+     * Sets the names of excluded {@link TypeScriptIntegration}s.
+     *
+     * @param excludedIntegrations names of {@link TypeScriptIntegration}s to exclude
+     */
+    public void setExcludedIntegrations(Set<String> excludedIntegrations) {
+        this.excludedIntegrations = excludedIntegrations;
+    }
+
+    /**
      * Returns whether to use experimental identity and auth.
      *
      * @return if experimental identity and auth should used. Default: false
@@ -469,7 +493,7 @@ public final class TypeScriptSettings {
         CLIENT(SymbolVisitor::new,
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                               SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, REQUIRED_MEMBER_MODE,
-                              CREATE_DEFAULT_README, EXPERIMENTAL_IDENTITY_AND_AUTH)),
+                              CREATE_DEFAULT_README, EXCLUDED_INTEGRATIONS, EXPERIMENTAL_IDENTITY_AND_AUTH)),
         SSDK((m, s) -> new ServerSymbolVisitor(m, new SymbolVisitor(m, s)),
                 Arrays.asList(PACKAGE, PACKAGE_DESCRIPTION, PACKAGE_JSON, PACKAGE_VERSION, PACKAGE_MANAGER,
                               SERVICE, PROTOCOL, TARGET_NAMESPACE, PRIVATE, REQUIRED_MEMBER_MODE,

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -42,6 +42,18 @@ public interface TypeScriptIntegration
         extends SmithyIntegration<TypeScriptSettings, TypeScriptWriter, TypeScriptCodegenContext> {
 
     /**
+     * Filters the integration based on {@link TypeScriptSettings}.
+     *
+     * By default, it will filter against the set of `excludedIntegrations`.
+     *
+     * @param settings settings to filter against
+     * @return whether the integration matches the settings or not.
+     */
+    default boolean matchesSettings(TypeScriptSettings settings) {
+        return !settings.getExcludedIntegrations().contains(name());
+    }
+
+    /**
      * Gets a list of plugins to apply to the generated client.
      *
      * @return Returns the list of RuntimePlugins to apply to the client.


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Filter `TypeScriptIntegration`s based on `TypeScriptSettings`.

This allows for integrations to be enabled or disabled based on settings in `smithy-build.json`. 
    
By default `matchSettings()` will filter on the new `excludedIntegrations` setting, which defines a set of integrations to exclude by name.

An example of how this new setting is used can be found here: https://github.com/awslabs/smithy-typescript/commit/6b5cc2e616de6ab781a734b181b310cd8d49fbb2

Also see: https://github.com/awslabs/smithy-typescript/pull/856

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
