### PR TITLE
move runtime packages into deps from devDeps

### DIFF
--- a/.changeset/heavy-donuts-repair.md
+++ b/.changeset/heavy-donuts-repair.md
@@ -1,0 +1,10 @@
+---
+"@smithy/service-error-classification": patch
+"@smithy/util-defaults-mode-browser": patch
+"@smithy/util-defaults-mode-node": patch
+"@smithy/middleware-stack": patch
+"@smithy/util-middleware": patch
+"@smithy/util-retry": patch
+---
+
+move devDeps into deps

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -25,10 +25,10 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "dependencies": {
+    "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/types": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -22,7 +22,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@smithy/types": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
@@ -55,5 +54,8 @@
   },
   "publishConfig": {
     "directory": ".release/package"
+  },
+  "dependencies": {
+    "@smithy/types": "workspace:^"
   }
 }

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -23,12 +23,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/property-provider": "workspace:^",
+    "@smithy/smithy-client": "workspace:^",
     "@smithy/types": "workspace:^",
     "bowser": "^2.11.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/smithy-client": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -26,11 +26,11 @@
     "@smithy/credential-provider-imds": "workspace:^",
     "@smithy/node-config-provider": "workspace:^",
     "@smithy/property-provider": "workspace:^",
+    "@smithy/smithy-client": "workspace:^",
     "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/smithy-client": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -26,10 +26,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/types": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -28,10 +28,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@smithy/service-error-classification": "workspace:^",
+    "@smithy/types": "workspace:^",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@smithy/types": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/scripts/check-dev-dependencies.js
+++ b/scripts/check-dev-dependencies.js
@@ -1,0 +1,44 @@
+/**
+ * Checks devDependency declarations for runtime packages.
+ * They should be moved to the dependencies section even if only imported for types.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..");
+const packages = path.join(root, "packages");
+const walk = require("./utils/walk");
+
+(async () => {
+  for (const folder of fs.readdirSync(packages)) {
+    const pkgJsonPath = path.join(packages, folder, "package.json");
+    const srcPath = path.join(packages, folder, "src");
+    const pkgJson = require(pkgJsonPath);
+
+    for await (const file of walk(srcPath, ["node_modules"])) {
+      const contents = fs.readFileSync(file);
+
+      if (file.endsWith(".spec.ts")) {
+        continue;
+      }
+
+      if (!file.endsWith(".ts")) {
+        continue;
+      }
+
+      for (const [dep, version] of Object.entries(pkgJson.devDependencies ?? {})) {
+        if (dep.startsWith("@smithy/") && contents.includes(`from "${dep}";`)) {
+          console.warn(`${dep} incorrectly declared in devDependencies of ${folder}`);
+          delete pkgJson.devDependencies[dep];
+          if (!pkgJson.dependencies) {
+            pkgJson.dependencies = {};
+          }
+          pkgJson.dependencies[dep] = version;
+
+          fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+        }
+      }
+    }
+  }
+})();

--- a/scripts/utils/walk.js
+++ b/scripts/utils/walk.js
@@ -1,0 +1,16 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+module.exports = async function* walk(dir, ignore = []) {
+  for await (const d of await fs.promises.opendir(dir)) {
+    const entry = path.join(dir, d.name);
+    if (ignore.find((ignored) => entry.includes(ignored))) {
+      continue;
+    }
+    if (d.isDirectory()) {
+      yield* walk(entry, ignore);
+    } else if (d.isFile()) {
+      yield entry;
+    }
+  }
+};


### PR DESCRIPTION
moves devDeps starting with `@smithy` into deps. Even if imported for types, they should not be in devDeps since they are imported in the runtime code.