### PR TITLE
Link to util-retry for docs

### DIFF
--- a/.changeset/old-fans-thank.md
+++ b/.changeset/old-fans-thank.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-retry": patch
+---
+
+Link to util-retry documentation

--- a/packages/middleware-retry/README.md
+++ b/packages/middleware-retry/README.md
@@ -2,3 +2,10 @@
 
 [![NPM version](https://img.shields.io/npm/v/@smithy/middleware-retry/latest.svg)](https://www.npmjs.com/package/@smithy/middleware-retry)
 [![NPM downloads](https://img.shields.io/npm/dm/@smithy/middleware-retry.svg)](https://www.npmjs.com/package/@smithy/middleware-retry)
+
+## Usage
+
+See [@smithy/util-retry](https://github.com/awslabs/smithy-typescript/tree/main/packages/util-retry)
+for retry behavior and configuration.
+
+See also: [AWS Documentation: Retry behavior](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).


### PR DESCRIPTION
This PR updates the README of middleware-retry to link to retry documentation on the util-retry package.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
