### PR TITLE
Add `matchSettings()` to `TypeScriptIntegration` and `TypeScriptCodegenPlugin`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java
@@ -15,6 +15,9 @@
 
 package software.amazon.smithy.typescript.codegen;
 
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+import java.util.logging.Logger;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.build.SmithyBuildPlugin;
 import software.amazon.smithy.codegen.core.directed.CodegenDirector;
@@ -26,6 +29,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
+    private static final Logger LOGGER = Logger.getLogger(TypeScriptCodegenPlugin.class.getName());
 
     @Override
     public String getName() {
@@ -50,6 +54,22 @@ public final class TypeScriptCodegenPlugin implements SmithyBuildPlugin {
         TypeScriptSettings settings = TypeScriptSettings.from(context.getModel(), context.getSettings(),
                 TypeScriptSettings.ArtifactType.CLIENT);
         runner.settings(settings);
+
+        // Only add integrations if the integrations match the settings
+        // This uses {@link TypeScriptIntegration#matchesSettings}, which is a
+        // Smithy internal API. This may be removed at any point.
+        runner.integrationFinder(() ->
+            () -> ServiceLoader.load(TypeScriptIntegration.class, CodegenDirector.class.getClassLoader())
+                .stream()
+                .map(Provider::get)
+                .filter(integration -> {
+                    boolean matchesSettings = integration.matchesSettings(settings);
+                    if (!matchesSettings) {
+                        LOGGER.info(() -> "Skipping TypeScript integration based on settings: " + integration.name());
+                    }
+                    return matchesSettings;
+                })
+                .iterator());
 
         runner.service(settings.getService());
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/TypeScriptIntegration.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.extensions.ExtensionConfigurationInterface;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -40,6 +41,19 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public interface TypeScriptIntegration
         extends SmithyIntegration<TypeScriptSettings, TypeScriptWriter, TypeScriptCodegenContext> {
+
+    /**
+     * Filters the integration based on {@link TypeScriptSettings}.
+     *
+     * This is annotated as a Smithy Internal API, and may be removed at any point.
+     *
+     * @param settings settings to filter against
+     * @return whether the integration matches the settings or not.
+     */
+    @SmithyInternalApi
+    default boolean matchesSettings(TypeScriptSettings settings) {
+        return true;
+    }
 
     /**
      * Gets a list of plugins to apply to the generated client.


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Filter `TypeScriptIntegration`s based on `TypeScriptSettings`.

This allows for integrations to be enabled or disabled based on settings
in `smithy-build.json`.

Note that this is annotated as a Smithy Internal API, and may be removed
at any point.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
