### PR TITLE
fix(shared-ini-file-loader): cache value returned by os.homedir()

### DIFF
--- a/.changeset/unlucky-tigers-raise.md
+++ b/.changeset/unlucky-tigers-raise.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Cache value returned by os.homedir()

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -62,7 +62,7 @@ describe(getHomeDir.name, () => {
   });
 
   describe("makes one homedir call irrespective of getHomeDir calls", () => {
-    it.each([10, 100, 1000, 10000])("calls: %d ", (num: number) => {
+    const testSingleHomeDirCall = (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");
         process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
@@ -75,6 +75,25 @@ describe(getHomeDir.name, () => {
 
         // There is one homedir call even through getHomeDir is called num times.
         expect(homedir).toHaveBeenCalledTimes(1);
+      });
+    };
+
+    describe("when geteuid is available", () => {
+      it.each([10, 100, 1000, 10000])("calls: %d ", testSingleHomeDirCall);
+    });
+
+    describe("when geteuid is not available", () => {
+      const OLD_GETEUID = process.geteuid;
+
+      beforeEach(() => {
+        // @ts-ignore Type 'undefined' is not assignable to type '() => number'.
+        process.geteuid = undefined;
+      });
+
+      it.each([10, 100, 1000, 10000])("calls: %d ", testSingleHomeDirCall);
+
+      afterEach(() => {
+        process.geteuid = OLD_GETEUID;
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -61,7 +61,7 @@ describe(getHomeDir.name, () => {
     expect(getHomeDir()).toEqual(mockHomeDir);
   });
 
-  describe("makes one homedir call per UID irrespective of getHomeDir calls", () => {
+  describe("makes one homedir call irrespective of getHomeDir calls", () => {
     it.each([10, 100, 1000, 10000])("calls: %d ", (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -17,7 +17,6 @@ describe(getHomeDir.name, () => {
 
   beforeEach(() => {
     (homedir as jest.Mock).mockReturnValue(mockHomeDir);
-    jest.spyOn(process, "geteuid").mockReturnValue(mockUid);
     process.env = {
       ...OLD_ENV,
       HOME: mockHOME,
@@ -34,16 +33,22 @@ describe(getHomeDir.name, () => {
 
   it("returns value in process.env.HOME first", () => {
     expect(getHomeDir()).toEqual(mockHOME);
+    expect(homedir).not.toHaveBeenCalled();
   });
 
   it("returns value in process.env.USERPROFILE second", () => {
     process.env = { ...process.env, HOME: undefined };
     expect(getHomeDir()).toEqual(mockUSERPROFILE);
+    expect(homedir).not.toHaveBeenCalled();
   });
 
   describe("returns value in HOMEPATH third", () => {
     beforeEach(() => {
       process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined };
+    });
+
+    afterEach(() => {
+      expect(homedir).not.toHaveBeenCalled();
     });
 
     it("uses value in process.env.HOMEDRIVE if it's set", () => {
@@ -57,8 +62,11 @@ describe(getHomeDir.name, () => {
   });
 
   it("returns value from homedir fourth", () => {
+    const processGeteuidSpy = jest.spyOn(process, "geteuid").mockReturnValue(mockUid);
     process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
     expect(getHomeDir()).toEqual(mockHomeDir);
+    expect(homedir).toHaveBeenCalledTimes(1);
+    expect(processGeteuidSpy).toHaveBeenCalledTimes(1);
   });
 
   describe("makes one homedir call irrespective of getHomeDir calls", () => {
@@ -79,22 +87,27 @@ describe(getHomeDir.name, () => {
     };
 
     describe("when geteuid is available", () => {
-      it.each([10, 100, 1000, 10000])("calls: %d ", testSingleHomeDirCall);
+      it.each([10, 100, 1000, 10000])("calls: %d ", (num: number) => {
+        const processGeteuidSpy = jest.spyOn(process, "geteuid").mockReturnValue(mockUid);
+        expect(processGeteuidSpy).not.toHaveBeenCalled();
+        testSingleHomeDirCall(num);
+        expect(processGeteuidSpy).toHaveBeenCalledTimes(num);
+      });
     });
 
     describe("when geteuid is not available", () => {
       const OLD_GETEUID = process.geteuid;
 
-      beforeEach(() => {
+      beforeAll(() => {
         // @ts-ignore Type 'undefined' is not assignable to type '() => number'.
         process.geteuid = undefined;
       });
 
-      it.each([10, 100, 1000, 10000])("calls: %d ", testSingleHomeDirCall);
-
-      afterEach(() => {
+      afterAll(() => {
         process.geteuid = OLD_GETEUID;
       });
+
+      it.each([10, 100, 1000, 10000])("calls: %d ", testSingleHomeDirCall);
     });
   });
 
@@ -102,12 +115,14 @@ describe(getHomeDir.name, () => {
     it.each([2, 10, 100])("calls: %d ", (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");
+        const processGeteuidSpy = jest.spyOn(process, "geteuid").mockReturnValue(mockUid);
         for (let i = 0; i < num; i++) {
           jest.spyOn(process, "geteuid").mockReturnValueOnce(mockUid + i);
         }
         process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
 
         expect(homedir).not.toHaveBeenCalled();
+        expect(processGeteuidSpy).not.toHaveBeenCalled();
         const homeDirArr = Array(num)
           .fill(num)
           .map(() => getHomeDir());
@@ -115,12 +130,15 @@ describe(getHomeDir.name, () => {
 
         // There is num homedir calls as each call returns different UID
         expect(homedir).toHaveBeenCalledTimes(num);
+        expect(processGeteuidSpy).toHaveBeenCalledTimes(num);
 
         const homeDir = getHomeDir();
         expect(homeDir).toStrictEqual(mockHomeDir);
 
         // No extra calls made to homedir, as mockUid is same as the first call.
         expect(homedir).toHaveBeenCalledTimes(num);
+        // Extra call was made to geteuid to get the same UID as the first call.
+        expect(processGeteuidSpy).toHaveBeenCalledTimes(num + 1);
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -59,4 +59,22 @@ describe(getHomeDir.name, () => {
     process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
     expect(getHomeDir()).toEqual(mockHomeDir);
   });
+
+  describe.only("makes one homedir call per user filepath irrespective of getHomeDir calls", () => {
+    it.each([10 /**100, 1000, 10000*/])("parallel calls: %d ", (num: number) => {
+      jest.isolateModules(() => {
+        const { getHomeDir } = require("./getHomeDir");
+        process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
+
+        expect(homedir).not.toHaveBeenCalled();
+        const homeDirArr = Array(num)
+          .fill(num)
+          .map(() => getHomeDir());
+        expect(homeDirArr).toStrictEqual(Array(num).fill(mockHomeDir));
+
+        // There is one homedir call even through getHomeDir is called in parallel num times.
+        expect(homedir).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -28,7 +28,6 @@ describe(getHomeDir.name, () => {
   afterEach(() => {
     process.env = OLD_ENV;
     jest.clearAllMocks();
-    jest.resetModules();
   });
 
   it("returns value in process.env.HOME first", () => {
@@ -61,7 +60,7 @@ describe(getHomeDir.name, () => {
   });
 
   describe.only("makes one homedir call per user filepath irrespective of getHomeDir calls", () => {
-    it.each([10 /**100, 1000, 10000*/])("parallel calls: %d ", (num: number) => {
+    it.each([10, 100, 1000, 10000])("parallel calls: %d ", (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");
         process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -6,6 +6,7 @@ import { getHomeDir } from "./getHomeDir";
 jest.mock("os");
 
 describe(getHomeDir.name, () => {
+  const mockUid = 1;
   const mockHOME = "mockHOME";
   const mockUSERPROFILE = "mockUSERPROFILE";
   const mockHOMEPATH = "mockHOMEPATH";
@@ -16,6 +17,7 @@ describe(getHomeDir.name, () => {
 
   beforeEach(() => {
     (homedir as jest.Mock).mockReturnValue(mockHomeDir);
+    jest.spyOn(process, "geteuid").mockReturnValue(mockUid);
     process.env = {
       ...OLD_ENV,
       HOME: mockHOME,
@@ -59,8 +61,8 @@ describe(getHomeDir.name, () => {
     expect(getHomeDir()).toEqual(mockHomeDir);
   });
 
-  describe("makes one homedir call per user filepath irrespective of getHomeDir calls", () => {
-    it.each([10, 100, 1000, 10000])("parallel calls: %d ", (num: number) => {
+  describe("makes one homedir call per UID irrespective of getHomeDir calls", () => {
+    it.each([10, 100, 1000, 10000])("calls: %d ", (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");
         process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
@@ -71,8 +73,35 @@ describe(getHomeDir.name, () => {
           .map(() => getHomeDir());
         expect(homeDirArr).toStrictEqual(Array(num).fill(mockHomeDir));
 
-        // There is one homedir call even through getHomeDir is called in parallel num times.
+        // There is one homedir call even through getHomeDir is called num times.
         expect(homedir).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("makes multiple homedir calls with based on UIDs", () => {
+    it.each([2, 10, 100])("calls: %d ", (num: number) => {
+      jest.isolateModules(() => {
+        const { getHomeDir } = require("./getHomeDir");
+        for (let i = 0; i < num; i++) {
+          jest.spyOn(process, "geteuid").mockReturnValueOnce(mockUid + i);
+        }
+        process.env = { ...process.env, HOME: undefined, USERPROFILE: undefined, HOMEPATH: undefined };
+
+        expect(homedir).not.toHaveBeenCalled();
+        const homeDirArr = Array(num)
+          .fill(num)
+          .map(() => getHomeDir());
+        expect(homeDirArr).toStrictEqual(Array(num).fill(mockHomeDir));
+
+        // There is num homedir calls as each call returns different UID
+        expect(homedir).toHaveBeenCalledTimes(num);
+
+        const homeDir = getHomeDir();
+        expect(homeDir).toStrictEqual(mockHomeDir);
+
+        // No extra calls made to homedir, as mockUid is same as the first call.
+        expect(homedir).toHaveBeenCalledTimes(num);
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.spec.ts
@@ -59,7 +59,7 @@ describe(getHomeDir.name, () => {
     expect(getHomeDir()).toEqual(mockHomeDir);
   });
 
-  describe.only("makes one homedir call per user filepath irrespective of getHomeDir calls", () => {
+  describe("makes one homedir call per user filepath irrespective of getHomeDir calls", () => {
     it.each([10, 100, 1000, 10000])("parallel calls: %d ", (num: number) => {
       jest.isolateModules(() => {
         const { getHomeDir } = require("./getHomeDir");

--- a/packages/shared-ini-file-loader/src/getHomeDir.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.ts
@@ -1,5 +1,16 @@
 import { homedir } from "os";
 import { sep } from "path";
+import { geteuid } from "process";
+
+const homeDirCache: Record<string, string> = {};
+
+const getHomeDirCacheKey = (): string => {
+  // geteuid is only available on POSIX platforms (i.e. not Windows or Android).
+  if (geteuid) {
+    return `${geteuid()}`;
+  }
+  return "DEFAULT";
+};
 
 /**
  * Get the HOME directory for the current runtime.
@@ -13,5 +24,8 @@ export const getHomeDir = (): string => {
   if (USERPROFILE) return USERPROFILE;
   if (HOMEPATH) return `${HOMEDRIVE}${HOMEPATH}`;
 
-  return homedir();
+  const homeDirCacheKey = getHomeDirCacheKey();
+  if (!homeDirCache[homeDirCacheKey]) homeDirCache[homeDirCacheKey] = homedir();
+
+  return homeDirCache[homeDirCacheKey];
 };


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/4345

*Description of changes:*
Caches value returned by `os.homedir()` to attempt fixing EMFILE errors with `uv_os_homedir`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
