### PR TITLE
Fix generating default rejected promise when chaining

### DIFF
--- a/.changeset/eight-pandas-worry.md
+++ b/.changeset/eight-pandas-worry.md
@@ -1,0 +1,5 @@
+---
+"@smithy/property-provider": patch
+---
+
+Fix generating default rejected promise when chaining

--- a/packages/property-provider/src/chain.spec.ts
+++ b/packages/property-provider/src/chain.spec.ts
@@ -1,48 +1,117 @@
 import { chain } from "./chain";
-import { fromStatic } from "./fromStatic";
 import { ProviderError } from "./ProviderError";
+
+const resolveStatic = (staticValue: unknown) => jest.fn().mockResolvedValue(staticValue);
+const rejectWithError = (errorMsg: string) => jest.fn().mockRejectedValue(new Error(errorMsg));
+const rejectWithProviderError = (errorMsg: string) => jest.fn().mockRejectedValue(new ProviderError(errorMsg));
 
 describe("chain", () => {
   it("should distill many credential providers into one", async () => {
-    const provider = chain(fromStatic("foo"), fromStatic("bar"));
-
+    const provider = chain(resolveStatic("foo"), resolveStatic("bar"));
     expect(typeof (await provider())).toBe("string");
   });
 
   it("should return the resolved value of the first successful promise", async () => {
-    const provider = chain(
-      () => Promise.reject(new ProviderError("Move along")),
-      () => Promise.reject(new ProviderError("Nothing to see here")),
-      fromStatic("foo")
-    );
+    const expectedOutput = "foo";
+    const providers = [
+      rejectWithProviderError("Move along"),
+      rejectWithProviderError("Nothing to see here"),
+      resolveStatic(expectedOutput),
+    ];
 
-    expect(await provider()).toBe("foo");
+    try {
+      const result = await chain(...providers)();
+      expect(result).toBe(expectedOutput);
+    } catch (error) {
+      throw error;
+    }
+
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).toHaveBeenCalledTimes(1);
   });
 
   it("should not invoke subsequent providers once one resolves", async () => {
+    const expectedOutput = "foo";
     const providers = [
-      jest.fn().mockRejectedValue(new ProviderError("Move along")),
-      jest.fn().mockResolvedValue("foo"),
-      jest.fn(() => fail("This provider should not be invoked")),
+      rejectWithProviderError("Move along"),
+      resolveStatic(expectedOutput),
+      rejectWithProviderError("This provider should not be invoked"),
     ];
 
-    expect(await chain(...providers)()).toBe("foo");
-    expect(providers[0].mock.calls.length).toBe(1);
-    expect(providers[1].mock.calls.length).toBe(1);
-    expect(providers[2].mock.calls.length).toBe(0);
+    try {
+      const result = await chain(...providers)();
+      expect(result).toBe(expectedOutput);
+    } catch (error) {
+      throw error;
+    }
+
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).not.toHaveBeenCalled();
+  });
+
+  describe("should throw if no provider resolves", () => {
+    const expectedErrorMsg = "Last provider failed";
+
+    it.each([
+      [ProviderError, rejectWithProviderError(expectedErrorMsg)],
+      [Error, rejectWithError(expectedErrorMsg)],
+    ])("case %p", async (errorType, errorProviderMockFn) => {
+      const firstProviderWhichRejects = rejectWithProviderError("Move along");
+      try {
+        await chain(firstProviderWhichRejects, errorProviderMockFn)();
+        throw new Error("Should not get here");
+      } catch (error) {
+        expect(error).toEqual(new errorType(expectedErrorMsg));
+      }
+      expect(firstProviderWhichRejects).toHaveBeenCalledTimes(1);
+      expect(errorProviderMockFn).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("should halt if an unrecognized error is encountered", async () => {
-    const provider = chain(
-      () => Promise.reject(new ProviderError("Move along")),
-      () => Promise.reject(new Error("Unrelated failure")),
-      fromStatic("foo")
-    );
+    const expectedErrorMsg = "Unrelated failure";
+    const providers = [rejectWithProviderError("Move along"), rejectWithError(expectedErrorMsg), resolveStatic("foo")];
 
-    await expect(provider()).rejects.toMatchObject(new Error("Unrelated failure"));
+    try {
+      await chain(...providers)();
+      throw new Error("Should not get here");
+    } catch (error) {
+      expect(error).toEqual(new Error(expectedErrorMsg));
+    }
+
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).not.toHaveBeenCalled();
+  });
+
+  it("should halt if ProviderError explicitly requests it", async () => {
+    const expectedError = new ProviderError("ProviderError with tryNextLink set to false", false);
+    const providers = [
+      rejectWithProviderError("Move along"),
+      jest.fn().mockRejectedValue(expectedError),
+      resolveStatic("foo"),
+    ];
+
+    try {
+      await chain(...providers)();
+      throw new Error("Should not get here");
+    } catch (error) {
+      expect(error).toEqual(expectedError);
+    }
+
+    expect(providers[0]).toHaveBeenCalledTimes(1);
+    expect(providers[1]).toHaveBeenCalledTimes(1);
+    expect(providers[2]).not.toHaveBeenCalled();
   });
 
   it("should reject chains with no links", async () => {
-    await expect(chain()()).rejects.toMatchObject(new Error("No providers in chain"));
+    try {
+      await chain()();
+      throw new Error("Should not get here");
+    } catch (error) {
+      expect(error).toEqual(new Error("No providers in chain"));
+    }
   });
 });


### PR DESCRIPTION
Fixes https://github.com/awslabs/smithy-typescript/issues/896.

This issue was originally reported in https://github.com/aws/aws-sdk-js-v3/issues/2263 and fixed in https://github.com/aws/aws-sdk-js-v3/pull/4843. This PR copies that fix to the @smithy/property-provider package.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
