### PR TITLE
ignore __type field in unions

### DIFF
--- a/.changeset/nasty-snails-provide.md
+++ b/.changeset/nasty-snails-provide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/smithy-client": patch
+---
+
+ignore \_\_type field in unions

--- a/packages/smithy-client/src/parse-utils.spec.ts
+++ b/packages/smithy-client/src/parse-utils.spec.ts
@@ -394,6 +394,33 @@ describe("expectUnion", () => {
       expect(expectUnion(value)).toEqual(value);
     });
   });
+
+  describe("ignores type", () => {
+    it("ignores the extra field with name __type", () => {
+      expect(() =>
+        expectUnion({
+          __type: "A",
+          A: "A",
+        })
+      ).not.toThrow();
+    });
+
+    it("does not skip other validation when ignoring the extra field with name __type", () => {
+      expect(() =>
+        expectUnion({
+          __type: "A",
+          A: "A",
+          B: "B", // too many keys
+        })
+      ).toThrow();
+
+      expect(() =>
+        expectUnion({
+          __type: "A", // not enough keys
+        })
+      ).toThrow();
+    });
+  });
 });
 
 describe("strictParseDouble", () => {

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -305,8 +305,9 @@ export const expectUnion = (value: unknown): Record<string, any> | undefined => 
   }
   const asObject = expectObject(value)!;
 
+  const ignoredKey = "__type";
   const setKeys = Object.entries(asObject)
-    .filter(([, v]) => v != null)
+    .filter(([k, v]) => v != null && k !== ignoredKey)
     .map(([k]) => k);
 
   if (setKeys.length === 0) {


### PR DESCRIPTION
Ignore `__type` key in unions for JSON protocols. 

- [ ] TODO: only for JSON protocols