### PR TITLE
fix(packages): move @smithy/node-config-provider to deps

### DIFF
--- a/.changeset/forty-shrimps-act.md
+++ b/.changeset/forty-shrimps-act.md
@@ -3,4 +3,4 @@
 "@smithy/config-resolver": patch
 ---
 
-Move packages with type imports to deps
+Move @smithy/node-config-provider to deps

--- a/.changeset/forty-shrimps-act.md
+++ b/.changeset/forty-shrimps-act.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-retry": patch
+"@smithy/config-resolver": patch
+---
+
+Move packages with type imports to deps

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -23,13 +23,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/node-config-provider": "workspace:^",
     "@smithy/types": "workspace:^",
     "@smithy/util-config-provider": "workspace:^",
     "@smithy/util-middleware": "workspace:^",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/node-config-provider": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -24,6 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/node-config-provider": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/service-error-classification": "workspace:^",
     "@smithy/types": "workspace:^",
@@ -33,7 +34,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@smithy/node-config-provider": "workspace:^",
     "@smithy/util-test": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3109

*Description of changes:*
Move packages with type imports to deps.

It's already done in:
* https://github.com/awslabs/smithy-typescript/blob/b0392a75e6328aef7802239d81a233455623bf43/packages/util-defaults-mode-node/package.json#L27
* https://github.com/awslabs/smithy-typescript/blob/b0392a75e6328aef7802239d81a233455623bf43/packages/credential-provider-imds/package.json#L29

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
