### PR TITLE
Add service and operation names to `HandlerExecutionContext`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -127,6 +127,7 @@ final class CommandGenerator implements Runnable {
         writer.addImport("Handler", "Handler", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("HandlerExecutionContext", "HandlerExecutionContext", TypeScriptDependency.SMITHY_TYPES);
         writer.addImport("MiddlewareStack", "MiddlewareStack", TypeScriptDependency.SMITHY_TYPES);
+        writer.addImport("SMITHY_CONTEXT_KEY", null, TypeScriptDependency.SMITHY_TYPES);
 
         String name = symbol.getName();
 
@@ -356,6 +357,10 @@ final class CommandGenerator implements Runnable {
                                 }
                             },
                             () -> writer.writeInline("(_: any) => _"));
+                });
+                writer.openBlock("[SMITHY_CONTEXT_KEY]: {", "},", () -> {
+                    writer.write("service: $S,", service.toShapeId().getName());
+                    writer.write("operation: $S,", operation.toShapeId().getName());
                 });
             });
             writer.write("const { requestHandler } = configuration;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -132,6 +132,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 Paths.get(".", serviceSymbol.getNamespace()));
             w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addImport("HttpAuthSchemeParametersProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.UTIL_MIDDLEWARE);
+            w.addImport("getSmithyContext", null, TypeScriptDependency.UTIL_MIDDLEWARE);
             w.openBlock("""
                 /**
                  * @internal
@@ -142,7 +144,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 serviceName, serviceSymbol.getName(), serviceName,
                 () -> {
                 w.openBlock("return {", "};", () -> {
-                    w.write("operation: context.commandName,");
+                    w.write("operation: getSmithyContext(context).operation as string,");
                     for (HttpAuthScheme authScheme : authIndex.getSupportedHttpAuthSchemes().values()) {
                         for (HttpAuthSchemeParameter parameter : authScheme.getHttpAuthSchemeParameters()) {
                             w.write("$L: $C,", parameter.name(), parameter.source());


### PR DESCRIPTION
*Issue #, if available:*

Resolves https://github.com/awslabs/smithy-typescript/issues/933

*Description of changes:*

Add service and operation names to `HandlerExecutionContext`

Dependent on: https://github.com/awslabs/smithy-typescript/pull/927

*Testing:*

#### Smithy context service and operation population

`smithy-typescript-codegen-test`: for the `Weather` service's `CreateCity` command, the following codegen diff is produced:

```diff
diff --color -Nur smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts
--- smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts	2023-09-13 16:03:06
+++ smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts	2023-09-13 16:03:21
@@ -23,6 +23,7 @@
   Handler,
   HandlerExecutionContext,
   MiddlewareStack,
+  SMITHY_CONTEXT_KEY,
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   SerdeContext as __SerdeContext,
@@ -81,6 +82,10 @@
         (_: any) => _,
       outputFilterSensitiveLog:
         (_: any) => _,
+      [SMITHY_CONTEXT_KEY]: {
+        service: "Weather",
+        operation: "CreateCity",
+      },
     }
     const { requestHandler } = configuration;
     return stack.resolve(
```

#### `experimentalIdentityAndAuth`: `HttpAuthSchemeParametersProvider` update

```diff
diff --color -Nur /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts
--- /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-14 14:43:01
+++ /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/auth/httpAuthSchemeProvider.ts	2023-09-14 14:43:33
@@ -7,7 +7,10 @@
   HttpAuthSchemeParametersProvider,
   HttpAuthSchemeProvider,
 } from "@smithy/experimental-identity-and-auth";
-import { normalizeProvider } from "@smithy/util-middleware";
+import {
+  getSmithyContext,
+  normalizeProvider,
+} from "@smithy/util-middleware";
 
 /**
  * @internal
@@ -21,7 +24,7 @@
  */
 export const defaultWeatherHttpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<WeatherClientResolvedConfig, WeatherHttpAuthSchemeParameters> = async (config, context) => {
   return {
-    operation: context.commandName,
+    operation: getSmithyContext(context).operation as string,
     region: await normalizeProvider(config.region)() || (() => {
       throw new Error("expected `region` to be configured for `aws.auth#sigv4`");
     })(),
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
