### PR TITLE
Update `ExtensionConfiguration`s to generate for clients only

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -437,13 +437,11 @@ final class DirectedTypeScriptCodegen
                 LOGGER.fine("Generating " + target + " runtime configuration");
                 configGenerator.generate(target);
             }
+            new ExtensionConfigurationGenerator(directive.model(), directive.service(), directive.symbolProvider(),
+                    directive.context().writerDelegator(), directive.context().integrations()).generate();
+            new RuntimeExtensionsGenerator(directive.model(), directive.service(), directive.symbolProvider(),
+                    directive.context().writerDelegator(), directive.context().integrations()).generate();
         }
-
-        new ExtensionConfigurationGenerator(directive.model(), directive.service(), directive.symbolProvider(),
-                directive.context().writerDelegator(), directive.context().integrations()).generate();
-
-        new RuntimeExtensionsGenerator(directive.model(), directive.service(), directive.symbolProvider(),
-                directive.context().writerDelegator(), directive.context().integrations()).generate();
 
         // Generate index for client.
         BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory =


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Currently, extension configuration code is being generated for SSDK even though it only affects clients.

This change changes it so it only generates for clients.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
