### PR TITLE
fix: broken ChecksumConfiguration  and ConditionalRecursiveTransformExact interface in TS < 4.4

### DIFF
--- a/.changeset/eleven-kids-decide.md
+++ b/.changeset/eleven-kids-decide.md
@@ -2,4 +2,4 @@
 "@smithy/types": patch
 ---
 
-fix: broken ChecksumConfiguration interface in TS < 4.4
+fix: broken ChecksumConfiguration interface in TS < 4.4 and conditional generic types in TS<4.1

--- a/.changeset/eleven-kids-decide.md
+++ b/.changeset/eleven-kids-decide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix: broken ChecksumConfiguration interface in TS < 4.4

--- a/.changeset/green-goats-stare.md
+++ b/.changeset/green-goats-stare.md
@@ -1,5 +1,0 @@
----
-"@smithy/types": patch
----
-
-fix(types): conditional generic types in TS<4.1

--- a/.changeset/green-goats-stare.md
+++ b/.changeset/green-goats-stare.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+fix(types): conditional generic types in TS<4.1

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,7 +30,7 @@
     "node": ">=14.0.0"
   },
   "typesVersions": {
-    "<4.0": {
+    "<=4.0": {
       "dist-types/*": [
         "dist-types/ts3.4/*"
       ]

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -23,19 +23,19 @@ export interface ChecksumAlgorithm {
 /**
  * @deprecated unused.
  */
-type ChecksumCnnfigurationLegacy = {
-	/**
-     * @deprecated unused.
-     */
-    [other in string | number]: any;
-}
+type ChecksumConfigurationLegacy = {
+  /**
+   * @deprecated unused.
+   */
+  [other in string | number]: any;
+};
 
 /**
  * @internal
  */
-export interface ChecksumConfiguration extends ChecksumCnnfigurationLegacy {
-    addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
-    checksumAlgorithms(): ChecksumAlgorithm[];
+export interface ChecksumConfiguration extends ChecksumConfigurationLegacy {
+  addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
+  checksumAlgorithms(): ChecksumAlgorithm[];
 }
 
 /**

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -21,16 +21,21 @@ export interface ChecksumAlgorithm {
 }
 
 /**
+ * @deprecated unused.
+ */
+type ChecksumCnnfigurationLegacy = {
+	/**
+     * @deprecated unused.
+     */
+    [other in string | number]: any;
+}
+
+/**
  * @internal
  */
-export interface ChecksumConfiguration {
-  addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
-  checksumAlgorithms(): ChecksumAlgorithm[];
-
-  /**
-   * @deprecated unused.
-   */
-  [other: string | number]: any;
+export interface ChecksumConfiguration extends ChecksumCnnfigurationLegacy {
+    addChecksumAlgorithm(algo: ChecksumAlgorithm): void;
+    checksumAlgorithms(): ChecksumAlgorithm[];
 }
 
 /**


### PR DESCRIPTION
This PR fixes the following 2 issues:

* Before TS 4.4, TS does not allow the index signature as union type. Consuming library with this interface will cause error.  This issue was fixed in TS 4.4: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#symbol-and-template-string-pattern-index-signatures. Fixing this issue so it won't break users with TSC < 4.4

```
"TS1337: An index signature parameter type cannot be a union type. Consider using a mapped object type instead. 

[other: string | number]: any;". 
```

* The referred type `ConditionalRecursiveTransformExact<T, FromType, ToType>` uses
conditional generic type that is only supported in TS>=4.1. However the typesVersions
directs consumers' TSC 4.0 to the types with this definition, hence consumers will see
following error:
```
error TS2315: Type 'ConditionalRecursiveTransformExact' is not generic.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
