### PR TITLE
Add `httpSigningMiddleware` to authorize and sign requests

### DIFF
--- a/.changeset/thin-hornets-ring.md
+++ b/.changeset/thin-hornets-ring.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `httpSigningMiddleware` to sign a request based on a selected auth scheme

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/middleware-retry": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/signature-v4": "workspace:^",
     "@smithy/types": "workspace:^",

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -6,5 +6,6 @@ export * from "./SigV4Signer";
 export * from "./apiKeyIdentity";
 export * from "./httpApiKeyAuth";
 export * from "./httpBearerAuth";
+export * from "./middleware-http-signing";
 export * from "./noAuth";
 export * from "./tokenIdentity";

--- a/packages/experimental-identity-and-auth/src/middleware-http-signing/getHttpSigningMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-signing/getHttpSigningMiddleware.ts
@@ -1,0 +1,27 @@
+import { retryMiddlewareOptions } from "@smithy/middleware-retry";
+import { FinalizeRequestHandlerOptions, Pluggable, RelativeMiddlewareOptions } from "@smithy/types";
+
+import { httpSigningMiddleware } from "./httpSigningMiddleware";
+
+/**
+ * @internal
+ */
+export const httpSigningMiddlewareOptions: FinalizeRequestHandlerOptions & RelativeMiddlewareOptions = {
+  step: "finalizeRequest",
+  tags: ["HTTP_SIGNING"],
+  name: "httpSigningMiddleware",
+  override: true,
+  relation: "after",
+  toMiddleware: retryMiddlewareOptions.name!,
+};
+
+/**
+ * @internal
+ */
+export const getHttpSigningPlugin = <Input extends object, Output extends object>(
+  config: object
+): Pluggable<Input, Output> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(httpSigningMiddleware(config), httpSigningMiddlewareOptions);
+  },
+});

--- a/packages/experimental-identity-and-auth/src/middleware-http-signing/httpSigningMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-signing/httpSigningMiddleware.ts
@@ -1,0 +1,57 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import {
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  FinalizeRequestMiddleware,
+  HandlerExecutionContext,
+  SMITHY_CONTEXT_KEY,
+} from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+
+import { SelectedHttpAuthScheme } from "../HttpAuthScheme";
+
+/**
+ * @internal
+ */
+interface HttpSigningMiddlewareSmithyContext extends Record<string, unknown> {
+  selectedHttpAuthScheme?: SelectedHttpAuthScheme;
+}
+
+/**
+ * @internal
+ */
+interface HttpSigningMiddlewareHandlerExecutionContext extends HandlerExecutionContext {
+  [SMITHY_CONTEXT_KEY]?: HttpSigningMiddlewareSmithyContext;
+}
+
+/**
+ * @internal
+ */
+export const httpSigningMiddleware = <Input extends object, Output extends object>(
+  config: object
+): FinalizeRequestMiddleware<Input, Output> => (
+  next: FinalizeHandler<Input, Output>,
+  context: HttpSigningMiddlewareHandlerExecutionContext
+): FinalizeHandler<Input, Output> => async (
+  args: FinalizeHandlerArguments<Input>
+): Promise<FinalizeHandlerOutput<Output>> => {
+  if (!HttpRequest.isInstance(args.request)) {
+    return next(args);
+  }
+
+  const smithyContext: HttpSigningMiddlewareSmithyContext = getSmithyContext(context);
+  const scheme = smithyContext.selectedHttpAuthScheme;
+  if (!scheme) {
+    throw new Error(`No HttpAuthScheme was selected: unable to sign request`);
+  }
+  const {
+    httpAuthOption: { signingProperties },
+    identity,
+    signer,
+  } = scheme;
+  return next({
+    ...args,
+    request: signer.sign(args.request, identity, signingProperties || {}),
+  });
+};

--- a/packages/experimental-identity-and-auth/src/middleware-http-signing/index.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-signing/index.ts
@@ -1,0 +1,2 @@
+export * from "./httpSigningMiddleware";
+export * from "./getHttpSigningMiddleware";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.integration;
+
+import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
+
+import java.util.List;
+import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Add middleware for {@code httpSigningMiddleware}.
+ *
+ * This is the experimental behavior for `experimentalIdentityAndAuth`.
+ */
+@SmithyInternalApi
+public class AddHttpSigningMiddleware implements TypeScriptIntegration {
+    /**
+     * Integration should only be used if `experimentalIdentityAndAuth` flag is true.
+     */
+    @Override
+    public boolean matchesSettings(TypeScriptSettings settings) {
+        return settings.getExperimentalIdentityAndAuth();
+    }
+
+    @Override
+    public List<RuntimeClientPlugin> getClientPlugins() {
+        return List.of(RuntimeClientPlugin.builder()
+            .withConventions(
+                TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                "HttpSigning",
+                HAS_MIDDLEWARE)
+            .build());
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -2,6 +2,7 @@ software.amazon.smithy.typescript.codegen.integration.AddClientRuntimeConfig
 software.amazon.smithy.typescript.codegen.integration.AddEventStreamDependency
 software.amazon.smithy.typescript.codegen.integration.AddChecksumRequiredDependency
 software.amazon.smithy.typescript.codegen.integration.AddDefaultsModeDependency
+software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpSigningMiddleware
 software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthRuntimeExtensionIntegration
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddNoAuthPlugin
 software.amazon.smithy.typescript.codegen.auth.http.integration.AddHttpApiKeyAuthPlugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@smithy/experimental-identity-and-auth@workspace:packages/experimental-identity-and-auth"
   dependencies:
+    "@smithy/middleware-retry": "workspace:^"
     "@smithy/protocol-http": "workspace:^"
     "@smithy/signature-v4": "workspace:^"
     "@smithy/types": "workspace:^"
@@ -2123,7 +2124,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@smithy/middleware-retry@workspace:packages/middleware-retry":
+"@smithy/middleware-retry@workspace:^, @smithy/middleware-retry@workspace:packages/middleware-retry":
   version: 0.0.0-use.local
   resolution: "@smithy/middleware-retry@workspace:packages/middleware-retry"
   dependencies:


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `httpSigningMiddleware` to authorize and sign requests.

Dependent on: https://github.com/awslabs/smithy-typescript/pull/927, https://github.com/awslabs/smithy-typescript/pull/928

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
