### PR TITLE
feat(experimentalIdentityAndAuth): add codegen for `HttpAuthExtensionConfiguration`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
@@ -20,6 +20,22 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public final record ConfigField(
     String name,
+    Type type,
     Consumer<TypeScriptWriter> source,
     Consumer<TypeScriptWriter> docs
-) {}
+) {
+    /**
+     * Defines the type of the config field.
+     */
+    @SmithyUnstableApi
+    public enum Type {
+        /**
+         * Specifies the property is important, e.g. {@code apiKey} for {@code @httpApiKeyAuth}
+         */
+        MAIN,
+        /**
+         * Specifies the property is auxiliary, e.g. {@code region} for {@code @aws.auth#sigv4}
+         */
+        AUXILIARY
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.typescript.codegen;
 
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -32,7 +31,6 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
-import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeProviderGenerator;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.MapUtils;
@@ -212,9 +210,7 @@ final class RuntimeConfigGenerator {
         if (target.equals(LanguageTarget.SHARED)) {
             configs.put("httpAuthSchemeProvider", w -> {
                 String providerName = "default" + service.toShapeId().getName() + "HttpAuthSchemeProvider";
-                w.addRelativeImport(providerName, null, Paths.get(".", CodegenUtils.SOURCE_FOLDER,
-                    HttpAuthSchemeProviderGenerator.HTTP_AUTH_FOLDER,
-                    HttpAuthSchemeProviderGenerator.HTTP_AUTH_SCHEME_RESOLVER_MODULE));
+                w.addImport(providerName, null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
                 w.write(providerName);
             });
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -32,7 +32,7 @@ import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
-import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeProviderGenerator;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
 import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -313,10 +313,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                 writer.write("httpAuthSchemes?: HttpAuthScheme[];\n");
 
                 String httpAuthSchemeProviderName = service.toShapeId().getName() + "HttpAuthSchemeProvider";
-                writer.addRelativeImport(httpAuthSchemeProviderName, null, Paths.get(".",
-                    CodegenUtils.SOURCE_FOLDER,
-                    HttpAuthSchemeProviderGenerator.HTTP_AUTH_FOLDER,
-                    HttpAuthSchemeProviderGenerator.HTTP_AUTH_SCHEME_RESOLVER_MODULE));
+                writer.addImport(httpAuthSchemeProviderName, null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
                 writer.writeDocs("""
                     experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which \
                     resolves which HttpAuthScheme to use.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
@@ -5,12 +5,18 @@
 
 package software.amazon.smithy.typescript.codegen.auth;
 
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import software.amazon.smithy.codegen.core.SymbolDependency;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex.AuthSchemeMode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.Dependency;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -20,6 +26,54 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AuthUtils {
+    public static final String HTTP_AUTH_FOLDER = "auth";
+
+    public static final String HTTP_AUTH_SCHEME_PROVIDER_MODULE = "httpAuthSchemeProvider";
+
+    public static final String HTTP_AUTH_SCHEME_PROVIDER_FILE =
+        HTTP_AUTH_SCHEME_PROVIDER_MODULE + ".ts";
+
+    public static final String HTTP_AUTH_SCHEME_PROVIDER_PATH =
+        Paths.get(".", CodegenUtils.SOURCE_FOLDER, HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_PROVIDER_FILE).toString();
+
+    public static final Dependency AUTH_HTTP_PROVIDER_DEPENDENCY = new Dependency() {
+        @Override
+        public String getPackageName() {
+            return Paths.get(
+                ".", CodegenUtils.SOURCE_FOLDER,
+                HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_PROVIDER_MODULE
+            ).toString();
+        }
+
+        @Override
+        public List<SymbolDependency> getDependencies() {
+            return Collections.emptyList();
+        }
+    };
+
+    public static final String HTTP_AUTH_SCHEME_EXTENSION_MODULE = "httpAuthExtensionConfiguration";
+
+    public static final String HTTP_AUTH_SCHEME_EXTENSION_FILE =
+        HTTP_AUTH_SCHEME_EXTENSION_MODULE + ".ts";
+
+    public static final String HTTP_AUTH_SCHEME_EXTENSION_PATH =
+        Paths.get(".", CodegenUtils.SOURCE_FOLDER, HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_EXTENSION_FILE).toString();
+
+    public static final Dependency AUTH_HTTP_EXTENSION_DEPENDENCY = new Dependency() {
+        @Override
+        public String getPackageName() {
+            return Paths.get(
+                ".", CodegenUtils.SOURCE_FOLDER,
+                HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_EXTENSION_MODULE
+            ).toString();
+        }
+
+        @Override
+        public List<SymbolDependency> getDependencies() {
+            return Collections.emptyList();
+        }
+    };
+
     private AuthUtils() {}
 
     public static Map<ShapeId, HttpAuthScheme> getAllEffectiveNoAuthAwareAuthSchemes(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -41,20 +41,6 @@ import software.amazon.smithy.utils.StringUtils;
  */
 @SmithyInternalApi
 public class HttpAuthSchemeProviderGenerator implements Runnable {
-    /**
-     * Directory segment for {@code auth/}.
-     */
-    public static final String HTTP_AUTH_FOLDER = "auth";
-    /**
-     * File name segment for {@code httpAuthSchemeProvder}.
-     */
-    public static final String HTTP_AUTH_SCHEME_RESOLVER_MODULE = "httpAuthSchemeProvider";
-
-    private static final String HTTP_AUTH_SCHEME_RESOLVER_FILE =
-        HTTP_AUTH_SCHEME_RESOLVER_MODULE + ".ts";
-    private static final String HTTP_AUTH_SCHEME_RESOLVER_PATH =
-        Paths.get(CodegenUtils.SOURCE_FOLDER, HTTP_AUTH_FOLDER, HTTP_AUTH_SCHEME_RESOLVER_FILE).toString();
-
     private final TypeScriptDelegator delegator;
     private final Model model;
 
@@ -104,7 +90,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     }
     */
     private void generateHttpAuthSchemeParametersInterface() {
-        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             w.openBlock("""
                 /**
                  * @internal
@@ -138,7 +124,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     };
     */
     private void generateDefaultHttpAuthSchemeParametersProviderFunction() {
-        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
                 Paths.get(".", serviceSymbol.getNamespace()));
             w.addImport("HandlerExecutionContext", null, TypeScriptDependency.SMITHY_TYPES);
@@ -190,7 +176,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     };
     */
     private void generateHttpAuthOptionFunction(ShapeId shapeId, HttpAuthScheme authScheme) {
-        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             String normalizedAuthSchemeName = normalizeAuthSchemeName(shapeId);
             w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addImport("HttpAuthOption", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
@@ -242,7 +228,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     }
     */
     private void generateHttpAuthSchemeProviderInterface() {
-        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             w.write("""
             /**
              * @internal
@@ -267,7 +253,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     };
     */
     private void generateHttpAuthSchemeProviderDefaultFunction() {
-        delegator.useFileWriter(HTTP_AUTH_SCHEME_RESOLVER_PATH.toString(), w -> {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             w.openBlock("""
             /**
              * @internal

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -17,7 +17,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
-import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty.Type;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -47,7 +46,7 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
         return Optional.of(HttpAuthScheme.builder()
                 .schemeId(HttpApiKeyAuthTrait.ID)
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
-                .addConfigField(new ConfigField("apiKey", w -> {
+                .addConfigField(new ConfigField("apiKey", ConfigField.Type.MAIN, w -> {
                     w.addImport("ApiKeyIdentity", null,
                         TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                     w.addImport("ApiKeyIdentityProvider", null,
@@ -55,12 +54,12 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                     w.write("ApiKeyIdentity | ApiKeyIdentityProvider");
                 }, w -> w.write("The API key to use when making requests.")))
                 .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "name", Type.SIGNING, t -> w -> {
+                    "name", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
                     HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
                     w.write("$S", httpApiKeyAuthTrait.getName());
                 }))
                 .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "in", Type.SIGNING, t -> w -> {
+                    "in", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
                     w.addImport("HttpApiKeyAuthLocation", null,
                         TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                     HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
@@ -74,7 +73,7 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                     }
                 }))
                 .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "scheme", Type.SIGNING, t -> w -> {
+                    "scheme", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
                     HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
                     httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
                         s -> w.write(s),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 import software.amazon.smithy.model.traits.HttpBearerAuthTrait;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.ConfigField.Type;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -43,7 +44,7 @@ public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegrat
         return Optional.of(HttpAuthScheme.builder()
                 .schemeId(HttpBearerAuthTrait.ID)
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
-                .addConfigField(new ConfigField("token", w -> {
+                .addConfigField(new ConfigField("token", Type.MAIN, w -> {
                     w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                     w.addImport("TokenIdentity", null,
                         TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -15,7 +15,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty;
-import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthOptionProperty.Type;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeParameter;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -47,12 +46,12 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
                 .schemeId(ShapeId.from("aws.auth#sigv4"))
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
                 .putDefaultSigner(LanguageTarget.SHARED, AWS_SIGV4_AUTH_SIGNER)
-                .addConfigField(new ConfigField("region", w -> {
+                .addConfigField(new ConfigField("region", ConfigField.Type.AUXILIARY, w -> {
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("Provider", "__Provider", TypeScriptDependency.SMITHY_TYPES);
                     w.write("string | __Provider<string>");
                 }, w -> w.write("The AWS region to which this client will send requests.")))
-                .addConfigField(new ConfigField("credentials", w -> {
+                .addConfigField(new ConfigField("credentials", ConfigField.Type.MAIN, w -> {
                     w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("AwsCredentialIdentity", null, TypeScriptDependency.SMITHY_TYPES);
                     w.addImport("AwsCredentialIdentityProvider", null, TypeScriptDependency.SMITHY_TYPES);
@@ -67,11 +66,11 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
                     });
                 }))
                 .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "name", Type.SIGNING, t -> w -> {
+                    "name", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
                     w.write("$S", t.toNode().expectObjectNode().getMember("name"));
                 }))
                 .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "region", Type.SIGNING, t -> w -> {
+                    "region", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
                     w.write("authParameters.region");
                 }))
                 .build());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthExtensionConfigurationInterface.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthExtensionConfigurationInterface.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import software.amazon.smithy.typescript.codegen.Dependency;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.extensions.ExtensionConfigurationInterface;
+import software.amazon.smithy.utils.Pair;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds the corresponding interface and functions for {@code HttpAuthExtensionConfiguration}.
+ *
+ * This is experimental for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public class HttpAuthExtensionConfigurationInterface implements ExtensionConfigurationInterface {
+    @Override
+    public Pair<String, Dependency> name() {
+        return Pair.of("HttpAuthExtensionConfiguration", AuthUtils.AUTH_HTTP_EXTENSION_DEPENDENCY);
+    }
+
+    @Override
+    public Pair<String, Dependency> getExtensionConfigurationFn() {
+        return Pair.of("getHttpAuthExtensionConfiguration", AuthUtils.AUTH_HTTP_EXTENSION_DEPENDENCY);
+    }
+
+    @Override
+    public Pair<String, Dependency> resolveRuntimeConfigFn() {
+        return Pair.of("resolveHttpAuthRuntimeConfig", AuthUtils.AUTH_HTTP_EXTENSION_DEPENDENCY);
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.TypeScriptDelegator;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.extensions.ExtensionConfigurationInterface;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Adds {@link HttpAuthExtensionConfigurationInterface} to a client.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegration {
+
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public List<ExtensionConfigurationInterface> getExtensionConfigurationInterfaces() {
+        return List.of(new HttpAuthExtensionConfigurationInterface());
+    }
+
+    @Override
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        if (!codegenContext.settings().generateClient()) {
+            return;
+        }
+        TypeScriptDelegator delegator = codegenContext.writerDelegator();
+        SupportedHttpAuthSchemesIndex authIndex =
+            new SupportedHttpAuthSchemesIndex(codegenContext.integrations());
+        ServiceIndex serviceIndex = ServiceIndex.of(codegenContext.model());
+        String serviceName = CodegenUtils.getServiceName(
+            codegenContext.settings(), codegenContext.model(), codegenContext.symbolProvider());
+        ServiceShape serviceShape = codegenContext.settings().getService(codegenContext.model());
+        Map<ShapeId, HttpAuthScheme> effectiveAuthSchemes =
+            AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(serviceShape, serviceIndex, authIndex);
+
+        generateHttpAuthExtensionConfigurationInterface(
+            delegator, effectiveAuthSchemes, serviceName);
+        generateHttpAuthExtensionRuntimeConfigType(
+            delegator, effectiveAuthSchemes, serviceName);
+        generateGetHttpAuthExtensionConfigurationFunction(
+            delegator, effectiveAuthSchemes, serviceName);
+        generateResolveHttpAuthRuntimeConfigFunction(
+            delegator, effectiveAuthSchemes, serviceName);
+    }
+
+    /*
+    import {
+      ApiKeyIdentity,
+      ApiKeyIdentityProvider,
+      AwsCredentialsIdentity,
+      AwsCredentialIdentityProvider,
+      HttpAuthScheme,
+      TokenIdentity,
+      TokenIdentityProvider
+    } from "@smithy/types";
+
+    import {
+      WeatherHttpAuthSchemeProvider
+    } from "./httpAuthSchemeProvider";
+
+    // ...
+
+    export interface HttpAuthExtensionConfiguration {
+      setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void;
+      httpAuthSchemes(): HttpAuthScheme[];
+
+      setHttpAuthSchemeProvider(httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider): void;
+      httpAuthSchemeProvider(): WeatherHttpAuthSchemeProvider;
+
+      // @aws.auth#sigv4
+      setCredentials(credentials: AwsCredentialsIdentity | AwsCredentialIdentityProvider): void;
+      credentials(): AwsCredentialsIdentity | AwsCredentialIdentityProvider | undefined;
+
+      // @httpApiKeyAuth
+      setApiKey(apiKey: ApiKeyIdentity | ApiKeyIdentityProvider): void;
+      apiKey(): ApiKeyIdentity | ApiKeyIdentityProvider | undefined;
+
+      // @httpBearerAuth
+      setToken(token: TokenIdentity| TokenIdentityProvider): void;
+      token(): TokenIdentity | TokenIdentityProvider | undefined;
+    }
+    */
+    private void generateHttpAuthExtensionConfigurationInterface(
+        TypeScriptDelegator delegator,
+        Map<ShapeId, HttpAuthScheme> effectiveAuthSchemes,
+        String serviceName
+    ) {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export interface HttpAuthExtensionConfiguration {""", "}",
+                () -> {
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.write("setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void;");
+                w.write("httpAuthSchemes(): HttpAuthScheme[];");
+
+                w.addImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
+                w.write("setHttpAuthSchemeProvider(httpAuthSchemeProvider: $LHttpAuthSchemeProvider): void;",
+                    serviceName);
+                w.write("httpAuthSchemeProvider(): $LHttpAuthSchemeProvider;", serviceName);
+
+                for (HttpAuthScheme authScheme : effectiveAuthSchemes.values()) {
+                    if (authScheme == null) {
+                        continue;
+                    }
+                    for (ConfigField configField : authScheme.getConfigFields()) {
+                        if (!configField.type().equals(ConfigField.Type.MAIN)) {
+                            continue;
+                        }
+                        String capitalizedName = StringUtils.capitalize(configField.name());
+                        w.write("set$L($L: $C): void;", capitalizedName, configField.name(), configField.source());
+                        w.write("$L(): $C | undefined;", configField.name(), configField.source());
+                    }
+                }
+            });
+        });
+    }
+
+    /*
+    import {
+      ApiKeyIdentity,
+      ApiKeyIdentityProvider,
+      AwsCredentialsIdentity,
+      AwsCredentialIdentityProvider,
+      HttpAuthScheme,
+      TokenIdentity,
+      TokenIdentityProvider
+    } from "@smithy/types";
+
+    import {
+      WeatherHttpAuthSchemeProvider
+    } from "./httpAuthSchemeProvider";
+
+    // ...
+
+    export type HttpAuthRuntimeConfig = Partial<{
+      httpAuthSchemes: HttpAuthScheme[];
+      httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider;
+      // @aws.auth#sigv4
+      credentials: AwsCredentialsIdentity | AwsCredentialIdentityProvider;
+      // @httpApiKeyAuth
+      apiKey: ApiKeyIdentity | ApiKeyIdentityProvider;
+      // @httpBearerAuth
+      token: TokenIdentity | TokenIdentityProvider;
+    }>;
+    */
+    private void generateHttpAuthExtensionRuntimeConfigType(
+        TypeScriptDelegator delegator,
+        Map<ShapeId, HttpAuthScheme> effectiveAuthSchemes,
+        String serviceName
+    ) {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export type HttpAuthRuntimeConfig = Partial<{""", "}>;",
+                () -> {
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.write("httpAuthSchemes: HttpAuthScheme[];");
+                w.addImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
+                w.write("httpAuthSchemeProvider: $LHttpAuthSchemeProvider;", serviceName);
+                for (HttpAuthScheme authScheme : effectiveAuthSchemes.values()) {
+                    if (authScheme == null) {
+                        continue;
+                    }
+                    for (ConfigField configField : authScheme.getConfigFields()) {
+                        if (!configField.type().equals(ConfigField.Type.MAIN)) {
+                            continue;
+                        }
+                        w.write("$L: $C;", configField.name(), configField.source());
+                    }
+                }
+            });
+        });
+    }
+
+    /*
+    import {
+      ApiKeyIdentity,
+      ApiKeyIdentityProvider,
+      AwsCredentialsIdentity,
+      AwsCredentialIdentityProvider,
+      HttpAuthScheme,
+      TokenIdentity,
+      TokenIdentityProvider
+    } from "@smithy/types";
+
+    import {
+      WeatherHttpAuthSchemeProvider
+    } from "./httpAuthSchemeProvider";
+
+    // ...
+
+    export const getHttpAuthExtensionConfiguration =
+      (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
+      let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+      let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
+      let _credentials = runtimeConfig.credentials;
+      let _apiKey = runtimeConfig.apiKey;
+      let _token = runtimeConfig.token;
+      return {
+        setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
+          _httpAuthSchemes.push(httpAuthScheme);
+        },
+        httpAuthSchemes(): HttpAuthScheme[] {
+          return _httpAuthSchemes;
+        },
+        setHttpAuthSchemeProvider(httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider): void {
+          _httpAuthSchemeProvider = httpAuthSchemeProvider;
+        },
+        httpAuthSchemeProvider(): WeatherHttpAuthSchemeProvider {
+          return _httpAuthSchemeProvider;
+        },
+        // Dependent on auth traits
+        setCredentials(credentials: AwsCredentialsIdentity | AwsCredentialIdentityProvider): void {
+          _credentials = credentials;
+        },
+        credentials(): AwsCredentialsIdentity | AwsCredentialIdentityProvider | undefined {
+          return _credentials;
+        },
+        setApiKey(apiKey: ApiKeyIdentity | ApiKeyIdentityProvider): void {
+          _apiKey = apiKey;
+        },
+        apiKey(): ApiKeyIdentity | ApiKeyIdentityProvider | undefined {
+          return _apiKey;
+        },
+        setToken(token: TokenIdentity | TokenIdentityProvider): void {
+          _token = token;
+        },
+        token(): TokenIdentity | TokenIdentityProvider | undefined {
+          return _token;
+        },
+      };
+    };
+    */
+    private void generateGetHttpAuthExtensionConfigurationFunction(
+        TypeScriptDelegator delegator,
+        Map<ShapeId, HttpAuthScheme> effectiveAuthSchemes,
+        String serviceName
+    ) {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): \
+                HttpAuthExtensionConfiguration => {""", "};",
+                () -> {
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.write("let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;");
+                w.addImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
+                w.write("let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;");
+                for (HttpAuthScheme authScheme : effectiveAuthSchemes.values()) {
+                    if (authScheme == null) {
+                        continue;
+                    }
+                    for (ConfigField configField : authScheme.getConfigFields()) {
+                        if (!configField.type().equals(ConfigField.Type.MAIN)) {
+                            continue;
+                        }
+                        w.write("let _$L = runtimeConfig.$L;", configField.name(), configField.name());
+                    }
+                }
+
+                w.openBlock("return {", "}",
+                () -> {
+                    w.write("""
+                        setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
+                          _httpAuthSchemes.push(httpAuthScheme);
+                        },
+                        httpAuthSchemes(): HttpAuthScheme[] {
+                          return _httpAuthSchemes;
+                        },""");
+                    w.write("""
+                        setHttpAuthSchemeProvider(httpAuthSchemeProvider: $LHttpAuthSchemeProvider): void {
+                          _httpAuthSchemeProvider = httpAuthSchemeProvider;
+                        },
+                        httpAuthSchemeProvider(): $LHttpAuthSchemeProvider {
+                          return _httpAuthSchemeProvider;
+                        },""", serviceName, serviceName);
+                    for (HttpAuthScheme authScheme : effectiveAuthSchemes.values()) {
+                        if (authScheme == null) {
+                            continue;
+                        }
+                        for (ConfigField configField : authScheme.getConfigFields()) {
+                            if (!configField.type().equals(ConfigField.Type.MAIN)) {
+                                continue;
+                            }
+                            String capitalizedName = StringUtils.capitalize(configField.name());
+                            w.write("""
+                                set$L($L: $C): void {
+                                  _$L = $L;
+                                },
+                                $L(): $C | undefined {
+                                  return _$L;
+                                },""",
+                                capitalizedName, configField.name(), configField.source(),
+                                configField.name(), configField.name(),
+                                configField.name(), configField.source(),
+                                configField.name());
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    /*
+    export const resolveHttpAuthRuntimeConfig =
+      (config: HttpAuthExtensionConfiguration): HttpAuthRuntimeConfig => {
+      return {
+        httpAuthSchemes: config.httpAuthSchemes(),
+        httpAuthSchemeProvider: config.httpAuthSchemeProvider(),
+        // Dependent on auth traits
+        credentials: config.credentials(),
+        apiKey: config.apiKey(),
+        token: config.token(),
+      };
+    };
+    */
+    private void generateResolveHttpAuthRuntimeConfigFunction(
+        TypeScriptDelegator delegator,
+        Map<ShapeId, HttpAuthScheme> effectiveAuthSchemes,
+        String serviceName
+    ) {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
+            w.openBlock("""
+                /**
+                 * @internal
+                 */
+                export const resolveHttpAuthRuntimeConfig = (config: HttpAuthExtensionConfiguration): \
+                HttpAuthRuntimeConfig => {""", "};",
+                () -> {
+                w.openBlock("return {", "};", () -> {
+                    w.write("httpAuthSchemes: config.httpAuthSchemes(),");
+                    w.write("httpAuthSchemeProvider: config.httpAuthSchemeProvider(),");
+                    for (HttpAuthScheme authScheme : effectiveAuthSchemes.values()) {
+                        if (authScheme == null) {
+                            continue;
+                        }
+                        for (ConfigField configField : authScheme.getConfigFields()) {
+                            if (!configField.type().equals(ConfigField.Type.MAIN)) {
+                                continue;
+                            }
+                            w.write("$L: config.$L(),", configField.name(), configField.name());
+                        }
+                    }
+                });
+            });
+        });
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -2,6 +2,7 @@ software.amazon.smithy.typescript.codegen.integration.AddClientRuntimeConfig
 software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
+software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthRuntimeExtensionIntegration
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpBearerAuthPlugin


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add code-generation for `HttpAuthExtensionConfiguration`, which allows
configuring:

- `httpAuthSchemes`
- `httpAuthSchemeProvider`
- Any `ConfigField` registered by `HttpAuthScheme`s

Also, add relative import dependencies for:

- `httpAuthSchemeProvider`
- `httpAuthExtensionConfiguration`

Dependent on: https://github.com/awslabs/smithy-typescript/pull/907

*Testing:*

Everything is gated by `experimentalIdentityAndAuth`.

Codegen diff in `smithy-typescript-codegen-test`: https://gist.github.com/syall/34efebcfb7ffa41dcebd0a40fdd30cf7#file-pr-910-diff

#### `auth/httpAuthExtensionConfiguration.ts`

The `HttpAuthExtensionConfiguration` specific for a service looks like this:

```diff
diff --color -Nur smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthExtensionConfiguration.ts smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthExtensionConfiguration.ts
--- smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthExtensionConfiguration.ts	1969-12-31 16:00:00
+++ smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthExtensionConfiguration.ts	2023-09-07 09:13:01
@@ -0,0 +1,96 @@
+// smithy-typescript generated code
+import { WeatherHttpAuthSchemeProvider } from "./httpAuthSchemeProvider";
+import {
+  ApiKeyIdentity,
+  ApiKeyIdentityProvider,
+  HttpAuthScheme,
+  TokenIdentity,
+  TokenIdentityProvider,
+} from "@smithy/experimental-identity-and-auth";
+import {
+  AwsCredentialIdentity,
+  AwsCredentialIdentityProvider,
+} from "@smithy/types";
+
+/**
+ * @internal
+ */
+export interface HttpAuthExtensionConfiguration {
+  setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void;
+  httpAuthSchemes(): HttpAuthScheme[];
+  setHttpAuthSchemeProvider(httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider): void;
+  httpAuthSchemeProvider(): WeatherHttpAuthSchemeProvider;
+  setCredentials(credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider): void;
+  credentials(): AwsCredentialIdentity | AwsCredentialIdentityProvider | undefined;
+  setApiKey(apiKey: ApiKeyIdentity | ApiKeyIdentityProvider): void;
+  apiKey(): ApiKeyIdentity | ApiKeyIdentityProvider | undefined;
+  setToken(token: TokenIdentity | TokenIdentityProvider): void;
+  token(): TokenIdentity | TokenIdentityProvider | undefined;
+}
+
+/**
+ * @internal
+ */
+export type HttpAuthRuntimeConfig = Partial<{
+  httpAuthSchemes: HttpAuthScheme[];
+  httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider;
+  credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  apiKey: ApiKeyIdentity | ApiKeyIdentityProvider;
+  token: TokenIdentity | TokenIdentityProvider;
+}>;
+
+/**
+ * @internal
+ */
+export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): HttpAuthExtensionConfiguration => {
+  let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;
+  let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;
+  let _credentials = runtimeConfig.credentials;
+  let _apiKey = runtimeConfig.apiKey;
+  let _token = runtimeConfig.token;
+  return {
+    setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
+      _httpAuthSchemes.push(httpAuthScheme);
+    },
+    httpAuthSchemes(): HttpAuthScheme[] {
+      return _httpAuthSchemes;
+    },
+    setHttpAuthSchemeProvider(httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider): void {
+      _httpAuthSchemeProvider = httpAuthSchemeProvider;
+    },
+    httpAuthSchemeProvider(): WeatherHttpAuthSchemeProvider {
+      return _httpAuthSchemeProvider;
+    },
+    setCredentials(credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider): void {
+      _credentials = credentials;
+    },
+    credentials(): AwsCredentialIdentity | AwsCredentialIdentityProvider | undefined {
+      return _credentials;
+    },
+    setApiKey(apiKey: ApiKeyIdentity | ApiKeyIdentityProvider): void {
+      _apiKey = apiKey;
+    },
+    apiKey(): ApiKeyIdentity | ApiKeyIdentityProvider | undefined {
+      return _apiKey;
+    },
+    setToken(token: TokenIdentity | TokenIdentityProvider): void {
+      _token = token;
+    },
+    token(): TokenIdentity | TokenIdentityProvider | undefined {
+      return _token;
+    },
+  }
+};
+
+/**
+ * @internal
+ */
+export const resolveHttpAuthRuntimeConfig = (config: HttpAuthExtensionConfiguration): HttpAuthRuntimeConfig => {
+  return {
+    httpAuthSchemes: config.httpAuthSchemes(),
+    httpAuthSchemeProvider: config.httpAuthSchemeProvider(),
+    credentials: config.credentials(),
+    apiKey: config.apiKey(),
+    token: config.token(),
+  };
+};
```

#### `extensionConfiguration.ts`

`HttpAuthExtensionConfiguration` is added to the service extension configuration interface:

```diff
diff --color -Nur smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/extensionConfiguration.ts smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/extensionConfiguration.ts
--- smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/extensionConfiguration.ts	2023-09-07 09:13:01
+++ smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/extensionConfiguration.ts	2023-09-07 09:13:01
@@ -1,7 +1,8 @@
 // smithy-typescript generated code
+import { HttpAuthExtensionConfiguration } from "./auth/httpAuthExtensionConfiguration";
 import { DefaultExtensionConfiguration } from "@smithy/types";
 
 /**
  * @internal
  */
-export interface WeatherExtensionConfiguration extends DefaultExtensionConfiguration {}
+export interface WeatherExtensionConfiguration extends DefaultExtensionConfiguration, HttpAuthExtensionConfiguration {}
```

#### `runtimeExtensions.ts`

`getHttpAuthExtensionConfiguration` and `resolveHttpAuthRuntimeConfig` are added to the `resolveRuntimeExtensions` stack:

```diff
diff --color -Nur smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/runtimeExtensions.ts smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/runtimeExtensions.ts
--- smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/control-experimental-identity-and-auth/typescript-codegen/src/runtimeExtensions.ts	2023-09-07 09:13:01
+++ smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/runtimeExtensions.ts	2023-09-07 09:13:01
@@ -1,5 +1,9 @@
 // smithy-typescript generated code
 import {
+  getHttpAuthExtensionConfiguration,
+  resolveHttpAuthRuntimeConfig,
+} from "./auth/httpAuthExtensionConfiguration";
+import {
   getDefaultExtensionConfiguration,
   resolveDefaultRuntimeConfig,
 } from "@smithy/smithy-client";
@@ -30,6 +34,7 @@
 ) => {
   const extensionConfiguration: WeatherExtensionConfiguration = {
     ...asPartial(getDefaultExtensionConfiguration(runtimeConfig)),
+    ...asPartial(getHttpAuthExtensionConfiguration(runtimeConfig)),
   };
 
   extensions.forEach(extension => extension.configure(extensionConfiguration));
@@ -37,5 +42,6 @@
   return {
     ...runtimeConfig,
     ...resolveDefaultRuntimeConfig(extensionConfiguration),
+    ...resolveHttpAuthRuntimeConfig(extensionConfiguration),
   };
 }
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
