### PR TITLE
Add Smithy context to `HandlerExecutionContext`

### DIFF
--- a/.changeset/light-goats-compare.md
+++ b/.changeset/light-goats-compare.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+Add Smithy context to `HandlerExecutionContext`

--- a/.changeset/modern-vans-jam.md
+++ b/.changeset/modern-vans-jam.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-middleware": patch
+---
+
+Add `getSmithyContext()` helper function

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -482,6 +482,11 @@ export interface MiddlewareStack<Input extends object, Output extends object> ex
 }
 
 /**
+ * @internal
+ */
+export const SMITHY_CONTEXT_KEY = "__smithy_context";
+
+/**
  * @public
  *
  * Data and helper objects that are not expected to change from one execution of
@@ -525,6 +530,12 @@ export interface HandlerExecutionContext {
     overrideInputFilterSensitiveLog(...args: any[]): string | void;
     overrideOutputFilterSensitiveLog(...args: any[]): string | void;
   }>;
+
+  /**
+   * @internal
+   * Context for Smithy properties
+   */
+  [SMITHY_CONTEXT_KEY]?: Record<string, unknown>;
 
   [key: string]: any;
 }

--- a/packages/util-middleware/src/getSmithyContext.ts
+++ b/packages/util-middleware/src/getSmithyContext.ts
@@ -1,0 +1,7 @@
+import { HandlerExecutionContext, SMITHY_CONTEXT_KEY } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const getSmithyContext = (context: HandlerExecutionContext): Record<string, unknown> =>
+  context[SMITHY_CONTEXT_KEY] || (context[SMITHY_CONTEXT_KEY] = {});

--- a/packages/util-middleware/src/index.ts
+++ b/packages/util-middleware/src/index.ts
@@ -1,4 +1,8 @@
 /**
  * @internal
  */
+export * from "./getSmithyContext";
+/**
+ * @internal
+ */
 export * from "./normalizeProvider";


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

- Add Smithy context to `HandlerExecutionContext`
- Add `getSmithyContext()` helper function

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
