### PR TITLE
Explicitly check for process.geteuid from global scope

### DIFF
--- a/.changeset/many-plums-agree.md
+++ b/.changeset/many-plums-agree.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": minor
+---
+
+Fix invalid import on Windows hosts

--- a/.changeset/many-plums-agree.md
+++ b/.changeset/many-plums-agree.md
@@ -1,5 +1,5 @@
 ---
-"@smithy/shared-ini-file-loader": minor
+"@smithy/shared-ini-file-loader": patch
 ---
 
 Explicitly check for process.geteuid from global scope

--- a/.changeset/many-plums-agree.md
+++ b/.changeset/many-plums-agree.md
@@ -2,4 +2,4 @@
 "@smithy/shared-ini-file-loader": minor
 ---
 
-Fix invalid import on Windows hosts
+Explicitly check for process.geteuid from global scope

--- a/packages/shared-ini-file-loader/src/getHomeDir.ts
+++ b/packages/shared-ini-file-loader/src/getHomeDir.ts
@@ -1,13 +1,12 @@
 import { homedir } from "os";
 import { sep } from "path";
-import { geteuid } from "process";
 
 const homeDirCache: Record<string, string> = {};
 
 const getHomeDirCacheKey = (): string => {
   // geteuid is only available on POSIX platforms (i.e. not Windows or Android).
-  if (geteuid) {
-    return `${geteuid()}`;
+  if (process && process.geteuid) {
+    return `${process.geteuid()}`;
   }
   return "DEFAULT";
 };


### PR DESCRIPTION
*Description of changes:*

Windows doesn't have `geteuid` so import statement will fail running in ESM. We can assume that targets that have `geteuid` also have process in global scope.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
