### PR TITLE
Add `httpAuthSchemeMiddleware` to select an auth scheme

### DIFF
--- a/.changeset/giant-games-speak.md
+++ b/.changeset/giant-games-speak.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Allow `DefaultIdentityProviderConfig` to accept `undefined` in the constructor

--- a/.changeset/moody-actors-bake.md
+++ b/.changeset/moody-actors-bake.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `httpAuthSchemeMiddleware` to select an auth scheme

--- a/.changeset/slow-pillows-matter.md
+++ b/.changeset/slow-pillows-matter.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `memoizeIdentityProvider()`

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/middleware-endpoint": "workspace:^",
     "@smithy/middleware-retry": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/signature-v4": "workspace:^",

--- a/packages/experimental-identity-and-auth/src/IdentityProviderConfig.ts
+++ b/packages/experimental-identity-and-auth/src/IdentityProviderConfig.ts
@@ -16,7 +16,7 @@ export interface IdentityProviderConfig {
 }
 
 /**
- * Default implementation of IddentityProviderConfig
+ * Default implementation of IdentityProviderConfig
  * @internal
  */
 export class DefaultIdentityProviderConfig implements IdentityProviderConfig {
@@ -27,9 +27,11 @@ export class DefaultIdentityProviderConfig implements IdentityProviderConfig {
    *
    * @param config scheme IDs and identity providers to configure
    */
-  constructor(config: Record<HttpAuthSchemeId, IdentityProvider<Identity>>) {
+  constructor(config: Record<HttpAuthSchemeId, IdentityProvider<Identity> | undefined>) {
     for (const [key, value] of Object.entries(config)) {
-      this.authSchemes.set(key, value);
+      if (value !== undefined) {
+        this.authSchemes.set(key, value);
+      }
     }
   }
 

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -7,6 +7,7 @@ export * from "./apiKeyIdentity";
 export * from "./createEndpointRuleSetHttpAuthSchemeProvider";
 export * from "./httpApiKeyAuth";
 export * from "./httpBearerAuth";
+export * from "./memoizeIdentityProvider";
 export * from "./middleware-http-signing";
 export * from "./noAuth";
 export * from "./tokenIdentity";

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -8,6 +8,7 @@ export * from "./createEndpointRuleSetHttpAuthSchemeProvider";
 export * from "./httpApiKeyAuth";
 export * from "./httpBearerAuth";
 export * from "./memoizeIdentityProvider";
+export * from "./middleware-http-auth-scheme";
 export * from "./middleware-http-signing";
 export * from "./noAuth";
 export * from "./tokenIdentity";

--- a/packages/experimental-identity-and-auth/src/memoizeIdentityProvider.ts
+++ b/packages/experimental-identity-and-auth/src/memoizeIdentityProvider.ts
@@ -1,0 +1,87 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+/**
+ * @internal
+ * This may need to be configurable in the future, but for now it is defaulted to 5min.
+ */
+export const EXPIRATION_MS = 300_000;
+
+/**
+ * @internal
+ */
+export const isIdentityExpired = (identity: Identity) =>
+  doesIdentityRequireRefresh(identity) && identity.expiration!.getTime() - Date.now() < EXPIRATION_MS;
+
+/**
+ * @internal
+ */
+export const doesIdentityRequireRefresh = (identity: Identity) => identity.expiration !== undefined;
+
+/**
+ * @internal
+ */
+export interface MemoizedIdentityProvider<IdentityT extends Identity> {
+  (options?: Record<string, any> & { forceRefresh?: boolean }): Promise<IdentityT>;
+}
+
+/**
+ * @internal
+ */
+export const memoizeIdentityProvider = <IdentityT extends Identity>(
+  provider: IdentityT | IdentityProvider<IdentityT> | undefined,
+  isExpired: (resolved: Identity) => boolean,
+  requiresRefresh: (resolved: Identity) => boolean
+): MemoizedIdentityProvider<IdentityT> | undefined => {
+  if (provider === undefined) {
+    return undefined;
+  }
+  const normalizedProvider: IdentityProvider<IdentityT> =
+    typeof provider !== "function" ? async () => Promise.resolve(provider) : provider;
+  let resolved: IdentityT;
+  let pending: Promise<IdentityT> | undefined;
+  let hasResult: boolean;
+  let isConstant = false;
+  // Wrapper over supplied provider with side effect to handle concurrent invocation.
+  const coalesceProvider: MemoizedIdentityProvider<IdentityT> = async (options) => {
+    if (!pending) {
+      pending = normalizedProvider(options);
+    }
+    try {
+      resolved = await pending;
+      hasResult = true;
+      isConstant = false;
+    } finally {
+      pending = undefined;
+    }
+    return resolved;
+  };
+
+  if (isExpired === undefined) {
+    // This is a static memoization; no need to incorporate refreshing unless using forceRefresh;
+    return async (options) => {
+      if (!hasResult || options?.forceRefresh) {
+        resolved = await coalesceProvider(options);
+      }
+      return resolved;
+    };
+  }
+
+  return async (options) => {
+    if (!hasResult || options?.forceRefresh) {
+      resolved = await coalesceProvider(options);
+    }
+    if (isConstant) {
+      return resolved;
+    }
+
+    if (!requiresRefresh(resolved)) {
+      isConstant = true;
+      return resolved;
+    }
+    if (isExpired(resolved)) {
+      await coalesceProvider(options);
+      return resolved;
+    }
+    return resolved;
+  };
+};

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/getHttpAuthSchemePlugin.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/getHttpAuthSchemePlugin.ts
@@ -1,0 +1,30 @@
+import { endpointMiddlewareOptions } from "@smithy/middleware-endpoint";
+import { MetadataBearer, Pluggable, RelativeMiddlewareOptions, SerializeHandlerOptions } from "@smithy/types";
+
+import { httpAuthSchemeMiddleware, PreviouslyResolved } from "./httpAuthSchemeMiddleware";
+
+/**
+ * @internal
+ */
+export const httpAuthSchemeMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
+  step: "serialize",
+  tags: ["HTTP_AUTH_SCHEME"],
+  name: "httpAuthSchemeMiddleware",
+  override: true,
+  relation: "before",
+  toMiddleware: endpointMiddlewareOptions.name!,
+};
+
+/**
+ * @internal
+ */
+export const getHttpAuthSchemePlugin = <
+  Input extends Record<string, unknown> = Record<string, unknown>,
+  Output extends MetadataBearer = MetadataBearer
+>(
+  config: PreviouslyResolved
+): Pluggable<Input, Output> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(httpAuthSchemeMiddleware(config), httpAuthSchemeMiddlewareOptions);
+  },
+});

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -1,0 +1,95 @@
+import {
+  HandlerExecutionContext,
+  MetadataBearer,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
+  SMITHY_CONTEXT_KEY,
+} from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+
+import { HttpAuthScheme, HttpAuthSchemeId, SelectedHttpAuthScheme } from "../HttpAuthScheme";
+import { HttpAuthSchemeParametersProvider, HttpAuthSchemeProvider } from "../HttpAuthSchemeProvider";
+import { IdentityProviderConfig } from "../IdentityProviderConfig";
+
+/**
+ * @internal
+ */
+export interface PreviouslyResolved {
+  httpAuthSchemes: HttpAuthScheme[];
+  httpAuthSchemeProvider: HttpAuthSchemeProvider;
+  httpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider;
+  identityProviderConfig: IdentityProviderConfig;
+}
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeMiddlewareSmithyContext extends Record<string, unknown> {
+  selectedHttpAuthScheme?: SelectedHttpAuthScheme;
+}
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeMiddlewareHandlerExecutionContext extends HandlerExecutionContext {
+  [SMITHY_CONTEXT_KEY]?: HttpAuthSchemeMiddlewareSmithyContext;
+}
+
+/**
+ * @internal
+ * Later HttpAuthSchemes with the same HttpAuthSchemeId will overwrite previous ones.
+ */
+function convertHttpAuthSchemesToMap(httpAuthSchemes: HttpAuthScheme[]): Map<HttpAuthSchemeId, HttpAuthScheme> {
+  const map = new Map();
+  for (const scheme of httpAuthSchemes) {
+    map.set(scheme.schemeId, scheme);
+  }
+  return map;
+}
+
+/**
+ * @internal
+ */
+export const httpAuthSchemeMiddleware = <
+  Input extends Record<string, unknown> = Record<string, unknown>,
+  Output extends MetadataBearer = MetadataBearer
+>(
+  config: PreviouslyResolved
+): SerializeMiddleware<Input, Output> => (
+  next: SerializeHandler<Input, Output>,
+  context: HttpAuthSchemeMiddlewareHandlerExecutionContext
+): SerializeHandler<Input, Output> => async (
+  args: SerializeHandlerArguments<Input>
+): Promise<SerializeHandlerOutput<Output>> => {
+  const options = config.httpAuthSchemeProvider(
+    await config.httpAuthSchemeParametersProvider(config, context, args.input)
+  );
+  const authSchemes = convertHttpAuthSchemesToMap(config.httpAuthSchemes);
+  const smithyContext: HttpAuthSchemeMiddlewareSmithyContext = getSmithyContext(context);
+  const failureReasons = [];
+  for (const option of options) {
+    const scheme = authSchemes.get(option.schemeId);
+    if (!scheme) {
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enable for this service.`);
+      continue;
+    }
+    const identityProvider = scheme.identityProvider(config.identityProviderConfig);
+    if (!identityProvider) {
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` did not have an IdentityProvider configured.`);
+      continue;
+    }
+    const identity = await identityProvider(option.identityProperties || {});
+    smithyContext.selectedHttpAuthScheme = {
+      httpAuthOption: option,
+      identity,
+      signer: scheme.signer,
+    };
+    break;
+  }
+  if (!smithyContext.selectedHttpAuthScheme) {
+    throw new Error(failureReasons.join("\n"));
+  }
+  return next(args);
+};

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/index.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/index.ts
@@ -1,0 +1,2 @@
+export * from "./httpAuthSchemeMiddleware";
+export * from "./getHttpAuthSchemePlugin";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -141,7 +141,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
 
     /*
     export const defaultWeatherHttpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider =
-    async (config, context) => {
+    async (config, context, input) => {
       return {
         operation: context.commandName,
       };
@@ -157,7 +157,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                  */
                 export const default$LHttpAuthSchemeParametersProvider: \
                 $LHttpAuthSchemeParametersProvider = \
-                async (config, context) => {""", "};",
+                async (config, context, input) => {""", "};",
                 serviceName, serviceName,
                 () -> {
                 w.openBlock("return {", "};", () -> {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -81,6 +81,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     @Override
     public void run() {
         generateHttpAuthSchemeParametersInterface();
+        generateHttpAuthSchemeParametersProviderInterface();
         generateDefaultHttpAuthSchemeParametersProviderFunction();
         generateHttpAuthOptionFunctions();
         generateHttpAuthSchemeProviderInterface();
@@ -114,13 +115,32 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     }
 
     /*
-    import { WeatherClientResolvedConfig } from "../WeatherClient";
     import { HttpAuthSchemeParametersProvider } from "@smithy/types";
+    import { WeatherClientResolvedConfig } from "../WeatherClient";
 
     // ...
 
-    export const defaultWeatherHttpAuthSchemeParametersProvider:
-      HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> =
+    export interface WeatherHttpAuthSchemeParametersProvider extends
+      HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> {}
+    */
+    private void generateHttpAuthSchemeParametersProviderInterface() {
+        delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
+            w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
+                Paths.get(".", serviceSymbol.getNamespace()));
+            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addImport("HttpAuthSchemeParametersProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.write("""
+                /**
+                 * @internal
+                 */
+                export interface $LHttpAuthSchemeParametersProvider extends \
+                HttpAuthSchemeParametersProvider<$LResolvedConfig, $LHttpAuthSchemeParameters> {}""",
+                serviceName, serviceSymbol.getName(), serviceName);
+        });
+    }
+
+    /*
+    export const defaultWeatherHttpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider =
     async (config, context) => {
       return {
         operation: context.commandName,
@@ -129,10 +149,6 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     */
     private void generateDefaultHttpAuthSchemeParametersProviderFunction() {
         delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
-            w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
-                Paths.get(".", serviceSymbol.getNamespace()));
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-            w.addImport("HttpAuthSchemeParametersProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
             w.addImport("getSmithyContext", null, TypeScriptDependency.UTIL_MIDDLEWARE);
             w.openBlock("""
@@ -140,9 +156,9 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                  * @internal
                  */
                 export const default$LHttpAuthSchemeParametersProvider: \
-                HttpAuthSchemeParametersProvider<$LResolvedConfig, $LHttpAuthSchemeParameters> = \
+                $LHttpAuthSchemeParametersProvider = \
                 async (config, context) => {""", "};",
-                serviceName, serviceSymbol.getName(), serviceName,
+                serviceName, serviceName,
                 () -> {
                 w.openBlock("return {", "};", () -> {
                     w.write("operation: getSmithyContext(context).operation as string,");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.ConfigField;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add config and middleware for {@code httpAuthSchemeMiddleware}.
+ */
+@SmithyInternalApi
+public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptIntegration {
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(
+            RuntimeClientPlugin.builder()
+                .withConventions(
+                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                    "HttpAuthScheme",
+                    HAS_MIDDLEWARE)
+                .build(),
+            RuntimeClientPlugin.builder()
+                .inputConfig(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("HttpAuthSchemeInputConfig")
+                        .build())
+                .resolvedConfig(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("HttpAuthSchemeResolvedConfig")
+                        .build())
+                .resolveFunction(Symbol.builder()
+                        .namespace(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_MODULE, "/")
+                        .name("resolveHttpAuthSchemeConfig")
+                        .build())
+                .build()
+        );
+    }
+
+    @Override
+    public void addConfigInterfaceFields(
+        TypeScriptSettings settings,
+        Model model,
+        SymbolProvider symbolProvider,
+        TypeScriptWriter writer
+    ) {
+        writer.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        writer.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        writer.writeDocs("""
+            experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides \
+            default identity providers and signers per auth scheme.
+            @internal""");
+        writer.write("httpAuthSchemes?: HttpAuthScheme[];\n");
+
+        String httpAuthSchemeProviderName = CodegenUtils.getServiceName(settings, model, symbolProvider)
+            + "HttpAuthSchemeProvider";
+        writer.addImport(httpAuthSchemeProviderName, null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
+        writer.writeDocs("""
+            experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which \
+            resolves which HttpAuthScheme to use.
+            @internal""");
+        writer.write("httpAuthSchemeProvider?: $L;\n", httpAuthSchemeProviderName);
+    }
+
+    @Override
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        if (!codegenContext.settings().generateClient()) {
+            return;
+        }
+        codegenContext.writerDelegator().useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
+            SupportedHttpAuthSchemesIndex authIndex = new SupportedHttpAuthSchemesIndex(codegenContext.integrations());
+            String service = CodegenUtils.getServiceName(
+                codegenContext.settings(), codegenContext.model(), codegenContext.symbolProvider());
+            ServiceShape serviceShape = codegenContext.settings().getService(codegenContext.model());
+            ServiceIndex serviceIndex = ServiceIndex.of(codegenContext.model());
+            Map<ShapeId, HttpAuthScheme> httpAuthSchemes
+                = AuthUtils.getAllEffectiveNoAuthAwareAuthSchemes(serviceShape, serviceIndex, authIndex);
+            Map<String, ConfigField> configFields =
+                AuthUtils.collectConfigFields(httpAuthSchemes.values());
+
+            generateHttpAuthSchemeInputConfigInterface(w, configFields);
+            generateHttpAuthSchemeResolvedConfigInterface(w, configFields, service);
+            generateResolveHttpAuthSchemeConfigFunction(w, configFields, httpAuthSchemes, authIndex, service);
+        });
+    }
+
+    /*
+    export interface HttpAuthSchemeInputConfig {
+      apiKey?: ApiKeyIdentity | ApiKeyIdentityProvider;
+
+      token?: TokenIdentity | TokenIdentityProvider;
+
+      region?: string | __Provider<string>;
+
+      credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+    }
+    */
+    private void generateHttpAuthSchemeInputConfigInterface(
+        TypeScriptWriter w,
+        Map<String, ConfigField> configFields
+    ) {
+        w.openBlock("""
+            /**
+             * @internal
+             */
+            export interface HttpAuthSchemeInputConfig {""", "}\n", () -> {
+                for (ConfigField configField : configFields.values()) {
+                    w.writeDocs(() -> w.write("$C", configField.docs()));
+                    w.write("$L?: $C;", configField.name(), configField.inputType());
+                }
+            });
+    }
+
+    /*
+    export interface HttpAuthSchemeResolvedConfig {
+      readonly apiKey?: ApiKeyIdentityProvider;
+
+      readonly token?: TokenIdentityProvider;
+
+      readonly region?: __Provider<string>;
+
+      readonly credentials?: AwsCredentialIdentityProvider;
+
+      readonly httpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider;
+
+      readonly identityProviderConfig: IdentityProviderConfig;
+    }
+    */
+    private void generateHttpAuthSchemeResolvedConfigInterface(
+        TypeScriptWriter w,
+        Map<String, ConfigField> configFields,
+        String service
+    ) {
+        w.openBlock("""
+            /**
+             * @internal
+             */
+            export interface HttpAuthSchemeResolvedConfig {""", "}\n", () -> {
+                for (ConfigField configField : configFields.values()) {
+                    w.writeDocs(() -> w.write("$C", configField.docs()));
+                    w.write("readonly $L?: $C;", configField.name(), configField.resolvedType());
+                }
+                w.writeDocs("""
+                    experimentalIdentityAndAuth: provides parameters for HttpAuthSchemeProvider.
+                    @internal""");
+                w.write("readonly httpAuthSchemeParametersProvider: $LHttpAuthSchemeParametersProvider;",
+                    service);
+
+                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("IdentityProviderConfig", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.writeDocs("""
+                    experimentalIdentityAndAuth: abstraction around identity configuration fields
+                    @internal""");
+                w.write("readonly identityProviderConfig: IdentityProviderConfig;");
+            });
+    }
+
+    /*
+    export const resolveHttpAuthSchemeConfig = (config: HttpAuthSchemeInputConfig): HttpAuthSchemeResolvedConfig => {
+      const credentials = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);
+      const region = config.region ? normalizeProvider(config.region) : undefined;
+      const apiKey = memoizeIdentityProvider(config.apiKey, isIdentityExpired, doesIdentityRequireRefresh);
+      const token = memoizeIdentityProvider(config.token, isIdentityExpired, doesIdentityRequireRefresh);
+      return {
+        ...config,
+        credentials,
+        region,
+        apiKey,
+        token,
+        httpAuthSchemeParametersProvider: defaultWeatherHttpAuthSchemeParametersProvider,
+        identityProviderConfig: new DefaultIdentityProviderConfig({
+          "aws.auth#sigv4": credentials,
+          "smithy.api#httpApiKeyAuth": apiKey,
+          "smithy.api#httpBearerAuth": token,
+        }),
+      };
+    };
+    */
+    private void generateResolveHttpAuthSchemeConfigFunction(
+        TypeScriptWriter w,
+        Map<String, ConfigField> configFields,
+        Map<ShapeId, HttpAuthScheme> httpAuthSchemes,
+        SupportedHttpAuthSchemesIndex authIndex,
+        String service
+    ) {
+        w.openBlock("""
+            /**
+             * @internal
+             */
+            export const resolveHttpAuthSchemeConfig = (config: HttpAuthSchemeInputConfig): \
+            HttpAuthSchemeResolvedConfig => {""", "};", () -> {
+                w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
+                w.addImport("normalizeProvider", null, TypeScriptDependency.UTIL_MIDDLEWARE);
+                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("memoizeIdentityProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("isIdentityExpired", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("doesIdentityRequireRefresh", null,
+                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("DefaultIdentityProviderConfig", null,
+                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                for (ConfigField configField : configFields.values()) {
+                    if (configField.type().equals(ConfigField.Type.MAIN)) {
+                        w.write("""
+                            const $L = memoizeIdentityProvider(config.$L, isIdentityExpired, \
+                            doesIdentityRequireRefresh);""",
+                            configField.name(),
+                            configField.name());
+                    }
+                    if (configField.type().equals(ConfigField.Type.AUXILIARY)) {
+                        w.write("const $L = config.$L ? normalizeProvider(config.$L) : undefined;",
+                            configField.name(),
+                            configField.name(),
+                            configField.name());
+                    }
+                }
+                w.openBlock("return {", "};", () -> {
+                    w.write("...config,");
+                    for (ConfigField configField : configFields.values()) {
+                        w.write("$L,", configField.name());
+                    }
+                    w.write("httpAuthSchemeParametersProvider: $T,",
+                        authIndex.getDefaultHttpAuthSchemeParametersProvider()
+                        .orElse(Symbol.builder()
+                            .name("default" + service + "HttpAuthSchemeParametersProvider")
+                            .build()));
+
+                    w.openBlock("identityProviderConfig: new DefaultIdentityProviderConfig({", "}),", () -> {
+                        Map<String, ConfigField> visitedConfigFields = new HashMap<>();
+                        for (HttpAuthScheme scheme : httpAuthSchemes.values()) {
+                            if (scheme == null) {
+                                continue;
+                            }
+                            for (ConfigField configField : scheme.getConfigFields()) {
+                                if (visitedConfigFields.containsKey(configField.name())) {
+                                    ConfigField visitedConfigField = visitedConfigFields.get(configField.name());
+                                    if (!configField.equals(visitedConfigField)) {
+                                        throw new CodegenException("Contradicting `ConfigField` defintions for `"
+                                            + configField.name()
+                                            + "`; existing: "
+                                            + visitedConfigField
+                                            + ", conflict: "
+                                            + configField);
+                                    }
+                                } else {
+                                    visitedConfigFields.put(configField.name(), configField);
+                                    if (configField.type().equals(ConfigField.Type.MAIN)) {
+                                        w.write("$S: $L,", scheme.getSchemeId().toString(), configField.name());
+                                    }
+                                }
+                            }
+                        }
+                    });
+                });
+            });
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -2,6 +2,7 @@ software.amazon.smithy.typescript.codegen.integration.AddClientRuntimeConfig
 software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
+software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpAuthSchemeMiddleware
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpSigningMiddleware
 software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthRuntimeExtensionIntegration
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/experimental-identity-and-auth@workspace:packages/experimental-identity-and-auth"
   dependencies:
+    "@smithy/middleware-endpoint": "workspace:^"
     "@smithy/middleware-retry": "workspace:^"
     "@smithy/protocol-http": "workspace:^"
     "@smithy/signature-v4": "workspace:^"
@@ -2105,7 +2106,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@smithy/middleware-endpoint@workspace:packages/middleware-endpoint":
+"@smithy/middleware-endpoint@workspace:^, @smithy/middleware-endpoint@workspace:packages/middleware-endpoint":
   version: 0.0.0-use.local
   resolution: "@smithy/middleware-endpoint@workspace:packages/middleware-endpoint"
   dependencies:


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Dependent on: https://github.com/awslabs/smithy-typescript/pull/948, https://github.com/awslabs/smithy-typescript/pull/949

This PR has changes to codegen `httpAuthSchemeMiddleware`.

- Add `memoizeIdentityProvider()` for normalizing and memoizing config identity properties
- Allow `DefaultIdentityProviderConfig` to accept `undefined` properties
- Add the `httpAuthSchemeMiddleware` implementation to select an auth scheme
- Codegen service-specific interface for `HttpAuthSchemeParametersProvider`
- Codegen `httpAuthSchemeMiddleware` and refactor `ConfigField` codegen
  - Codegen `httpAuthSchemeMiddleware`, and also generate `resolveHttpAuthSchemeConfig` and input / resolved config interfaces.
  - `resolveHttpAuthSchemeConfig` normalizes `ConfigField` values, and for the "main" `ConfigField`s, the property is mapped in `DefaultIdentityProviderConfig`.
  - `ConfigField` codegen is removed from `ServiceBareBonesClientGenerator` and is moved to `AddHttpAuthSchemeMiddleware::addConfigInterfaceFields()`.

*Testing:*

*Note: all changes are gated by the `experimentalIdentityAndAuth` flag*

The codegen diff is as follows:

```diff
diff --color -Nur /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts
--- /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts	2023-09-20 13:49:32
+++ /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts	2023-09-20 13:50:03
@@ -1,6 +1,11 @@
 // smithy-typescript generated code
-import { WeatherHttpAuthSchemeProvider } from "./auth/httpAuthSchemeProvider";
 import {
+  HttpAuthSchemeInputConfig,
+  HttpAuthSchemeResolvedConfig,
+  WeatherHttpAuthSchemeProvider,
+  resolveHttpAuthSchemeConfig,
+} from "./auth/httpAuthSchemeProvider";
+import {
   CreateCityCommandInput,
   CreateCityCommandOutput,
 } from "./commands/CreateCityCommand";
@@ -104,11 +109,8 @@
   resolveEventStreamSerdeConfig,
 } from "@smithy/eventstream-serde-config-resolver";
 import {
-  ApiKeyIdentity,
-  ApiKeyIdentityProvider,
   HttpAuthScheme,
-  TokenIdentity,
-  TokenIdentityProvider,
+  getHttpAuthSchemePlugin,
   getHttpSigningPlugin,
 } from "@smithy/experimental-identity-and-auth";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
@@ -131,8 +133,6 @@
   SmithyResolvedConfiguration as __SmithyResolvedConfiguration,
 } from "@smithy/smithy-client";
 import {
-  AwsCredentialIdentity,
-  AwsCredentialIdentityProvider,
   BodyLengthCalculator as __BodyLengthCalculator,
   CheckOptionalClientConfig as __CheckOptionalClientConfig,
   Checksum as __Checksum,
@@ -274,18 +274,6 @@
   disableHostPrefix?: boolean;
 
   /**
-   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
-   * @internal
-   */
-  httpAuthSchemes?: HttpAuthScheme[];
-
-  /**
-   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
-   * @internal
-   */
-  httpAuthSchemeProvider?: WeatherHttpAuthSchemeProvider;
-
-  /**
    * Value for how many times a request will be made at most in case of retry.
    */
   maxAttempts?: number | __Provider<number>;
@@ -330,31 +318,23 @@
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
 
   /**
-   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
    * @internal
    */
-  sdkStreamMixin?: __SdkStreamMixinInjector;
+  httpAuthSchemes?: HttpAuthScheme[];
 
   /**
-   * The API key to use when making requests.
+   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
+   * @internal
    */
-  apiKey?: ApiKeyIdentity | ApiKeyIdentityProvider;
+  httpAuthSchemeProvider?: WeatherHttpAuthSchemeProvider;
 
   /**
-   * The credentials used to sign requests.
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
    */
-  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 
-  /**
-   * The AWS region to which this client will send requests.
-   */
-  region?: string | __Provider<string>;
-
-  /**
-   * The token used to authenticate requests.
-   */
-  token?: TokenIdentity | TokenIdentityProvider;
-
 }
 
 /**
@@ -367,6 +347,7 @@
   & CustomEndpointsInputConfig
   & RetryInputConfig
   & EventStreamSerdeInputConfig
+  & HttpAuthSchemeInputConfig
   & ClientInputEndpointParameters
 /**
  * @public
@@ -386,6 +367,7 @@
   & CustomEndpointsResolvedConfig
   & RetryResolvedConfig
   & EventStreamSerdeResolvedConfig
+  & HttpAuthSchemeResolvedConfig
   & ClientResolvedEndpointParameters
 /**
  * @public
@@ -417,11 +399,13 @@
     let _config_4 = resolveCustomEndpointsConfig(_config_3);
     let _config_5 = resolveRetryConfig(_config_4);
     let _config_6 = resolveEventStreamSerdeConfig(_config_5);
-    let _config_7 = resolveRuntimeExtensions(_config_6, configuration?.extensions || []);
-    super(_config_7);
-    this.config = _config_7;
+    let _config_7 = resolveHttpAuthSchemeConfig(_config_6);
+    let _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
+    super(_config_8);
+    this.config = _config_8;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
+    this.middlewareStack.use(getHttpAuthSchemePlugin(this.config));
     this.middlewareStack.use(getHttpSigningPlugin(this.config));
   }
 
diff --color -Nur /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts
--- /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-20 13:49:32
+++ /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-20 13:50:03
@@ -1,13 +1,27 @@
 // smithy-typescript generated code
 import { WeatherClientResolvedConfig } from "../WeatherClient";
 import {
+  ApiKeyIdentity,
+  ApiKeyIdentityProvider,
+  DefaultIdentityProviderConfig,
   HttpApiKeyAuthLocation,
   HttpAuthOption,
   HttpAuthSchemeParameters,
   HttpAuthSchemeParametersProvider,
   HttpAuthSchemeProvider,
+  IdentityProviderConfig,
+  TokenIdentity,
+  TokenIdentityProvider,
+  doesIdentityRequireRefresh,
+  isIdentityExpired,
+  memoizeIdentityProvider,
 } from "@smithy/experimental-identity-and-auth";
 import {
+  AwsCredentialIdentity,
+  AwsCredentialIdentityProvider,
+  Provider as __Provider,
+} from "@smithy/types";
+import {
   getSmithyContext,
   normalizeProvider,
 } from "@smithy/util-middleware";
@@ -22,7 +36,12 @@
 /**
  * @internal
  */
-export const defaultWeatherHttpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> = async (config, context) => {
+export interface WeatherHttpAuthSchemeParametersProvider extends HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> {}
+
+/**
+ * @internal
+ */
+export const defaultWeatherHttpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider = async (config, context, input) => {
   return {
     operation: getSmithyContext(context).operation as string,
     region: await normalizeProvider(config.region)() || (() => {
@@ -128,4 +147,81 @@
     };
   };
   return options;
+};
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeInputConfig {
+  /**
+   * The API key to use when making requests.
+   */
+  apiKey?: ApiKeyIdentity | ApiKeyIdentityProvider;
+  /**
+   * The credentials used to sign requests.
+   */
+  credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  /**
+   * The AWS region to which this client will send requests.
+   */
+  region?: string | __Provider<string>;
+  /**
+   * The token used to authenticate requests.
+   */
+  token?: TokenIdentity | TokenIdentityProvider;
+}
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeResolvedConfig {
+  /**
+   * The API key to use when making requests.
+   */
+  readonly apiKey?: ApiKeyIdentityProvider;
+  /**
+   * The credentials used to sign requests.
+   */
+  readonly credentials?: AwsCredentialIdentityProvider;
+  /**
+   * The AWS region to which this client will send requests.
+   */
+  readonly region?: __Provider<string>;
+  /**
+   * The token used to authenticate requests.
+   */
+  readonly token?: TokenIdentityProvider;
+  /**
+   * experimentalIdentityAndAuth: provides parameters for HttpAuthSchemeProvider.
+   * @internal
+   */
+  readonly httpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider;
+  /**
+   * experimentalIdentityAndAuth: abstraction around identity configuration fields
+   * @internal
+   */
+  readonly identityProviderConfig: IdentityProviderConfig;
+}
+
+/**
+ * @internal
+ */
+export const resolveHttpAuthSchemeConfig = (config: HttpAuthSchemeInputConfig): HttpAuthSchemeResolvedConfig => {
+  const apiKey = memoizeIdentityProvider(config.apiKey, isIdentityExpired, doesIdentityRequireRefresh);
+  const credentials = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);
+  const region = config.region ? normalizeProvider(config.region) : undefined;
+  const token = memoizeIdentityProvider(config.token, isIdentityExpired, doesIdentityRequireRefresh);
+  return {
+    ...config,
+    apiKey,
+    credentials,
+    region,
+    token,
+    httpAuthSchemeParametersProvider: defaultWeatherHttpAuthSchemeParametersProvider,
+    identityProviderConfig: new DefaultIdentityProviderConfig({
+      "aws.auth#sigv4": credentials,
+      "smithy.api#httpApiKeyAuth": apiKey,
+      "smithy.api#httpBearerAuth": token,
+    }),
+  };
 };
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
