### PR TITLE
Add `HttpAuthScheme` interfaces for auth scheme resolution

### DIFF
--- a/.changeset/gorgeous-rabbits-collect.md
+++ b/.changeset/gorgeous-rabbits-collect.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add additional `HttpAuthScheme` interfaces for auth scheme resolution

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -38,3 +38,12 @@ export interface HttpAuthOption {
   identityProperties?: Record<string, unknown>;
   signingProperties?: Record<string, unknown>;
 }
+
+/**
+ * @internal
+ */
+export interface SelectedHttpAuthScheme {
+  httpAuthOption: HttpAuthOption;
+  identity: Identity;
+  signer: HttpSigner;
+}

--- a/packages/experimental-identity-and-auth/src/HttpAuthSchemeProvider.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthSchemeProvider.ts
@@ -1,0 +1,27 @@
+import { HandlerExecutionContext } from "@smithy/types";
+
+import { HttpAuthOption } from "./HttpAuthScheme";
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeParameters {
+  operation?: string;
+}
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeProvider<TParameters extends HttpAuthSchemeParameters = HttpAuthSchemeParameters> {
+  (authParameters: TParameters): HttpAuthOption[];
+}
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeParametersProvider<
+  C extends object = object,
+  T extends HttpAuthSchemeParameters = HttpAuthSchemeParameters
+> {
+  (config: C, context: HandlerExecutionContext): Promise<T>;
+}

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./HttpAuthScheme";
+export * from "./HttpAuthSchemeProvider";
 export * from "./HttpSigner";
 export * from "./IdentityProviderConfig";
 export * from "./SigV4Signer";


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

- Add additional `HttpAuthScheme` interfaces for auth scheme resolution
- Update `HttpAuthSchemeProviderGenerator` to use new interfaces


*Testing:*

Expected diff in the codegen changes in `smithy-typescript-codegen-test`:

```diff
diff --color -Nur smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts
--- smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-13 13:23:54
+++ smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-13 13:24:10
@@ -3,25 +3,23 @@
 import {
   HttpApiKeyAuthLocation,
   HttpAuthOption,
+  HttpAuthSchemeParameters,
+  HttpAuthSchemeParametersProvider,
+  HttpAuthSchemeProvider,
 } from "@smithy/experimental-identity-and-auth";
-import { HandlerExecutionContext } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
 /**
  * @internal
  */
-export interface WeatherHttpAuthSchemeParameters {
-  operation?: string;
+export interface WeatherHttpAuthSchemeParameters extends HttpAuthSchemeParameters {
   region?: string;
 }
 
 /**
  * @internal
  */
-export async function defaultWeatherHttpAuthSchemeParametersProvider(
-    config: WeatherClientResolvedConfig,
-    context: HandlerExecutionContext
-): Promise<WeatherHttpAuthSchemeParameters> {
+export const defaultWeatherHttpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> = async (config, context) => {
   return {
     operation: context.commandName,
     region: await normalizeProvider(config.region)() || (() => {
@@ -72,14 +70,12 @@
 /**
  * @internal
  */
-export interface WeatherHttpAuthSchemeProvider {
-  (authParameters: WeatherHttpAuthSchemeParameters): HttpAuthOption[];
-}
+export interface WeatherHttpAuthSchemeProvider extends HttpAuthSchemeProvider<WeatherHttpAuthSchemeParameters> {}
 
 /**
  * @internal
  */
-export function defaultWeatherHttpAuthSchemeProvider(authParameters: WeatherHttpAuthSchemeParameters): HttpAuthOption[] {
+export const defaultWeatherHttpAuthSchemeProvider: WeatherHttpAuthSchemeProvider = (authParameters) => {
   const options: HttpAuthOption[] = [];
   switch (authParameters.operation) {
     case "OnlyHttpApiKeyAuth": {

```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
