### PR TITLE
Add http client component to runtime extension

### DIFF
--- a/.changeset/shy-kids-call.md
+++ b/.changeset/shy-kids-call.md
@@ -1,0 +1,8 @@
+---
+"@smithy/protocol-http": major
+"@smithy/fetch-http-handler": minor
+"@smithy/node-http-handler": minor
+"@smithy/util-test": minor
+---
+
+Add http client component to runtime extension

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "turbo run test",
     "test:integration": "yarn build-test-packages && turbo run test:integration",
     "lint": "turbo run lint",
+    "lint-fix": "turbo run lint -- --fix",
     "format": "turbo run format --parallel",
     "stage-release": "turbo run stage-release",
     "extract:docs": "mkdir -p api-extractor-packages && turbo run extract:docs",

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -55,6 +55,54 @@ describe(FetchHttpHandler.name, () => {
     expect(await blobToText(response.response.body)).toBe("FOO");
   });
 
+  it("put HttpClientConfig", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob(["FOO"])),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+    const fetchHttpHandler = new FetchHttpHandler();
+    fetchHttpHandler.updateHttpClientConfig("requestTimeout", 200);
+
+    await fetchHttpHandler.handle({} as any, {});
+
+    expect(fetchHttpHandler.httpHandlerConfigs().requestTimeout).toBe(200);
+  });
+
+  it("update HttpClientConfig", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob(["FOO"])),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+    const fetchHttpHandler = new FetchHttpHandler({ requestTimeout: 200 });
+    fetchHttpHandler.updateHttpClientConfig("requestTimeout", 300);
+
+    await fetchHttpHandler.handle({} as any, {});
+
+    expect(fetchHttpHandler.httpHandlerConfigs().requestTimeout).toBe(300);
+  });
+
+  it("httpHandlerConfigs returns empty object if handle is not called", async () => {
+    const fetchHttpHandler = new FetchHttpHandler();
+    fetchHttpHandler.updateHttpClientConfig("requestTimeout", 300);
+    expect(fetchHttpHandler.httpHandlerConfigs()).toEqual({});
+  });
+
   it("defaults to response.blob for response.body = null", async () => {
     const mockResponse = {
       body: null,

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -19,9 +19,9 @@ export interface FetchHttpHandlerOptions {
 
 type FetchHttpHandlerConfig = FetchHttpHandlerOptions;
 
-export class FetchHttpHandler implements HttpHandler {
+export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
   private config?: FetchHttpHandlerConfig;
-  private readonly configProvider: Promise<FetchHttpHandlerConfig>;
+  private configProvider: Promise<FetchHttpHandlerConfig>;
 
   constructor(options?: FetchHttpHandlerOptions | Provider<FetchHttpHandlerOptions | undefined>) {
     if (typeof options === "function") {
@@ -129,5 +129,17 @@ export class FetchHttpHandler implements HttpHandler {
       );
     }
     return Promise.race(raceOfPromises);
+  }
+
+  updateHttpClientConfig(key: keyof FetchHttpHandlerConfig, value: FetchHttpHandlerConfig[typeof key]): void {
+    this.config = undefined;
+    this.configProvider = this.configProvider.then((config) => {
+      config[key] = value;
+      return config;
+    });
+  }
+
+  httpHandlerConfigs(): FetchHttpHandlerConfig {
+    return this.config ?? {};
   }
 }

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -50,9 +50,9 @@ interface ResolvedNodeHttpHandlerConfig {
 
 export const DEFAULT_REQUEST_TIMEOUT = 0;
 
-export class NodeHttpHandler implements HttpHandler {
+export class NodeHttpHandler implements HttpHandler<NodeHttpHandlerOptions> {
   private config?: ResolvedNodeHttpHandlerConfig;
-  private readonly configProvider: Promise<ResolvedNodeHttpHandlerConfig>;
+  private configProvider: Promise<ResolvedNodeHttpHandlerConfig>;
 
   // Node http handler is hard-coded to http/1.1: https://github.com/nodejs/node/blob/ff5664b83b89c55e4ab5d5f60068fb457f1f5872/lib/_http_server.js#L286
   public readonly metadata = { handlerProtocol: "http/1.1" };
@@ -191,5 +191,19 @@ export class NodeHttpHandler implements HttpHandler {
 
       writeRequestBodyPromise = writeRequestBody(req, request, this.config.requestTimeout).catch(_reject);
     });
+  }
+
+  updateHttpClientConfig(key: keyof NodeHttpHandlerOptions, value: NodeHttpHandlerOptions[typeof key]): void {
+    this.config = undefined;
+    this.configProvider = this.configProvider.then((config) => {
+      return {
+        ...config,
+        [key]: value,
+      };
+    });
+  }
+
+  httpHandlerConfigs(): NodeHttpHandlerOptions {
+    return this.config ?? {};
   }
 }

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -643,4 +643,55 @@ describe(NodeHttp2Handler.name, () => {
     } as any);
     handler.destroy();
   });
+
+  it("put HttpClientConfig", async () => {
+    const server = createMockHttp2Server();
+    server.on("request", (request, response) => {
+      expect(request.url).toBe("http://foo:bar@localhost/");
+      response.statusCode = 200;
+    });
+    const handler = new NodeHttp2Handler({});
+
+    const requestTimeout = 200;
+
+    handler.updateHttpClientConfig("requestTimeout", requestTimeout);
+
+    await handler.handle({
+      ...getMockReqOptions(),
+      username: "foo",
+      password: "bar",
+      path: "/",
+    } as any);
+    handler.destroy();
+
+    expect(handler.httpHandlerConfigs().requestTimeout).toEqual(requestTimeout);
+  });
+
+  it("update existing HttpClientConfig", async () => {
+    const server = createMockHttp2Server();
+    server.on("request", (request, response) => {
+      expect(request.url).toBe("http://foo:bar@localhost/");
+      response.statusCode = 200;
+    });
+    const handler = new NodeHttp2Handler({ requestTimeout: 200 });
+
+    const requestTimeout = 300;
+
+    handler.updateHttpClientConfig("requestTimeout", requestTimeout);
+
+    await handler.handle({
+      ...getMockReqOptions(),
+      username: "foo",
+      password: "bar",
+      path: "/",
+    } as any);
+    handler.destroy();
+
+    expect(handler.httpHandlerConfigs().requestTimeout).toEqual(requestTimeout);
+  });
+
+  it("httpHandlerConfigs returns empty object if handle is not called", async () => {
+    const nodeHttpHandler = new NodeHttp2Handler();
+    expect(nodeHttpHandler.httpHandlerConfigs()).toEqual({});
+  });
 });

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -41,9 +41,9 @@ export interface NodeHttp2HandlerOptions {
   maxConcurrentStreams?: number;
 }
 
-export class NodeHttp2Handler implements HttpHandler {
+export class NodeHttp2Handler implements HttpHandler<NodeHttp2HandlerOptions> {
   private config?: NodeHttp2HandlerOptions;
-  private readonly configProvider: Promise<NodeHttp2HandlerOptions>;
+  private configProvider: Promise<NodeHttp2HandlerOptions>;
 
   public readonly metadata = { handlerProtocol: "h2" };
 
@@ -200,6 +200,20 @@ export class NodeHttp2Handler implements HttpHandler {
 
       writeRequestBodyPromise = writeRequestBody(req, request, requestTimeout);
     });
+  }
+
+  updateHttpClientConfig(key: keyof NodeHttp2HandlerOptions, value: NodeHttp2HandlerOptions[typeof key]): void {
+    this.config = undefined;
+    this.configProvider = this.configProvider.then((config) => {
+      return {
+        ...config,
+        [key]: value,
+      };
+    });
+  }
+
+  httpHandlerConfigs(): NodeHttp2HandlerOptions {
+    return this.config ?? {};
   }
 
   /**

--- a/packages/protocol-http/src/extensions/httpExtensionConfiguration.ts
+++ b/packages/protocol-http/src/extensions/httpExtensionConfiguration.ts
@@ -1,0 +1,56 @@
+import { HttpHandler } from "../httpHandler";
+
+/**
+ * @internal
+ */
+export interface HttpHandlerExtensionConfiguration<HandlerConfig extends object = Record<string, unknown>> {
+  setHttpHandler(handler: HttpHandler<HandlerConfig>): void;
+  httpHandler(): HttpHandler<HandlerConfig>;
+  updateHttpClientConfig(key: keyof HandlerConfig, value: HandlerConfig[typeof key]): void;
+  httpHandlerConfigs(): HandlerConfig;
+}
+
+/**
+ * @internal
+ */
+export type HttpHandlerExtensionConfigType<HandlerConfig extends object = Record<string, unknown>> = Partial<{
+  httpHandler: HttpHandler<HandlerConfig>;
+}>;
+
+/**
+ * @internal
+ *
+ * Helper function to resolve default extension configuration from runtime config
+ */
+export const getHttpHandlerExtensionConfiguration = <HandlerConfig extends object = Record<string, unknown>>(
+  runtimeConfig: HttpHandlerExtensionConfigType<HandlerConfig>
+) => {
+  let httpHandler = runtimeConfig.httpHandler!;
+  return {
+    setHttpHandler(handler: HttpHandler<HandlerConfig>): void {
+      httpHandler = handler;
+    },
+    httpHandler(): HttpHandler<HandlerConfig> {
+      return httpHandler;
+    },
+    updateHttpClientConfig(key: keyof HandlerConfig, value: HandlerConfig[typeof key]): void {
+      httpHandler.updateHttpClientConfig(key, value);
+    },
+    httpHandlerConfigs(): HandlerConfig {
+      return httpHandler.httpHandlerConfigs();
+    },
+  };
+};
+
+/**
+ * @internal
+ *
+ * Helper function to resolve runtime config from default extension configuration
+ */
+export const resolveHttpHandlerRuntimeConfig = <HandlerConfig extends object = Record<string, unknown>>(
+  httpHandlerExtensionConfiguration: HttpHandlerExtensionConfiguration<HandlerConfig>
+): HttpHandlerExtensionConfigType<HandlerConfig> => {
+  return {
+    httpHandler: httpHandlerExtensionConfiguration.httpHandler(),
+  };
+};

--- a/packages/protocol-http/src/extensions/index.ts
+++ b/packages/protocol-http/src/extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./httpExtensionConfiguration";

--- a/packages/protocol-http/src/httpHandler.ts
+++ b/packages/protocol-http/src/httpHandler.ts
@@ -3,4 +3,19 @@ import { HttpHandlerOptions, RequestHandler } from "@smithy/types";
 import { HttpRequest } from "./httpRequest";
 import { HttpResponse } from "./httpResponse";
 
-export type HttpHandler = RequestHandler<HttpRequest, HttpResponse, HttpHandlerOptions>;
+/**
+ * @internal
+ */
+export type HttpHandler<HttpHandlerConfig> = RequestHandler<HttpRequest, HttpResponse, HttpHandlerOptions> & {
+  /**
+   * @internal
+   * @param key
+   * @param value
+   */
+  updateHttpClientConfig(key: keyof HttpHandlerConfig, value: HttpHandlerConfig[typeof key]): void;
+
+  /**
+   * @internal
+   */
+  httpHandlerConfigs(): HttpHandlerConfig;
+};

--- a/packages/protocol-http/src/index.ts
+++ b/packages/protocol-http/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./extensions";
 export * from "./Field";
 export * from "./Fields";
 export * from "./httpHandler";

--- a/packages/util-stream/src/util-stream.integ.spec.ts
+++ b/packages/util-stream/src/util-stream.integ.spec.ts
@@ -68,6 +68,10 @@ describe("util-stream", () => {
           }),
         };
       }
+      updateHttpClientConfig(key: string, value: any) {}
+      httpHandlerConfigs(): Record<string, any> {
+        return {};
+      }
     })();
 
     it("should allow string as payload blob and allow conversion of output payload blob to string", async () => {

--- a/private/util-test/src/test-http-handler.ts
+++ b/private/util-test/src/test-http-handler.ts
@@ -35,11 +35,13 @@ const MOCK_CREDENTIALS = {
   secretAccessKey: "MOCK_SECRET_ACCESS_KEY_ID",
 };
 
+interface TestHttpHandlerConfig {}
+
 /**
  * Supplied to test clients to assert correct requests.
  * @internal
  */
-export class TestHttpHandler implements HttpHandler {
+export class TestHttpHandler implements HttpHandler<TestHttpHandlerConfig> {
   private static WATCHER = Symbol("TestHttpHandler_WATCHER");
   private originalSend?: Function;
   private originalRequestHandler?: RequestHandler<any, any, any>;
@@ -127,6 +129,12 @@ export class TestHttpHandler implements HttpHandler {
   public async destroy(): Promise<void> {
     (this.client as any).config.requestHandler = this.originalRequestHandler;
     (this.client as any).send = this.originalSend as any;
+  }
+
+  updateHttpClientConfig(key: keyof TestHttpHandlerConfig, value: TestHttpHandlerConfig[typeof key]): void {}
+
+  httpHandlerConfigs(): TestHttpHandlerConfig {
+    return {};
   }
 
   private check(matcher?: Matcher, observed?: any) {


### PR DESCRIPTION
This PR adds http client component to the runtime extensions. 

Using S3 as an example:
```
export class CustomHttpExtension implements RuntimeExtension {
    configure(extensionConfiguration: S3ExtensionConfiguration): void {
       extensionConfiguration.setHttpHandler(...);
       extensionConfiguration.updateHttpClientConfig("requestTimeout", requestTimeout);
    }
}

// extensions can be passed via the client constructor object
S3Client({
  ...
  extensions: [CustomHttpExtension()]
})
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
