### PR TITLE
enforce import type statements with linter

### DIFF
--- a/.changeset/rotten-scissors-lick.md
+++ b/.changeset/rotten-scissors-lick.md
@@ -1,0 +1,45 @@
+---
+"@smithy/service-client-documentation-generator": patch
+"@smithy/eventstream-serde-config-resolver": patch
+"@smithy/experimental-identity-and-auth": patch
+"@smithy/middleware-apply-body-checksum": patch
+"@smithy/service-error-classification": patch
+"@smithy/eventstream-serde-universal": patch
+"@smithy/eventstream-serde-browser": patch
+"@smithy/middleware-content-length": patch
+"@smithy/credential-provider-imds": patch
+"@smithy/util-defaults-mode-node": patch
+"@smithy/eventstream-serde-node": patch
+"@smithy/shared-ini-file-loader": patch
+"@smithy/node-config-provider": patch
+"@smithy/middleware-endpoint": patch
+"@smithy/querystring-builder": patch
+"@smithy/util-stream-browser": patch
+"@smithy/fetch-http-handler": patch
+"@smithy/invalid-dependency": patch
+"@smithy/querystring-parser": patch
+"@smithy/eventstream-codec": patch
+"@smithy/hash-blob-browser": patch
+"@smithy/node-http-handler": patch
+"@smithy/property-provider": patch
+"@smithy/hash-stream-node": patch
+"@smithy/middleware-retry": patch
+"@smithy/middleware-serde": patch
+"@smithy/middleware-stack": patch
+"@smithy/util-stream-node": patch
+"@smithy/config-resolver": patch
+"@smithy/util-middleware": patch
+"@smithy/protocol-http": patch
+"@smithy/smithy-client": patch
+"@smithy/signature-v4": patch
+"@smithy/util-stream": patch
+"@smithy/util-waiter": patch
+"@smithy/url-parser": patch
+"@smithy/util-retry": patch
+"@smithy/hash-node": patch
+"@smithy/util-test": patch
+"@smithy/md5-js": patch
+"@smithy/types": patch
+---
+
+use import type with lint rule

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     /** Turn off strict enforcement */
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",

--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
 import { booleanSelector, SelectorType } from "@smithy/util-config-provider";
 
 /**

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
 import { booleanSelector, SelectorType } from "@smithy/util-config-provider";
 
 /**

--- a/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
@@ -1,7 +1,7 @@
-import { Endpoint, Provider, UrlParser } from "@smithy/types";
+import type { Endpoint, Provider, UrlParser } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
-import { EndpointsInputConfig, EndpointsResolvedConfig } from "./resolveEndpointsConfig";
+import type { EndpointsInputConfig, EndpointsResolvedConfig } from "./resolveEndpointsConfig";
 
 /**
  * @public

--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -1,4 +1,4 @@
-import { Endpoint, Provider, RegionInfoProvider, UrlParser } from "@smithy/types";
+import type { Endpoint, Provider, RegionInfoProvider, UrlParser } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
 import { getEndpointFromRegion } from "./utils/getEndpointFromRegion";

--- a/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.ts
+++ b/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.ts
@@ -1,4 +1,4 @@
-import { Provider, RegionInfoProvider, UrlParser } from "@smithy/types";
+import type { Provider, RegionInfoProvider, UrlParser } from "@smithy/types";
 
 interface GetEndpointFromRegionOptions {
   region: Provider<string>;

--- a/packages/config-resolver/src/regionConfig/config.ts
+++ b/packages/config-resolver/src/regionConfig/config.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors, LocalConfigOptions } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors, LocalConfigOptions } from "@smithy/node-config-provider";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 import { getRealRegion } from "./getRealRegion";
 import { isFipsRegion } from "./isFipsRegion";

--- a/packages/config-resolver/src/regionInfo/EndpointVariant.ts
+++ b/packages/config-resolver/src/regionInfo/EndpointVariant.ts
@@ -1,4 +1,4 @@
-import { EndpointVariantTag } from "./EndpointVariantTag";
+import type { EndpointVariantTag } from "./EndpointVariantTag";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -1,4 +1,4 @@
-import { EndpointVariant } from "./EndpointVariant";
+import type { EndpointVariant } from "./EndpointVariant";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionInfo/RegionHash.ts
+++ b/packages/config-resolver/src/regionInfo/RegionHash.ts
@@ -1,4 +1,4 @@
-import { EndpointVariant } from "./EndpointVariant";
+import type { EndpointVariant } from "./EndpointVariant";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionInfo/getHostnameFromVariants.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getHostnameFromVariants.spec.ts
@@ -1,5 +1,6 @@
-import { EndpointVariant } from "./EndpointVariant";
-import { getHostnameFromVariants, GetHostnameFromVariantsOptions } from "./getHostnameFromVariants";
+import type { EndpointVariant } from "./EndpointVariant";
+import type { GetHostnameFromVariantsOptions } from "./getHostnameFromVariants";
+import { getHostnameFromVariants } from "./getHostnameFromVariants";
 
 describe(getHostnameFromVariants.name, () => {
   const getMockHostname = (options: GetHostnameFromVariantsOptions) => JSON.stringify(options);

--- a/packages/config-resolver/src/regionInfo/getHostnameFromVariants.ts
+++ b/packages/config-resolver/src/regionInfo/getHostnameFromVariants.ts
@@ -1,4 +1,4 @@
-import { EndpointVariant } from "./EndpointVariant";
+import type { EndpointVariant } from "./EndpointVariant";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
@@ -3,8 +3,8 @@ import { getRegionInfo } from "./getRegionInfo";
 import { getResolvedHostname } from "./getResolvedHostname";
 import { getResolvedPartition } from "./getResolvedPartition";
 import { getResolvedSigningRegion } from "./getResolvedSigningRegion";
-import { PartitionHash } from "./PartitionHash";
-import { RegionHash } from "./RegionHash";
+import type { PartitionHash } from "./PartitionHash";
+import type { RegionHash } from "./RegionHash";
 
 jest.mock("./getHostnameFromVariants");
 jest.mock("./getResolvedHostname");

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.ts
@@ -1,11 +1,11 @@
-import { RegionInfo } from "@smithy/types";
+import type { RegionInfo } from "@smithy/types";
 
 import { getHostnameFromVariants } from "./getHostnameFromVariants";
 import { getResolvedHostname } from "./getResolvedHostname";
 import { getResolvedPartition } from "./getResolvedPartition";
 import { getResolvedSigningRegion } from "./getResolvedSigningRegion";
-import { PartitionHash } from "./PartitionHash";
-import { RegionHash } from "./RegionHash";
+import type { PartitionHash } from "./PartitionHash";
+import type { RegionHash } from "./RegionHash";
 
 /**
  * @internal

--- a/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
@@ -1,5 +1,5 @@
 import { getResolvedPartition } from "./getResolvedPartition";
-import { PartitionHash } from "./PartitionHash";
+import type { PartitionHash } from "./PartitionHash";
 
 describe(getResolvedPartition.name, () => {
   const mockRegion = "mockRegion";

--- a/packages/config-resolver/src/regionInfo/getResolvedPartition.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedPartition.ts
@@ -1,4 +1,4 @@
-import { PartitionHash } from "./PartitionHash";
+import type { PartitionHash } from "./PartitionHash";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
 
 import { EndpointMode } from "./EndpointMode";
 

--- a/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
@@ -5,7 +5,8 @@ import {
   fromContainerMetadata,
 } from "./fromContainerMetadata";
 import { httpRequest } from "./remoteProvider/httpRequest";
-import { fromImdsCredentials, ImdsCredentials } from "./remoteProvider/ImdsCredentials";
+import type { ImdsCredentials } from "./remoteProvider/ImdsCredentials";
+import { fromImdsCredentials } from "./remoteProvider/ImdsCredentials";
 
 const mockHttpRequest = <any>httpRequest;
 jest.mock("./remoteProvider/httpRequest");

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -1,11 +1,12 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentityProvider } from "@smithy/types";
-import { RequestOptions } from "http";
+import type { AwsCredentialIdentityProvider } from "@smithy/types";
+import type { RequestOptions } from "http";
 import { parse } from "url";
 
 import { httpRequest } from "./remoteProvider/httpRequest";
 import { fromImdsCredentials, isImdsCredentials } from "./remoteProvider/ImdsCredentials";
-import { providerConfigFromInit, RemoteProviderInit } from "./remoteProvider/RemoteProviderInit";
+import type { RemoteProviderInit } from "./remoteProvider/RemoteProviderInit";
+import { providerConfigFromInit } from "./remoteProvider/RemoteProviderInit";
 import { retry } from "./remoteProvider/retry";
 
 /**

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -1,12 +1,13 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { AwsCredentialIdentity, Provider } from "@smithy/types";
-import { RequestOptions } from "http";
+import type { AwsCredentialIdentity, Provider } from "@smithy/types";
+import type { RequestOptions } from "http";
 
 import { httpRequest } from "./remoteProvider/httpRequest";
 import { fromImdsCredentials, isImdsCredentials } from "./remoteProvider/ImdsCredentials";
-import { providerConfigFromInit, RemoteProviderInit } from "./remoteProvider/RemoteProviderInit";
+import type { RemoteProviderInit } from "./remoteProvider/RemoteProviderInit";
+import { providerConfigFromInit } from "./remoteProvider/RemoteProviderInit";
 import { retry } from "./remoteProvider/retry";
-import { InstanceMetadataCredentials } from "./types";
+import type { InstanceMetadataCredentials } from "./types";
 import { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";
 import { staticStabilityProvider } from "./utils/staticStabilityProvider";
 

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.spec.ts
@@ -1,6 +1,7 @@
-import { AwsCredentialIdentity } from "@smithy/types";
+import type { AwsCredentialIdentity } from "@smithy/types";
 
-import { fromImdsCredentials, ImdsCredentials, isImdsCredentials } from "./ImdsCredentials";
+import type { ImdsCredentials } from "./ImdsCredentials";
+import { fromImdsCredentials, isImdsCredentials } from "./ImdsCredentials";
 
 const creds: ImdsCredentials = Object.freeze({
   AccessKeyId: "foo",

--- a/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/ImdsCredentials.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentity } from "@smithy/types";
+import type { AwsCredentialIdentity } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/httpRequest.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "@smithy/property-provider";
 import { Buffer } from "buffer";
-import { IncomingMessage, request, RequestOptions } from "http";
+import type { IncomingMessage, RequestOptions } from "http";
+import { request } from "http";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/types.ts
+++ b/packages/credential-provider-imds/src/types.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentity } from "@smithy/types";
+import type { AwsCredentialIdentity } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
 
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -1,6 +1,6 @@
-import { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
 
-import { InstanceMetadataCredentials } from "../types";
+import type { InstanceMetadataCredentials } from "../types";
 
 const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 5 * 60;
 const STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS = 5 * 60;

--- a/packages/credential-provider-imds/src/utils/getInstanceMetadataEndpoint.ts
+++ b/packages/credential-provider-imds/src/utils/getInstanceMetadataEndpoint.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@smithy/node-config-provider";
-import { Endpoint } from "@smithy/types";
+import type { Endpoint } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
 
 import { Endpoint as InstanceMetadataEndpoint } from "../config/Endpoint";

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.spec.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
 
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 import { staticStabilityProvider } from "./staticStabilityProvider";

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
@@ -1,6 +1,7 @@
-import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
+import type { Logger, Provider } from "@smithy/types";
+import { AwsCredentialIdentity } from "@smithy/types";
 
-import { InstanceMetadataCredentials } from "../types";
+import type { InstanceMetadataCredentials } from "../types";
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 
 /**

--- a/packages/eventstream-codec/src/EventStreamCodec.ts
+++ b/packages/eventstream-codec/src/EventStreamCodec.ts
@@ -1,5 +1,5 @@
 import { Crc32 } from "@aws-crypto/crc32";
-import {
+import type {
   AvailableMessage,
   AvailableMessages,
   Message,
@@ -7,7 +7,7 @@ import {
   MessageEncoder,
   MessageHeaders,
 } from "@smithy/types";
-import { Decoder, Encoder } from "@smithy/types";
+import type { Decoder, Encoder } from "@smithy/types";
 
 import { HeaderMarshaller } from "./HeaderMarshaller";
 import { splitMessage } from "./splitMessage";

--- a/packages/eventstream-codec/src/HeaderMarshaller.spec.ts
+++ b/packages/eventstream-codec/src/HeaderMarshaller.spec.ts
@@ -1,4 +1,4 @@
-import { MessageHeaders } from "@smithy/types";
+import type { MessageHeaders } from "@smithy/types";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 
 import { HeaderMarshaller } from "./HeaderMarshaller";

--- a/packages/eventstream-codec/src/HeaderMarshaller.ts
+++ b/packages/eventstream-codec/src/HeaderMarshaller.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, MessageHeaders, MessageHeaderValue } from "@smithy/types";
+import type { Decoder, Encoder, MessageHeaders, MessageHeaderValue } from "@smithy/types";
 import { fromHex, toHex } from "@smithy/util-hex-encoding";
 
 import { Int64 } from "./Int64";

--- a/packages/eventstream-codec/src/Int64.ts
+++ b/packages/eventstream-codec/src/Int64.ts
@@ -1,4 +1,4 @@
-import { Int64 as IInt64 } from "@smithy/types";
+import type { Int64 as IInt64 } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 
 export interface Int64 extends IInt64 {}

--- a/packages/eventstream-codec/src/Message.ts
+++ b/packages/eventstream-codec/src/Message.ts
@@ -1,4 +1,4 @@
-import { Int64 } from "./Int64";
+import type { Int64 } from "./Int64";
 
 /**
  * An event stream message. The headers and body properties will always be

--- a/packages/eventstream-codec/src/MessageDecoderStream.spec.ts
+++ b/packages/eventstream-codec/src/MessageDecoderStream.spec.ts
@@ -1,4 +1,4 @@
-import { Message } from "@smithy/types";
+import type { Message } from "@smithy/types";
 
 import { MessageDecoderStream } from "./MessageDecoderStream";
 

--- a/packages/eventstream-codec/src/MessageDecoderStream.ts
+++ b/packages/eventstream-codec/src/MessageDecoderStream.ts
@@ -1,4 +1,4 @@
-import { Message, MessageDecoder } from "@smithy/types";
+import type { Message, MessageDecoder } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/eventstream-codec/src/MessageEncoderStream.ts
+++ b/packages/eventstream-codec/src/MessageEncoderStream.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEncoder } from "@smithy/types";
+import type { Message, MessageEncoder } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/eventstream-codec/src/SmithyMessageDecoderStream.ts
+++ b/packages/eventstream-codec/src/SmithyMessageDecoderStream.ts
@@ -1,4 +1,4 @@
-import { Message } from "@smithy/types";
+import type { Message } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/eventstream-codec/src/SmithyMessageEncoderStream.spec.ts
+++ b/packages/eventstream-codec/src/SmithyMessageEncoderStream.spec.ts
@@ -1,4 +1,4 @@
-import { Message } from "@smithy/types";
+import type { Message } from "@smithy/types";
 
 import { SmithyMessageEncoderStream } from "./SmithyMessageEncoderStream";
 

--- a/packages/eventstream-codec/src/SmithyMessageEncoderStream.ts
+++ b/packages/eventstream-codec/src/SmithyMessageEncoderStream.ts
@@ -1,4 +1,4 @@
-import { Message } from "@smithy/types";
+import type { Message } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/eventstream-codec/src/TestVectors.fixture.ts
+++ b/packages/eventstream-codec/src/TestVectors.fixture.ts
@@ -1,5 +1,5 @@
 import { Int64 } from "./Int64";
-import { TestVectors } from "./vectorTypes.fixture";
+import type { TestVectors } from "./vectorTypes.fixture";
 
 export const vectors: TestVectors = {
   all_headers: {

--- a/packages/eventstream-codec/src/vectorTypes.fixture.ts
+++ b/packages/eventstream-codec/src/vectorTypes.fixture.ts
@@ -1,4 +1,4 @@
-import { Message } from "./Message";
+import type { Message } from "./Message";
 
 export interface NegativeTestVector {
   expectation: "failure";

--- a/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
@@ -1,5 +1,5 @@
 import { EventStreamMarshaller as UniversalEventStreamMarshaller } from "@smithy/eventstream-serde-universal";
-import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
+import type { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
 
 import { iterableToReadableStream, readableStreamtoIterable } from "./utils";
 

--- a/packages/eventstream-serde-browser/src/provider.ts
+++ b/packages/eventstream-serde-browser/src/provider.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
+import type { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
 
 import { EventStreamMarshaller } from "./EventStreamMarshaller";
 

--- a/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
+++ b/packages/eventstream-serde-config-resolver/src/EventStreamSerdeConfig.ts
@@ -1,4 +1,4 @@
-import { EventStreamMarshaller, EventStreamSerdeProvider } from "@smithy/types";
+import type { EventStreamMarshaller, EventStreamSerdeProvider } from "@smithy/types";
 
 /**
  * @public

--- a/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
@@ -1,5 +1,5 @@
 import { EventStreamMarshaller as UniversalEventStreamMarshaller } from "@smithy/eventstream-serde-universal";
-import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
+import type { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
 import { Readable } from "stream";
 
 import { readabletoIterable } from "./utils";

--- a/packages/eventstream-serde-node/src/provider.ts
+++ b/packages/eventstream-serde-node/src/provider.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
+import type { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
 
 import { EventStreamMarshaller } from "./EventStreamMarshaller";
 

--- a/packages/eventstream-serde-node/src/utils.ts
+++ b/packages/eventstream-serde-node/src/utils.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import type { Readable } from "stream";
 
 /**
  * Convert object stream piped in into an async iterable. This

--- a/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
@@ -5,7 +5,7 @@ import {
   SmithyMessageDecoderStream,
   SmithyMessageEncoderStream,
 } from "@smithy/eventstream-codec";
-import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
+import type { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Message } from "@smithy/types";
 
 import { getChunkedStream } from "./getChunkedStream";
 import { getMessageUnmarshaller } from "./getUnmarshalledStream";

--- a/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
+++ b/packages/eventstream-serde-universal/src/fixtures/MockEventMessageSource.fixture.ts
@@ -1,4 +1,5 @@
-import { Readable, ReadableOptions } from "stream";
+import type { ReadableOptions } from "stream";
+import { Readable } from "stream";
 
 /**
  * @internal

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
@@ -1,5 +1,5 @@
 import { EventStreamCodec } from "@smithy/eventstream-codec";
-import { Message } from "@smithy/types";
+import type { Message } from "@smithy/types";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
 
 import { endEventMessage, exception, recordEventMessage, statsEventMessage } from "./fixtures/event.fixture";

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
@@ -1,5 +1,5 @@
-import { EventStreamCodec } from "@smithy/eventstream-codec";
-import { Encoder, Message } from "@smithy/types";
+import type { EventStreamCodec } from "@smithy/eventstream-codec";
+import type { Encoder, Message } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/eventstream-serde-universal/src/provider.ts
+++ b/packages/eventstream-serde-universal/src/provider.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
+import type { Decoder, Encoder, EventSigner, EventStreamSerdeProvider, Provider } from "@smithy/types";
 
 import { EventStreamMarshaller } from "./EventStreamMarshaller";
 

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -1,7 +1,7 @@
-import { Identity, IdentityProvider } from "@smithy/types";
+import type { Identity, IdentityProvider } from "@smithy/types";
 
-import { HttpSigner } from "./HttpSigner";
-import { IdentityProviderConfig } from "./IdentityProviderConfig";
+import type { HttpSigner } from "./HttpSigner";
+import type { IdentityProviderConfig } from "./IdentityProviderConfig";
 
 /**
  * ID for {@link HttpAuthScheme}

--- a/packages/experimental-identity-and-auth/src/HttpAuthSchemeProvider.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthSchemeProvider.ts
@@ -1,6 +1,6 @@
-import { HandlerExecutionContext } from "@smithy/types";
+import type { HandlerExecutionContext } from "@smithy/types";
 
-import { HttpAuthOption } from "./HttpAuthScheme";
+import type { HttpAuthOption } from "./HttpAuthScheme";
 
 /**
  * @internal

--- a/packages/experimental-identity-and-auth/src/HttpSigner.ts
+++ b/packages/experimental-identity-and-auth/src/HttpSigner.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, Identity } from "@smithy/types";
+import type { HttpRequest, Identity } from "@smithy/types";
 
 /**
  * Interface to sign identity and signing properties.

--- a/packages/experimental-identity-and-auth/src/IdentityProviderConfig.ts
+++ b/packages/experimental-identity-and-auth/src/IdentityProviderConfig.ts
@@ -1,6 +1,6 @@
-import { Identity, IdentityProvider } from "@smithy/types";
+import type { Identity, IdentityProvider } from "@smithy/types";
 
-import { HttpAuthSchemeId } from "./HttpAuthScheme";
+import type { HttpAuthSchemeId } from "./HttpAuthScheme";
 
 /**
  * Interface to get an IdentityProvider for a specified HttpAuthScheme

--- a/packages/experimental-identity-and-auth/src/SigV4Signer.ts
+++ b/packages/experimental-identity-and-auth/src/SigV4Signer.ts
@@ -1,8 +1,8 @@
-import { HttpRequest } from "@smithy/protocol-http";
+import type { HttpRequest } from "@smithy/protocol-http";
 import { SignatureV4 } from "@smithy/signature-v4";
-import { AwsCredentialIdentity, HttpRequest as IHttpRequest } from "@smithy/types";
+import type { AwsCredentialIdentity, HttpRequest as IHttpRequest } from "@smithy/types";
 
-import { HttpSigner } from "./HttpSigner";
+import type { HttpSigner } from "./HttpSigner";
 
 /**
  * @internal

--- a/packages/experimental-identity-and-auth/src/apiKeyIdentity.ts
+++ b/packages/experimental-identity-and-auth/src/apiKeyIdentity.ts
@@ -1,4 +1,4 @@
-import { Identity, IdentityProvider } from "@smithy/types";
+import type { Identity, IdentityProvider } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
@@ -1,8 +1,8 @@
-import { HttpRequest } from "@smithy/protocol-http";
-import { HttpRequest as IHttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/protocol-http";
+import type { HttpRequest as IHttpRequest } from "@smithy/types";
 
-import { ApiKeyIdentity } from "./apiKeyIdentity";
-import { HttpSigner } from "./HttpSigner";
+import type { ApiKeyIdentity } from "./apiKeyIdentity";
+import type { HttpSigner } from "./HttpSigner";
 
 /**
  * @internal

--- a/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
@@ -1,8 +1,8 @@
-import { HttpRequest } from "@smithy/protocol-http";
-import { HttpRequest as IHttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/protocol-http";
+import type { HttpRequest as IHttpRequest } from "@smithy/types";
 
-import { HttpSigner } from "./HttpSigner";
-import { TokenIdentity } from "./tokenIdentity";
+import type { HttpSigner } from "./HttpSigner";
+import type { TokenIdentity } from "./tokenIdentity";
 
 /**
  * @internal

--- a/packages/experimental-identity-and-auth/src/noAuth.ts
+++ b/packages/experimental-identity-and-auth/src/noAuth.ts
@@ -1,6 +1,6 @@
-import { HttpRequest, Identity } from "@smithy/types";
+import type { HttpRequest, Identity } from "@smithy/types";
 
-import { HttpSigner } from "./HttpSigner";
+import type { HttpSigner } from "./HttpSigner";
 
 /**
  * Signer for the synthetic @smithy.api#noAuth auth scheme.

--- a/packages/experimental-identity-and-auth/src/tokenIdentity.ts
+++ b/packages/experimental-identity-and-auth/src/tokenIdentity.ts
@@ -1,4 +1,4 @@
-import { Identity, IdentityProvider } from "@smithy/types";
+import type { Identity, IdentityProvider } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -1,6 +1,7 @@
-import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
+import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
-import { HeaderBag, HttpHandlerOptions, Provider } from "@smithy/types";
+import type { HeaderBag, HttpHandlerOptions, Provider } from "@smithy/types";
 
 import { requestTimeout } from "./request-timeout";
 

--- a/packages/fetch-http-handler/src/stream-collector.ts
+++ b/packages/fetch-http-handler/src/stream-collector.ts
@@ -1,4 +1,4 @@
-import { StreamCollector } from "@smithy/types";
+import type { StreamCollector } from "@smithy/types";
 import { fromBase64 } from "@smithy/util-base64";
 
 //reference: https://snack.expo.io/r1JCSWRGU

--- a/packages/hash-blob-browser/src/index.ts
+++ b/packages/hash-blob-browser/src/index.ts
@@ -1,5 +1,5 @@
 import { blobReader } from "@smithy/chunked-blob-reader";
-import { ChecksumConstructor, HashConstructor, StreamHasher } from "@smithy/types";
+import type { ChecksumConstructor, HashConstructor, StreamHasher } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/hash-node/src/index.ts
+++ b/packages/hash-node/src/index.ts
@@ -1,8 +1,10 @@
-import { Checksum, SourceData } from "@smithy/types";
-import { fromArrayBuffer, fromString, StringEncoding } from "@smithy/util-buffer-from";
+import type { Checksum, SourceData } from "@smithy/types";
+import type { StringEncoding } from "@smithy/util-buffer-from";
+import { fromArrayBuffer, fromString } from "@smithy/util-buffer-from";
 import { toUint8Array } from "@smithy/util-utf8";
 import { Buffer } from "buffer";
-import { createHash, createHmac, Hash as NodeHash, Hmac } from "crypto";
+import type { Hash as NodeHash, Hmac } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 /**
  * @internal

--- a/packages/hash-stream-node/src/HashCalculator.ts
+++ b/packages/hash-stream-node/src/HashCalculator.ts
@@ -1,6 +1,7 @@
-import { Checksum, Hash } from "@smithy/types";
+import type { Checksum, Hash } from "@smithy/types";
 import { toUint8Array } from "@smithy/util-utf8";
-import { Writable, WritableOptions } from "stream";
+import type { WritableOptions } from "stream";
+import { Writable } from "stream";
 
 /**
  * @internal

--- a/packages/hash-stream-node/src/fileStreamHasher.ts
+++ b/packages/hash-stream-node/src/fileStreamHasher.ts
@@ -1,6 +1,7 @@
-import { HashConstructor, StreamHasher } from "@smithy/types";
-import { createReadStream, ReadStream } from "fs";
-import { Readable } from "stream";
+import type { HashConstructor, StreamHasher } from "@smithy/types";
+import type { ReadStream } from "fs";
+import { createReadStream } from "fs";
+import type { Readable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";
 

--- a/packages/hash-stream-node/src/readableStreamHasher.spec.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.spec.ts
@@ -1,4 +1,4 @@
-import { Hash } from "@smithy/types";
+import type { Hash } from "@smithy/types";
 import { Readable, Writable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -1,5 +1,5 @@
-import { HashConstructor, StreamHasher } from "@smithy/types";
-import { Readable } from "stream";
+import type { HashConstructor, StreamHasher } from "@smithy/types";
+import type { Readable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";
 

--- a/packages/invalid-dependency/src/invalidProvider.ts
+++ b/packages/invalid-dependency/src/invalidProvider.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 /**
  * @internal
  */

--- a/packages/md5-js/src/index.ts
+++ b/packages/md5-js/src/index.ts
@@ -1,4 +1,4 @@
-import { Checksum, SourceData } from "@smithy/types";
+import type { Checksum, SourceData } from "@smithy/types";
 import { fromUtf8 } from "@smithy/util-utf8";
 
 import { BLOCK_SIZE, DIGEST_LENGTH, INIT } from "./constants";

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.spec.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.spec.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
-import { ChecksumConstructor } from "@smithy/types";
+import type { ChecksumConstructor } from "@smithy/types";
 
 import { applyMd5BodyChecksumMiddleware } from "./applyMd5BodyChecksumMiddleware";
 

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
@@ -1,6 +1,6 @@
 import { isArrayBuffer } from "@smithy/is-array-buffer";
 import { HttpRequest } from "@smithy/protocol-http";
-import {
+import type {
   BuildHandler,
   BuildHandlerArguments,
   BuildHandlerOptions,
@@ -11,7 +11,7 @@ import {
   Pluggable,
 } from "@smithy/types";
 
-import { Md5BodyChecksumResolvedConfig } from "./md5Configuration";
+import type { Md5BodyChecksumResolvedConfig } from "./md5Configuration";
 
 export const applyMd5BodyChecksumMiddleware = (options: Md5BodyChecksumResolvedConfig): BuildMiddleware<any, any> => <
   Output extends MetadataBearer

--- a/packages/middleware-apply-body-checksum/src/md5Configuration.ts
+++ b/packages/middleware-apply-body-checksum/src/md5Configuration.ts
@@ -1,4 +1,4 @@
-import { ChecksumConstructor, Encoder, HashConstructor, StreamHasher } from "@smithy/types";
+import type { ChecksumConstructor, Encoder, HashConstructor, StreamHasher } from "@smithy/types";
 
 /**
  * @public

--- a/packages/middleware-content-length/src/index.ts
+++ b/packages/middleware-content-length/src/index.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
-import {
+import type {
   BodyLengthCalculator,
   BuildHandler,
   BuildHandlerArguments,

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
@@ -1,4 +1,4 @@
-import { Endpoint } from "@smithy/types";
+import type { Endpoint } from "@smithy/types";
 
 import { createConfigValueProvider } from "./createConfigValueProvider";
 

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -1,4 +1,4 @@
-import { Endpoint, EndpointV2 } from "@smithy/types";
+import type { Endpoint, EndpointV2 } from "@smithy/types";
 
 /**
  * Normalize some key of the client config to an async provider.

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -1,8 +1,8 @@
-import { EndpointParameters, EndpointV2, HandlerExecutionContext } from "@smithy/types";
+import type { EndpointParameters, EndpointV2, HandlerExecutionContext } from "@smithy/types";
 
-import { EndpointResolvedConfig } from "../resolveEndpointConfig";
+import type { EndpointResolvedConfig } from "../resolveEndpointConfig";
 import { resolveParamsForS3 } from "../service-customizations";
-import { EndpointParameterInstructions } from "../types";
+import type { EndpointParameterInstructions } from "../types";
 import { createConfigValueProvider } from "./createConfigValueProvider";
 
 /**

--- a/packages/middleware-endpoint/src/adaptors/toEndpointV1.ts
+++ b/packages/middleware-endpoint/src/adaptors/toEndpointV1.ts
@@ -1,4 +1,4 @@
-import { Endpoint, EndpointV2 } from "@smithy/types";
+import type { Endpoint, EndpointV2 } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
 
 /**

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AuthScheme,
   EndpointParameters,
   EndpointV2,
@@ -11,8 +11,8 @@ import {
 } from "@smithy/types";
 
 import { getEndpointFromInstructions } from "./adaptors/getEndpointFromInstructions";
-import { EndpointResolvedConfig } from "./resolveEndpointConfig";
-import { EndpointParameterInstructions } from "./types";
+import type { EndpointResolvedConfig } from "./resolveEndpointConfig";
+import type { EndpointParameterInstructions } from "./types";
 
 /**
  * @internal

--- a/packages/middleware-endpoint/src/getEndpointPlugin.ts
+++ b/packages/middleware-endpoint/src/getEndpointPlugin.ts
@@ -1,9 +1,9 @@
 import { serializerMiddlewareOption } from "@smithy/middleware-serde";
-import { EndpointParameters, Pluggable, RelativeMiddlewareOptions, SerializeHandlerOptions } from "@smithy/types";
+import type { EndpointParameters, Pluggable, RelativeMiddlewareOptions, SerializeHandlerOptions } from "@smithy/types";
 
 import { endpointMiddleware } from "./endpointMiddleware";
-import { EndpointResolvedConfig } from "./resolveEndpointConfig";
-import { EndpointParameterInstructions } from "./types";
+import type { EndpointResolvedConfig } from "./resolveEndpointConfig";
+import type { EndpointParameterInstructions } from "./types";
 
 /**
  * @internal

--- a/packages/middleware-endpoint/src/resolveEndpointConfig.ts
+++ b/packages/middleware-endpoint/src/resolveEndpointConfig.ts
@@ -1,4 +1,4 @@
-import { Endpoint, EndpointParameters, EndpointV2, Logger, Provider, UrlParser } from "@smithy/types";
+import type { Endpoint, EndpointParameters, EndpointV2, Logger, Provider, UrlParser } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 
 import { toEndpointV1 } from "./adaptors/toEndpointV1";

--- a/packages/middleware-endpoint/src/service-customizations/s3.ts
+++ b/packages/middleware-endpoint/src/service-customizations/s3.ts
@@ -1,4 +1,4 @@
-import { EndpointParameters } from "@smithy/types";
+import type { EndpointParameters } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/middleware-retry/src/AdaptiveRetryStrategy.spec.ts
+++ b/packages/middleware-retry/src/AdaptiveRetryStrategy.spec.ts
@@ -1,8 +1,9 @@
-import { DefaultRateLimiter, RateLimiter, RETRY_MODES } from "@smithy/util-retry";
+import type { RateLimiter } from "@smithy/util-retry";
+import { DefaultRateLimiter, RETRY_MODES } from "@smithy/util-retry";
 
 import { AdaptiveRetryStrategy } from "./AdaptiveRetryStrategy";
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
-import { RetryQuota } from "./types";
+import type { RetryQuota } from "./types";
 
 jest.mock("./StandardRetryStrategy");
 jest.mock("@smithy/util-retry");

--- a/packages/middleware-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/middleware-retry/src/AdaptiveRetryStrategy.ts
@@ -1,7 +1,9 @@
-import { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider } from "@smithy/types";
-import { DefaultRateLimiter, RateLimiter, RETRY_MODES } from "@smithy/util-retry";
+import type { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider } from "@smithy/types";
+import type { RateLimiter } from "@smithy/util-retry";
+import { DefaultRateLimiter, RETRY_MODES } from "@smithy/util-retry";
 
-import { StandardRetryStrategy, StandardRetryStrategyOptions } from "./StandardRetryStrategy";
+import type { StandardRetryStrategyOptions } from "./StandardRetryStrategy";
+import { StandardRetryStrategy } from "./StandardRetryStrategy";
 
 /**
  * Strategy options to be passed to AdaptiveRetryStrategy

--- a/packages/middleware-retry/src/StandardRetryStrategy.spec.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.spec.ts
@@ -13,7 +13,7 @@ import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
-import { RetryQuota } from "./types";
+import type { RetryQuota } from "./types";
 
 jest.mock("@smithy/service-error-classification");
 jest.mock("./delayDecider");

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -1,7 +1,7 @@
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isThrottlingError } from "@smithy/service-error-classification";
-import { SdkError } from "@smithy/types";
-import { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider, RetryStrategy } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
+import type { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider, RetryStrategy } from "@smithy/types";
 import {
   DEFAULT_MAX_ATTEMPTS,
   DEFAULT_RETRY_DELAY_BASE,
@@ -16,7 +16,7 @@ import { v4 } from "uuid";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 import { defaultDelayDecider } from "./delayDecider";
 import { defaultRetryDecider } from "./retryDecider";
-import { DelayDecider, RetryDecider, RetryQuota } from "./types";
+import type { DelayDecider, RetryDecider, RetryQuota } from "./types";
 import { asSdkError } from "./util";
 
 /**

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,5 +1,5 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
-import { Provider, RetryStrategy, RetryStrategyV2 } from "@smithy/types";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { Provider, RetryStrategy, RetryStrategyV2 } from "@smithy/types";
 import { normalizeProvider } from "@smithy/util-middleware";
 import {
   AdaptiveRetryStrategy,

--- a/packages/middleware-retry/src/defaultRetryQuota.spec.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.spec.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 import { INITIAL_RETRY_TOKENS, NO_RETRY_INCREMENT, RETRY_COST, TIMEOUT_RETRY_COST } from "@smithy/util-retry";
 
 import { getDefaultRetryQuota } from "./defaultRetryQuota";

--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -1,7 +1,7 @@
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 import { NO_RETRY_INCREMENT, RETRY_COST, TIMEOUT_RETRY_COST } from "@smithy/util-retry";
 
-import { RetryQuota } from "./types";
+import type { RetryQuota } from "./types";
 
 export interface DefaultRetryQuotaOptions {
   /**

--- a/packages/middleware-retry/src/omitRetryHeadersMiddleware.spec.ts
+++ b/packages/middleware-retry/src/omitRetryHeadersMiddleware.spec.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
-import { FinalizeHandlerArguments, MiddlewareStack } from "@smithy/types";
+import type { FinalizeHandlerArguments, MiddlewareStack } from "@smithy/types";
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
 
 import {

--- a/packages/middleware-retry/src/omitRetryHeadersMiddleware.ts
+++ b/packages/middleware-retry/src/omitRetryHeadersMiddleware.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
-import {
+import type {
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,

--- a/packages/middleware-retry/src/retryDecider.spec.ts
+++ b/packages/middleware-retry/src/retryDecider.spec.ts
@@ -4,7 +4,7 @@ import {
   isThrottlingError,
   isTransientError,
 } from "@smithy/service-error-classification";
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 
 import { defaultRetryDecider } from "./retryDecider";
 

--- a/packages/middleware-retry/src/retryDecider.ts
+++ b/packages/middleware-retry/src/retryDecider.ts
@@ -4,7 +4,7 @@ import {
   isThrottlingError,
   isTransientError,
 } from "@smithy/service-error-classification";
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 
 export const defaultRetryDecider = (error: SdkError) => {
   if (!error) {

--- a/packages/middleware-retry/src/retryMiddleware.spec.ts
+++ b/packages/middleware-retry/src/retryMiddleware.spec.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
-import { FinalizeHandlerArguments, HandlerExecutionContext, MiddlewareStack } from "@smithy/types";
+import type { FinalizeHandlerArguments, HandlerExecutionContext, MiddlewareStack } from "@smithy/types";
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
 import { v4 } from "uuid";
 

--- a/packages/middleware-retry/src/retryMiddleware.ts
+++ b/packages/middleware-retry/src/retryMiddleware.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
 import { isServerError, isThrottlingError, isTransientError } from "@smithy/service-error-classification";
-import {
+import type {
   AbsoluteLocation,
   FinalizeHandler,
   FinalizeHandlerArguments,
@@ -19,7 +19,7 @@ import {
 import { INVOCATION_ID_HEADER, REQUEST_HEADER } from "@smithy/util-retry";
 import { v4 } from "uuid";
 
-import { RetryResolvedConfig } from "./configurations";
+import type { RetryResolvedConfig } from "./configurations";
 import { asSdkError } from "./util";
 
 export const retryMiddleware = (options: RetryResolvedConfig) => <Output extends MetadataBearer = MetadataBearer>(

--- a/packages/middleware-retry/src/types.ts
+++ b/packages/middleware-retry/src/types.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 
 /**
  * Determines whether an error is retryable based on the number of retries

--- a/packages/middleware-retry/src/util.ts
+++ b/packages/middleware-retry/src/util.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 
 export const asSdkError = (error: unknown): SdkError => {
   if (error instanceof Error) return error;

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DeserializeHandler,
   DeserializeHandlerArguments,
   DeserializeHandlerOutput,

--- a/packages/middleware-serde/src/serdePlugin.ts
+++ b/packages/middleware-serde/src/serdePlugin.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DeserializeHandlerOptions,
   Endpoint,
   EndpointBearer,

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   EndpointBearer,
   HandlerExecutionContext,
   RequestSerializer,

--- a/packages/middleware-stack/src/MiddlewareStack.spec.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.spec.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DeserializeHandlerArguments,
   DeserializeMiddleware,
   FinalizeHandler,

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AbsoluteLocation,
   DeserializeHandler,
   Handler,
@@ -12,7 +12,7 @@ import {
   Step,
 } from "@smithy/types";
 
-import { AbsoluteMiddlewareEntry, MiddlewareEntry, Normalized, RelativeMiddlewareEntry } from "./types";
+import type { AbsoluteMiddlewareEntry, MiddlewareEntry, Normalized, RelativeMiddlewareEntry } from "./types";
 
 export const constructStack = <Input extends object, Output extends object>(): MiddlewareStack<Input, Output> => {
   let absoluteEntries: AbsoluteMiddlewareEntry<Input, Output>[] = [];

--- a/packages/middleware-stack/src/types.ts
+++ b/packages/middleware-stack/src/types.ts
@@ -1,4 +1,4 @@
-import { AbsoluteLocation, HandlerOptions, MiddlewareType, Priority, RelativeLocation, Step } from "@smithy/types";
+import type { AbsoluteLocation, HandlerOptions, MiddlewareType, Priority, RelativeLocation, Step } from "@smithy/types";
 
 export interface MiddlewareEntry<Input extends object, Output extends object> extends HandlerOptions {
   middleware: MiddlewareType<Input, Output>;

--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -1,9 +1,10 @@
 import { chain, fromStatic, memoize } from "@smithy/property-provider";
-import { Profile } from "@smithy/types";
+import type { Profile } from "@smithy/types";
 
 import { loadConfig } from "./configLoader";
 import { fromEnv } from "./fromEnv";
-import { fromSharedConfigFiles, SharedConfigInit } from "./fromSharedConfigFiles";
+import type { SharedConfigInit } from "./fromSharedConfigFiles";
+import { fromSharedConfigFiles } from "./fromSharedConfigFiles";
 
 jest.mock("./fromEnv");
 jest.mock("./fromSharedConfigFiles");

--- a/packages/node-config-provider/src/configLoader.ts
+++ b/packages/node-config-provider/src/configLoader.ts
@@ -1,9 +1,12 @@
 import { chain, memoize } from "@smithy/property-provider";
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
-import { fromEnv, GetterFromEnv } from "./fromEnv";
-import { fromSharedConfigFiles, GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
-import { fromStatic, FromStaticConfig } from "./fromStatic";
+import type { GetterFromEnv } from "./fromEnv";
+import { fromEnv } from "./fromEnv";
+import type { GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
+import { fromSharedConfigFiles } from "./fromSharedConfigFiles";
+import type { FromStaticConfig } from "./fromStatic";
+import { fromStatic } from "./fromStatic";
 
 export type LocalConfigOptions = SharedConfigInit;
 

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -1,6 +1,7 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
 
-import { fromEnv, GetterFromEnv } from "./fromEnv";
+import type { GetterFromEnv } from "./fromEnv";
+import { fromEnv } from "./fromEnv";
 
 describe("fromEnv", () => {
   describe("with env var getter", () => {

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,5 +1,5 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
 export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | undefined;

--- a/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
@@ -1,8 +1,9 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { getProfileName, loadSharedConfigFiles } from "@smithy/shared-ini-file-loader";
-import { ParsedIniData, Profile } from "@smithy/types";
+import type { ParsedIniData, Profile } from "@smithy/types";
 
-import { fromSharedConfigFiles, GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
+import type { GetterFromConfig, SharedConfigInit } from "./fromSharedConfigFiles";
+import { fromSharedConfigFiles } from "./fromSharedConfigFiles";
 
 jest.mock("@smithy/shared-ini-file-loader", () => ({
   getProfileName: jest.fn(),

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,6 +1,7 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
-import { getProfileName, loadSharedConfigFiles, SourceProfileInit } from "@smithy/shared-ini-file-loader";
-import { Profile, Provider } from "@smithy/types";
+import type { SourceProfileInit } from "@smithy/shared-ini-file-loader";
+import { getProfileName, loadSharedConfigFiles } from "@smithy/shared-ini-file-loader";
+import type { Profile, Provider } from "@smithy/types";
 
 export interface SharedConfigInit extends SourceProfileInit {
   /**

--- a/packages/node-config-provider/src/fromStatic.ts
+++ b/packages/node-config-provider/src/fromStatic.ts
@@ -1,5 +1,5 @@
 import { fromStatic as convertToProvider } from "@smithy/property-provider";
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 export type FromStaticConfig<T> = T | (() => T) | Provider<T>;
 type Getter<T> = (() => T) | Provider<T>;

--- a/packages/node-http-handler/src/get-transformed-headers.ts
+++ b/packages/node-http-handler/src/get-transformed-headers.ts
@@ -1,5 +1,5 @@
-import { HeaderBag } from "@smithy/types";
-import { IncomingHttpHeaders } from "http2";
+import type { HeaderBag } from "@smithy/types";
+import type { IncomingHttpHeaders } from "http2";
 
 const getTransformedHeaders = (headers: IncomingHttpHeaders) => {
   const transformedHeaders: HeaderBag = {};

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -1,8 +1,10 @@
 import { AbortController } from "@smithy/abort-controller";
 import { HttpRequest } from "@smithy/protocol-http";
-import http, { Server as HttpServer } from "http";
-import https, { Server as HttpsServer } from "https";
-import { AddressInfo } from "net";
+import type { Server as HttpServer } from "http";
+import http from "http";
+import type { Server as HttpsServer } from "https";
+import https from "https";
+import type { AddressInfo } from "net";
 
 import { NodeHttpHandler } from "./node-http-handler";
 import { ReadFromBuffers } from "./readable.mock";

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -1,8 +1,10 @@
-import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
+import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
-import { HttpHandlerOptions, Provider } from "@smithy/types";
+import type { HttpHandlerOptions, Provider } from "@smithy/types";
 import { Agent as hAgent, request as hRequest } from "http";
-import { Agent as hsAgent, request as hsRequest, RequestOptions } from "https";
+import type { RequestOptions } from "https";
+import { Agent as hsAgent, request as hsRequest } from "https";
 
 import { NODEJS_TIMEOUT_ERROR_CODES } from "./constants";
 import { getTransformedHeaders } from "./get-transformed-headers";

--- a/packages/node-http-handler/src/node-http2-connection-manager.ts
+++ b/packages/node-http-handler/src/node-http2-connection-manager.ts
@@ -1,7 +1,8 @@
-import { RequestContext } from "@smithy/types";
-import { ConnectConfiguration } from "@smithy/types";
-import { ConnectionManager, ConnectionManagerConfiguration } from "@smithy/types";
-import http2, { ClientHttp2Session } from "http2";
+import type { RequestContext } from "@smithy/types";
+import type { ConnectConfiguration } from "@smithy/types";
+import type { ConnectionManager, ConnectionManagerConfiguration } from "@smithy/types";
+import type { ClientHttp2Session } from "http2";
+import http2 from "http2";
 
 import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
 

--- a/packages/node-http-handler/src/node-http2-connection-pool.ts
+++ b/packages/node-http-handler/src/node-http2-connection-pool.ts
@@ -1,5 +1,5 @@
-import { ConnectionPool } from "@smithy/types";
-import { ClientHttp2Session } from "http2";
+import type { ConnectionPool } from "@smithy/types";
+import type { ClientHttp2Session } from "http2";
 
 export class NodeHttp2ConnectionPool implements ConnectionPool<ClientHttp2Session> {
   private sessions: ClientHttp2Session[] = [];

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -1,12 +1,15 @@
 import { AbortController } from "@smithy/abort-controller";
-import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { HttpResponse } from "@smithy/protocol-http";
+import { HttpRequest } from "@smithy/protocol-http";
 import { rejects } from "assert";
-import http2, { ClientHttp2Session, ClientHttp2Stream, constants, Http2Server, Http2Stream } from "http2";
+import type { ClientHttp2Session, ClientHttp2Stream, Http2Server, Http2Stream } from "http2";
+import http2, { constants } from "http2";
 import { Duplex } from "stream";
 import { promisify } from "util";
 
 import { NodeHttp2ConnectionPool } from "./node-http2-connection-pool";
-import { NodeHttp2Handler, NodeHttp2HandlerOptions } from "./node-http2-handler";
+import type { NodeHttp2HandlerOptions } from "./node-http2-handler";
+import { NodeHttp2Handler } from "./node-http2-handler";
 import { createMockHttp2Server, createResponseFunction, createResponseFunctionWithDelay } from "./server.mock";
 
 describe(NodeHttp2Handler.name, () => {

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -1,7 +1,9 @@
-import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
+import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
-import { ConnectConfiguration, HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
-import { ClientHttp2Session, constants } from "http2";
+import type { ConnectConfiguration, HttpHandlerOptions, Provider, RequestContext } from "@smithy/types";
+import type { ClientHttp2Session } from "http2";
+import { constants } from "http2";
 
 import { getTransformedHeaders } from "./get-transformed-headers";
 import { NodeHttp2ConnectionManager } from "./node-http2-connection-manager";

--- a/packages/node-http-handler/src/readable.mock.ts
+++ b/packages/node-http-handler/src/readable.mock.ts
@@ -1,4 +1,5 @@
-import { Readable, ReadableOptions } from "stream";
+import type { ReadableOptions } from "stream";
+import { Readable } from "stream";
 
 export interface ReadFromBuffersOptions extends ReadableOptions {
   buffers: Buffer[];

--- a/packages/node-http-handler/src/server.mock.ts
+++ b/packages/node-http-handler/src/server.mock.ts
@@ -1,8 +1,11 @@
-import { HeaderBag, HttpResponse } from "@smithy/types";
+import type { HeaderBag, HttpResponse } from "@smithy/types";
 import { readFileSync } from "fs";
-import { createServer as createHttpServer, IncomingMessage, Server as HttpServer, ServerResponse } from "http";
-import { createServer as createHttp2Server, Http2Server } from "http2";
-import { createServer as createHttpsServer, Server as HttpsServer } from "https";
+import type { IncomingMessage, Server as HttpServer, ServerResponse } from "http";
+import { createServer as createHttpServer } from "http";
+import type { Http2Server } from "http2";
+import { createServer as createHttp2Server } from "http2";
+import type { Server as HttpsServer } from "https";
+import { createServer as createHttpsServer } from "https";
 import { join } from "path";
 import { Readable } from "stream";
 

--- a/packages/node-http-handler/src/set-connection-timeout.ts
+++ b/packages/node-http-handler/src/set-connection-timeout.ts
@@ -1,5 +1,5 @@
-import { ClientRequest } from "http";
-import { Socket } from "net";
+import type { ClientRequest } from "http";
+import type { Socket } from "net";
 
 export const setConnectionTimeout = (request: ClientRequest, reject: (err: Error) => void, timeoutInMs = 0) => {
   if (!timeoutInMs) {

--- a/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.spec.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { ClientRequest } from "http";
+import type { ClientRequest } from "http";
 import { Socket } from "net";
 
 import { setSocketKeepAlive } from "./set-socket-keep-alive";

--- a/packages/node-http-handler/src/set-socket-keep-alive.ts
+++ b/packages/node-http-handler/src/set-socket-keep-alive.ts
@@ -1,4 +1,4 @@
-import { ClientRequest } from "http";
+import type { ClientRequest } from "http";
 
 export interface SocketKeepAliveOptions {
   keepAlive: boolean;

--- a/packages/node-http-handler/src/set-socket-timeout.ts
+++ b/packages/node-http-handler/src/set-socket-timeout.ts
@@ -1,4 +1,4 @@
-import { ClientRequest } from "http";
+import type { ClientRequest } from "http";
 
 export const setSocketTimeout = (request: ClientRequest, reject: (err: Error) => void, timeoutInMs = 0) => {
   request.setTimeout(timeoutInMs, () => {

--- a/packages/node-http-handler/src/stream-collector/index.ts
+++ b/packages/node-http-handler/src/stream-collector/index.ts
@@ -1,5 +1,5 @@
-import { StreamCollector } from "@smithy/types";
-import { Readable } from "stream";
+import type { StreamCollector } from "@smithy/types";
+import type { Readable } from "stream";
 
 import { Collector } from "./collector";
 

--- a/packages/node-http-handler/src/stream-collector/readable.mock.ts
+++ b/packages/node-http-handler/src/stream-collector/readable.mock.ts
@@ -1,4 +1,5 @@
-import { Readable, ReadableOptions } from "stream";
+import type { ReadableOptions } from "stream";
+import { Readable } from "stream";
 
 export interface ReadFromBuffersOptions extends ReadableOptions {
   buffers: Buffer[];

--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -1,6 +1,6 @@
-import { HttpRequest } from "@smithy/types";
-import { ClientRequest } from "http";
-import { ClientHttp2Stream } from "http2";
+import type { HttpRequest } from "@smithy/types";
+import type { ClientRequest } from "http";
+import type { ClientHttp2Stream } from "http2";
 import { Readable } from "stream";
 
 const MIN_WAIT_TIME = 1000;

--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 import { ProviderError } from "./ProviderError";
 

--- a/packages/property-provider/src/fromStatic.ts
+++ b/packages/property-provider/src/fromStatic.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -1,4 +1,4 @@
-import { MemoizedProvider, Provider } from "@smithy/types";
+import type { MemoizedProvider, Provider } from "@smithy/types";
 
 interface MemoizeOverload {
   /**

--- a/packages/protocol-http/src/Field.ts
+++ b/packages/protocol-http/src/Field.ts
@@ -1,4 +1,5 @@
-import { FieldOptions, FieldPosition } from "@smithy/types";
+import type { FieldOptions } from "@smithy/types";
+import { FieldPosition } from "@smithy/types";
 
 /**
  * A name-value pair representing a single field

--- a/packages/protocol-http/src/Fields.ts
+++ b/packages/protocol-http/src/Fields.ts
@@ -1,6 +1,6 @@
-import { FieldPosition } from "@smithy/types";
+import type { FieldPosition } from "@smithy/types";
 
-import { Field } from "./Field";
+import type { Field } from "./Field";
 
 export type FieldsOptions = { fields?: Field[]; encoding?: string };
 

--- a/packages/protocol-http/src/extensions/httpExtensionConfiguration.ts
+++ b/packages/protocol-http/src/extensions/httpExtensionConfiguration.ts
@@ -1,4 +1,4 @@
-import { HttpHandler } from "../httpHandler";
+import type { HttpHandler } from "../httpHandler";
 
 /**
  * @internal

--- a/packages/protocol-http/src/httpHandler.ts
+++ b/packages/protocol-http/src/httpHandler.ts
@@ -1,7 +1,7 @@
-import { HttpHandlerOptions, RequestHandler } from "@smithy/types";
+import type { HttpHandlerOptions, RequestHandler } from "@smithy/types";
 
-import { HttpRequest } from "./httpRequest";
-import { HttpResponse } from "./httpResponse";
+import type { HttpRequest } from "./httpRequest";
+import type { HttpResponse } from "./httpResponse";
 
 /**
  * @internal

--- a/packages/protocol-http/src/httpRequest.ts
+++ b/packages/protocol-http/src/httpRequest.ts
@@ -1,4 +1,4 @@
-import { HeaderBag, HttpMessage, HttpRequest as IHttpRequest, QueryParameterBag, URI } from "@smithy/types";
+import type { HeaderBag, HttpMessage, HttpRequest as IHttpRequest, QueryParameterBag, URI } from "@smithy/types";
 
 type HttpRequestOptions = Partial<HttpMessage> & Partial<URI> & { method?: string };
 

--- a/packages/protocol-http/src/httpResponse.ts
+++ b/packages/protocol-http/src/httpResponse.ts
@@ -1,4 +1,4 @@
-import { HeaderBag, HttpMessage, HttpResponse as IHttpResponse } from "@smithy/types";
+import type { HeaderBag, HttpMessage, HttpResponse as IHttpResponse } from "@smithy/types";
 
 type HttpResponseOptions = Partial<HttpMessage> & {
   statusCode: number;

--- a/packages/protocol-http/src/types.ts
+++ b/packages/protocol-http/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FieldOptions as __FieldOptions,
   FieldPosition as __FieldPosition,
   HeaderBag as __HeaderBag,

--- a/packages/querystring-builder/src/index.ts
+++ b/packages/querystring-builder/src/index.ts
@@ -1,4 +1,4 @@
-import { QueryParameterBag } from "@smithy/types";
+import type { QueryParameterBag } from "@smithy/types";
 import { escapeUri } from "@smithy/util-uri-escape";
 
 /**

--- a/packages/querystring-parser/src/index.spec.ts
+++ b/packages/querystring-parser/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { QueryParameterBag } from "@smithy/types";
+import type { QueryParameterBag } from "@smithy/types";
 
 import { parseQueryString } from "./";
 

--- a/packages/querystring-parser/src/index.ts
+++ b/packages/querystring-parser/src/index.ts
@@ -1,4 +1,4 @@
-import { QueryParameterBag } from "@smithy/types";
+import type { QueryParameterBag } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/service-client-documentation-generator/src/index.ts
+++ b/packages/service-client-documentation-generator/src/index.ts
@@ -1,4 +1,5 @@
-import { Application, ParameterType } from "typedoc";
+import type { Application } from "typedoc";
+import { ParameterType } from "typedoc";
 
 import { SdkClientTocPlugin } from "./sdk-client-toc-plugin";
 

--- a/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -1,19 +1,21 @@
 import { dirname } from "path";
-import {
-  BindOption,
-  ContainerReflection,
+import type {
   Context,
-  Converter,
   DeclarationReflection,
   Logger,
   Options,
   ProjectReflection,
   ReferenceType,
+  Renderer,
+} from "typedoc";
+import {
+  BindOption,
+  ContainerReflection,
+  Converter,
   ReflectionCategory,
   ReflectionFlag,
   ReflectionGroup,
   ReflectionKind,
-  Renderer,
 } from "typedoc";
 
 import { isClientModel } from "./utils";

--- a/packages/service-client-documentation-generator/src/utils.ts
+++ b/packages/service-client-documentation-generator/src/utils.ts
@@ -1,5 +1,5 @@
 import { sep } from "path";
-import { Reflection } from "typedoc";
+import type { Reflection } from "typedoc";
 
 /**
  * @internal

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { RetryableTrait, SdkError } from "@smithy/types";
+import type { RetryableTrait, SdkError } from "@smithy/types";
 
 import {
   CLOCK_SKEW_ERROR_CODES,

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@smithy/types";
+import type { SdkError } from "@smithy/types";
 
 import {
   CLOCK_SKEW_ERROR_CODES,

--- a/packages/shared-ini-file-loader/src/getProfileData.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
 const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/;
 

--- a/packages/shared-ini-file-loader/src/getSsoSessionData.ts
+++ b/packages/shared-ini-file-loader/src/getSsoSessionData.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
 const ssoSessionKeyRegex = /^sso-session\s(["'])?([^\1]+)\1$/;
 

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -1,4 +1,4 @@
-import { SharedConfigFiles } from "@smithy/types";
+import type { SharedConfigFiles } from "@smithy/types";
 
 import { getConfigFilepath } from "./getConfigFilepath";
 import { getCredentialsFilepath } from "./getCredentialsFilepath";

--- a/packages/shared-ini-file-loader/src/loadSsoSessionData.ts
+++ b/packages/shared-ini-file-loader/src/loadSsoSessionData.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
 import { getConfigFilepath } from "./getConfigFilepath";
 import { getSsoSessionData } from "./getSsoSessionData";

--- a/packages/shared-ini-file-loader/src/mergeConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/mergeConfigFiles.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
 /**
  * Merge multiple profile config files such that settings each file are kept together

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,6 +1,7 @@
-import { ParsedIniData } from "@smithy/types";
+import type { ParsedIniData } from "@smithy/types";
 
-import { loadSharedConfigFiles, SharedConfigInit } from "./loadSharedConfigFiles";
+import type { SharedConfigInit } from "./loadSharedConfigFiles";
+import { loadSharedConfigFiles } from "./loadSharedConfigFiles";
 import { mergeConfigFiles } from "./mergeConfigFiles";
 
 export interface SourceProfileInit extends SharedConfigInit {

--- a/packages/shared-ini-file-loader/src/types.ts
+++ b/packages/shared-ini-file-loader/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ParsedIniData as __ParsedIniData,
   Profile as __Profile,
   SharedConfigFiles as __SharedConfigFiles,

--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { HttpRequest } from "@smithy/protocol-http";
-import { AwsCredentialIdentity, SignableMessage, TimestampHeaderValue } from "@smithy/types";
+import type { AwsCredentialIdentity, SignableMessage, TimestampHeaderValue } from "@smithy/types";
 
 import {
   ALGORITHM_IDENTIFIER,

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -1,5 +1,5 @@
 import { HeaderMarshaller } from "@smithy/eventstream-codec";
-import {
+import type {
   AwsCredentialIdentity,
   ChecksumConstructor,
   DateInput,

--- a/packages/signature-v4/src/cloneRequest.spec.ts
+++ b/packages/signature-v4/src/cloneRequest.spec.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, QueryParameterBag } from "@smithy/types";
+import type { HttpRequest, QueryParameterBag } from "@smithy/types";
 
 import { cloneRequest } from "./cloneRequest";
 

--- a/packages/signature-v4/src/cloneRequest.ts
+++ b/packages/signature-v4/src/cloneRequest.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, QueryParameterBag } from "@smithy/types";
+import type { HttpRequest, QueryParameterBag } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/signature-v4/src/credentialDerivation.spec.ts
+++ b/packages/signature-v4/src/credentialDerivation.spec.ts
@@ -1,5 +1,5 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
-import { AwsCredentialIdentity } from "@smithy/types";
+import type { AwsCredentialIdentity } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 
 import { clearCredentialCache, createScope, getSigningKey } from "./credentialDerivation";

--- a/packages/signature-v4/src/credentialDerivation.ts
+++ b/packages/signature-v4/src/credentialDerivation.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialIdentity, ChecksumConstructor, HashConstructor, SourceData } from "@smithy/types";
+import type { AwsCredentialIdentity, ChecksumConstructor, HashConstructor, SourceData } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUint8Array } from "@smithy/util-utf8";
 

--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@smithy/protocol-http";
-import { HeaderBag } from "@smithy/types";
+import type { HeaderBag } from "@smithy/types";
 
 import { ALWAYS_UNSIGNABLE_HEADERS } from "./constants";
 import { getCanonicalHeaders } from "./getCanonicalHeaders";

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -1,4 +1,4 @@
-import { HeaderBag, HttpRequest } from "@smithy/types";
+import type { HeaderBag, HttpRequest } from "@smithy/types";
 
 import { ALWAYS_UNSIGNABLE_HEADERS, PROXY_HEADER_PATTERN, SEC_HEADER_PATTERN } from "./constants";
 

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/types";
 import { escapeUri } from "@smithy/util-uri-escape";
 
 import { SIGNATURE_HEADER } from "./constants";

--- a/packages/signature-v4/src/getPayloadHash.ts
+++ b/packages/signature-v4/src/getPayloadHash.ts
@@ -1,5 +1,5 @@
 import { isArrayBuffer } from "@smithy/is-array-buffer";
-import { ChecksumConstructor, HashConstructor, HttpRequest } from "@smithy/types";
+import type { ChecksumConstructor, HashConstructor, HttpRequest } from "@smithy/types";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUint8Array } from "@smithy/util-utf8";
 

--- a/packages/signature-v4/src/headerUtil.ts
+++ b/packages/signature-v4/src/headerUtil.ts
@@ -1,4 +1,4 @@
-import { HeaderBag } from "@smithy/types";
+import type { HeaderBag } from "@smithy/types";
 
 export const hasHeader = (soughtHeader: string, headers: HeaderBag): boolean => {
   soughtHeader = soughtHeader.toLowerCase();

--- a/packages/signature-v4/src/moveHeadersToQuery.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, QueryParameterBag } from "@smithy/types";
+import type { HttpRequest, QueryParameterBag } from "@smithy/types";
 
 import { cloneRequest } from "./cloneRequest";
 

--- a/packages/signature-v4/src/prepareRequest.ts
+++ b/packages/signature-v4/src/prepareRequest.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/types";
 
 import { cloneRequest } from "./cloneRequest";
 import { GENERATED_HEADERS } from "./constants";

--- a/packages/signature-v4/src/suite.fixture.ts
+++ b/packages/signature-v4/src/suite.fixture.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from "@smithy/types";
+import type { HttpRequest } from "@smithy/types";
 
 export interface TestCase {
   name: string;

--- a/packages/smithy-client/src/NoOpLogger.ts
+++ b/packages/smithy-client/src/NoOpLogger.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@smithy/types";
+import type { Logger } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/smithy-client/src/client.ts
+++ b/packages/smithy-client/src/client.ts
@@ -1,5 +1,5 @@
 import { constructStack } from "@smithy/middleware-stack";
-import { Client as IClient, Command, MetadataBearer, MiddlewareStack, RequestHandler } from "@smithy/types";
+import type { Client as IClient, Command, MetadataBearer, MiddlewareStack, RequestHandler } from "@smithy/types";
 
 /**
  * @public

--- a/packages/smithy-client/src/collect-stream-body.ts
+++ b/packages/smithy-client/src/collect-stream-body.ts
@@ -1,4 +1,4 @@
-import { SerdeContext } from "@smithy/types";
+import type { SerdeContext } from "@smithy/types";
 import { Uint8ArrayBlobAdapter } from "@smithy/util-stream";
 
 /**

--- a/packages/smithy-client/src/command.ts
+++ b/packages/smithy-client/src/command.ts
@@ -1,5 +1,5 @@
 import { constructStack } from "@smithy/middleware-stack";
-import { Command as ICommand, Handler, MetadataBearer, MiddlewareStack as IMiddlewareStack } from "@smithy/types";
+import type { Command as ICommand, Handler, MetadataBearer, MiddlewareStack as IMiddlewareStack } from "@smithy/types";
 
 /**
  * @public

--- a/packages/smithy-client/src/create-aggregated-client.ts
+++ b/packages/smithy-client/src/create-aggregated-client.ts
@@ -1,4 +1,4 @@
-import { Client } from "./client";
+import type { Client } from "./client";
 
 /**
  * @internal

--- a/packages/smithy-client/src/default-error-handler.ts
+++ b/packages/smithy-client/src/default-error-handler.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, ResponseMetadata } from "@smithy/types";
+import type { HttpResponse, ResponseMetadata } from "@smithy/types";
 
 import { decorateServiceException } from "./exceptions";
 

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -1,4 +1,5 @@
-import { decorateServiceException, ExceptionOptionType, ServiceException } from "./exceptions";
+import type { ExceptionOptionType } from "./exceptions";
+import { decorateServiceException, ServiceException } from "./exceptions";
 
 it("ServiceException extends from Error", () => {
   expect(

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyException } from "@smithy/types";
+import type { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyException } from "@smithy/types";
 
 /**
  * The type of the exception class constructor parameter. The returned type contains the properties

--- a/packages/smithy-client/src/extensions/defaultExtensionConfiguration.ts
+++ b/packages/smithy-client/src/extensions/defaultExtensionConfiguration.ts
@@ -1,7 +1,9 @@
 import type { DefaultExtensionConfiguration } from "@smithy/types";
 
-import { getChecksumConfiguration, PartialChecksumRuntimeConfigType, resolveChecksumRuntimeConfig } from "./checksum";
-import { getRetryConfiguration, PartialRetryRuntimeConfigType, resolveRetryRuntimeConfig } from "./retry";
+import type { PartialChecksumRuntimeConfigType } from "./checksum";
+import { getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
+import type { PartialRetryRuntimeConfigType } from "./retry";
+import { getRetryConfiguration, resolveRetryRuntimeConfig } from "./retry";
 
 /**
  * @internal

--- a/packages/smithy-client/src/extensions/retry.ts
+++ b/packages/smithy-client/src/extensions/retry.ts
@@ -1,4 +1,4 @@
-import { Provider, RetryStrategy, RetryStrategyConfiguration, RetryStrategyV2 } from "@smithy/types";
+import type { Provider, RetryStrategy, RetryStrategyConfiguration, RetryStrategyV2 } from "@smithy/types";
 
 export type PartialRetryRuntimeConfigType = Partial<{ retryStrategy: Provider<RetryStrategyV2 | RetryStrategy> }>;
 

--- a/packages/smithy-client/src/object-mapping.spec.ts
+++ b/packages/smithy-client/src/object-mapping.spec.ts
@@ -1,4 +1,5 @@
-import { map, ObjectMappingInstructions, SourceMappingInstructions, take } from "./object-mapping";
+import type { ObjectMappingInstructions, SourceMappingInstructions } from "./object-mapping";
+import { map, take } from "./object-mapping";
 
 describe("object mapping", () => {
   const example: ObjectMappingInstructions = {

--- a/packages/types/src/blob/blob-payload-input-types.ts
+++ b/packages/types/src/blob/blob-payload-input-types.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import type { Readable } from "stream";
 
 /**
  * @public

--- a/packages/types/src/checksum.ts
+++ b/packages/types/src/checksum.ts
@@ -1,4 +1,4 @@
-import { SourceData } from "./crypto";
+import type { SourceData } from "./crypto";
 
 /**
  * @public

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,7 +1,7 @@
-import { Command } from "./command";
-import { MiddlewareStack } from "./middleware";
-import { MetadataBearer } from "./response";
-import { Exact } from "./util";
+import type { Command } from "./command";
+import type { MiddlewareStack } from "./middleware";
+import type { MetadataBearer } from "./response";
+import type { Exact } from "./util";
 
 /**
  * @public

--- a/packages/types/src/command.ts
+++ b/packages/types/src/command.ts
@@ -1,5 +1,5 @@
-import { Handler, MiddlewareStack } from "./middleware";
-import { MetadataBearer } from "./response";
+import type { Handler, MiddlewareStack } from "./middleware";
+import type { MetadataBearer } from "./response";
 
 /**
  * @public

--- a/packages/types/src/connection/manager.ts
+++ b/packages/types/src/connection/manager.ts
@@ -1,5 +1,5 @@
-import { RequestContext } from "../transfer";
-import { ConnectConfiguration } from "./config";
+import type { RequestContext } from "../transfer";
+import type { ConnectConfiguration } from "./config";
 
 export interface ConnectionManagerConfiguration {
   /**

--- a/packages/types/src/encode.ts
+++ b/packages/types/src/encode.ts
@@ -1,4 +1,4 @@
-import { Message } from "./eventStream";
+import type { Message } from "./eventStream";
 
 export interface MessageEncoder {
   encode(message: Message): Uint8Array;

--- a/packages/types/src/endpoint.ts
+++ b/packages/types/src/endpoint.ts
@@ -1,4 +1,4 @@
-import { AuthScheme } from "./auth";
+import type { AuthScheme } from "./auth";
 
 /**
  * @public

--- a/packages/types/src/endpoints/EndpointRuleObject.ts
+++ b/packages/types/src/endpoints/EndpointRuleObject.ts
@@ -1,5 +1,5 @@
-import { EndpointObjectProperty } from "../endpoint";
-import { ConditionObject, Expression } from "./shared";
+import type { EndpointObjectProperty } from "../endpoint";
+import type { ConditionObject, Expression } from "./shared";
 
 export type EndpointObjectProperties = Record<string, EndpointObjectProperty>;
 export type EndpointObjectHeaders = Record<string, Expression[]>;

--- a/packages/types/src/endpoints/ErrorRuleObject.ts
+++ b/packages/types/src/endpoints/ErrorRuleObject.ts
@@ -1,4 +1,4 @@
-import { ConditionObject, Expression } from "./shared";
+import type { ConditionObject, Expression } from "./shared";
 
 export type ErrorRuleObject = {
   type: "error";

--- a/packages/types/src/endpoints/RuleSetObject.ts
+++ b/packages/types/src/endpoints/RuleSetObject.ts
@@ -1,4 +1,4 @@
-import { RuleSetRules } from "./TreeRuleObject";
+import type { RuleSetRules } from "./TreeRuleObject";
 
 export type DeprecatedObject = {
   message?: string;

--- a/packages/types/src/endpoints/TreeRuleObject.ts
+++ b/packages/types/src/endpoints/TreeRuleObject.ts
@@ -1,6 +1,6 @@
-import { EndpointRuleObject } from "./EndpointRuleObject";
-import { ErrorRuleObject } from "./ErrorRuleObject";
-import { ConditionObject } from "./shared";
+import type { EndpointRuleObject } from "./EndpointRuleObject";
+import type { ErrorRuleObject } from "./ErrorRuleObject";
+import type { ConditionObject } from "./shared";
 
 export type RuleSetRules = Array<EndpointRuleObject | ErrorRuleObject | TreeRuleObject>;
 

--- a/packages/types/src/endpoints/shared.ts
+++ b/packages/types/src/endpoints/shared.ts
@@ -1,4 +1,4 @@
-import { Logger } from "../logger";
+import type { Logger } from "../logger";
 
 export type ReferenceObject = { ref: string };
 

--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -1,11 +1,11 @@
-import { HttpRequest } from "./http";
-import {
+import type { HttpRequest } from "./http";
+import type {
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
   HandlerExecutionContext,
 } from "./middleware";
-import { MetadataBearer } from "./response";
+import type { MetadataBearer } from "./response";
 /**
  * @public
  *

--- a/packages/types/src/extensions/checksum.ts
+++ b/packages/types/src/extensions/checksum.ts
@@ -1,5 +1,5 @@
-import { ChecksumConstructor } from "../checksum";
-import { HashConstructor } from "../crypto";
+import type { ChecksumConstructor } from "../checksum";
+import type { HashConstructor } from "../crypto";
 
 /**
  * @internal

--- a/packages/types/src/extensions/defaultClientConfiguration.ts
+++ b/packages/types/src/extensions/defaultClientConfiguration.ts
@@ -1,4 +1,5 @@
-import { ChecksumConfiguration, getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
+import type { ChecksumConfiguration } from "./checksum";
+import { getChecksumConfiguration, resolveChecksumRuntimeConfig } from "./checksum";
 
 /**
  * @deprecated will be replaced by DefaultExtensionConfiguration.

--- a/packages/types/src/extensions/defaultExtensionConfiguration.ts
+++ b/packages/types/src/extensions/defaultExtensionConfiguration.ts
@@ -1,5 +1,5 @@
-import { ChecksumConfiguration } from "./checksum";
-import { RetryStrategyConfiguration } from "./retry";
+import type { ChecksumConfiguration } from "./checksum";
+import type { RetryStrategyConfiguration } from "./retry";
 
 /**
  * @internal

--- a/packages/types/src/extensions/retry.ts
+++ b/packages/types/src/extensions/retry.ts
@@ -1,5 +1,5 @@
-import { RetryStrategyV2 } from "../retry";
-import { Provider, RetryStrategy } from "../util";
+import type { RetryStrategyV2 } from "../retry";
+import type { Provider, RetryStrategy } from "../util";
 
 /**
  * A configuration interface with methods called by runtime extension

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -1,5 +1,5 @@
-import { AbortSignal } from "./abort";
-import { URI } from "./uri";
+import type { AbortSignal } from "./abort";
+import type { URI } from "./uri";
 
 /**
  * @public

--- a/packages/types/src/identity/awsCredentialIdentity.ts
+++ b/packages/types/src/identity/awsCredentialIdentity.ts
@@ -1,4 +1,4 @@
-import { Identity, IdentityProvider } from "./identity";
+import type { Identity, IdentityProvider } from "./identity";
 
 /**
  * @public

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,7 +1,7 @@
-import { AuthScheme, HttpAuthDefinition } from "./auth";
-import { EndpointV2 } from "./endpoint";
-import { Logger } from "./logger";
-import { UserAgent } from "./util";
+import type { AuthScheme, HttpAuthDefinition } from "./auth";
+import type { EndpointV2 } from "./endpoint";
+import type { Logger } from "./logger";
+import type { UserAgent } from "./util";
 
 /**
  * @public

--- a/packages/types/src/pagination.ts
+++ b/packages/types/src/pagination.ts
@@ -1,4 +1,4 @@
-import { Client } from "./client";
+import type { Client } from "./client";
 
 /**
  * @public

--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -1,6 +1,6 @@
-import { Endpoint } from "./http";
-import { RequestHandler } from "./transfer";
-import { Decoder, Encoder, Provider } from "./util";
+import type { Endpoint } from "./http";
+import type { RequestHandler } from "./transfer";
+import type { Decoder, Encoder, Provider } from "./util";
 
 /**
  * @public

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -1,5 +1,5 @@
-import { HttpResponse } from "./http";
-import { MetadataBearer } from "./response";
+import type { HttpResponse } from "./http";
+import type { MetadataBearer } from "./response";
 
 /**
  * @public

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -1,5 +1,5 @@
-import { Message } from "./eventStream";
-import { HttpRequest } from "./http";
+import type { Message } from "./eventStream";
+import type { HttpRequest } from "./http";
 
 /**
  * @public

--- a/packages/types/src/stream.ts
+++ b/packages/types/src/stream.ts
@@ -1,6 +1,6 @@
-import { ChecksumConstructor } from "./checksum";
-import { HashConstructor, StreamHasher } from "./crypto";
-import { BodyLengthCalculator, Encoder } from "./util";
+import type { ChecksumConstructor } from "./checksum";
+import type { HashConstructor, StreamHasher } from "./crypto";
+import type { BodyLengthCalculator, Encoder } from "./util";
 
 /**
  * @public

--- a/packages/types/src/uri.ts
+++ b/packages/types/src/uri.ts
@@ -1,4 +1,4 @@
-import { QueryParameterBag } from "./http";
+import type { QueryParameterBag } from "./http";
 
 /**
  * @internal

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -1,6 +1,6 @@
-import { Endpoint } from "./http";
-import { FinalizeHandler, FinalizeHandlerArguments, FinalizeHandlerOutput } from "./middleware";
-import { MetadataBearer } from "./response";
+import type { Endpoint } from "./http";
+import type { FinalizeHandler, FinalizeHandlerArguments, FinalizeHandlerOutput } from "./middleware";
+import type { MetadataBearer } from "./response";
 
 /**
  * @public

--- a/packages/types/src/waiter.ts
+++ b/packages/types/src/waiter.ts
@@ -1,4 +1,4 @@
-import { AbortController } from "./abort";
+import type { AbortController } from "./abort";
 
 /**
  * @public

--- a/packages/url-parser/src/index.spec.ts
+++ b/packages/url-parser/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { Endpoint } from "@smithy/types";
+import type { Endpoint } from "@smithy/types";
 
 import { parseUrl } from ".";
 

--- a/packages/url-parser/src/index.ts
+++ b/packages/url-parser/src/index.ts
@@ -1,5 +1,5 @@
 import { parseQueryString } from "@smithy/querystring-parser";
-import { Endpoint, QueryParameterBag, UrlParser } from "@smithy/types";
+import type { Endpoint, QueryParameterBag, UrlParser } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/util-defaults-mode-node/src/defaultsModeConfig.ts
+++ b/packages/util-defaults-mode-node/src/defaultsModeConfig.ts
@@ -1,4 +1,4 @@
-import { LoadedConfigSelectors } from "@smithy/node-config-provider";
+import type { LoadedConfigSelectors } from "@smithy/node-config-provider";
 import type { DefaultsMode } from "@smithy/smithy-client";
 
 const AWS_DEFAULTS_MODE_ENV = "AWS_DEFAULTS_MODE";

--- a/packages/util-middleware/src/getSmithyContext.ts
+++ b/packages/util-middleware/src/getSmithyContext.ts
@@ -1,4 +1,5 @@
-import { HandlerExecutionContext, SMITHY_CONTEXT_KEY } from "@smithy/types";
+import type { HandlerExecutionContext } from "@smithy/types";
+import { SMITHY_CONTEXT_KEY } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/util-middleware/src/normalizeProvider.ts
+++ b/packages/util-middleware/src/normalizeProvider.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@smithy/types";
+import type { Provider } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/util-retry/src/AdaptiveRetryStrategy.spec.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.spec.ts
@@ -1,10 +1,10 @@
-import { RetryErrorInfo, StandardRetryToken } from "@smithy/types";
+import type { RetryErrorInfo, StandardRetryToken } from "@smithy/types";
 
 import { AdaptiveRetryStrategy } from "./AdaptiveRetryStrategy";
 import { RETRY_MODES } from "./config";
 import { DefaultRateLimiter } from "./DefaultRateLimiter";
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
-import { RateLimiter } from "./types";
+import type { RateLimiter } from "./types";
 
 jest.mock("./StandardRetryStrategy");
 jest.mock("./DefaultRateLimiter");

--- a/packages/util-retry/src/AdaptiveRetryStrategy.ts
+++ b/packages/util-retry/src/AdaptiveRetryStrategy.ts
@@ -1,9 +1,9 @@
-import { Provider, RetryErrorInfo, RetryStrategyV2, RetryToken, StandardRetryToken } from "@smithy/types";
+import type { Provider, RetryErrorInfo, RetryStrategyV2, RetryToken, StandardRetryToken } from "@smithy/types";
 
 import { RETRY_MODES } from "./config";
 import { DefaultRateLimiter } from "./DefaultRateLimiter";
 import { StandardRetryStrategy } from "./StandardRetryStrategy";
-import { RateLimiter } from "./types";
+import type { RateLimiter } from "./types";
 
 /**
  * @public

--- a/packages/util-retry/src/DefaultRateLimiter.ts
+++ b/packages/util-retry/src/DefaultRateLimiter.ts
@@ -1,6 +1,6 @@
 import { isThrottlingError } from "@smithy/service-error-classification";
 
-import { RateLimiter } from "./types";
+import type { RateLimiter } from "./types";
 
 /**
  * @public

--- a/packages/util-retry/src/StandardRetryStrategy.spec.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.spec.ts
@@ -1,4 +1,4 @@
-import { RetryErrorInfo, RetryErrorType } from "@smithy/types";
+import type { RetryErrorInfo, RetryErrorType } from "@smithy/types";
 
 import { RETRY_MODES } from "./config";
 import { DEFAULT_RETRY_DELAY_BASE, INITIAL_RETRY_TOKENS } from "./constants";

--- a/packages/util-retry/src/StandardRetryStrategy.ts
+++ b/packages/util-retry/src/StandardRetryStrategy.ts
@@ -1,4 +1,4 @@
-import { Provider, RetryErrorInfo, RetryErrorType, RetryStrategyV2, StandardRetryToken } from "@smithy/types";
+import type { Provider, RetryErrorInfo, RetryErrorType, RetryStrategyV2, StandardRetryToken } from "@smithy/types";
 
 import { DEFAULT_MAX_ATTEMPTS, RETRY_MODES } from "./config";
 import {

--- a/packages/util-retry/src/defaultRetryBackoffStrategy.ts
+++ b/packages/util-retry/src/defaultRetryBackoffStrategy.ts
@@ -1,4 +1,4 @@
-import { StandardRetryBackoffStrategy } from "@smithy/types";
+import type { StandardRetryBackoffStrategy } from "@smithy/types";
 
 import { DEFAULT_RETRY_DELAY_BASE, MAXIMUM_RETRY_DELAY } from "./constants";
 

--- a/packages/util-retry/src/defaultRetryToken.ts
+++ b/packages/util-retry/src/defaultRetryToken.ts
@@ -1,4 +1,4 @@
-import { StandardRetryToken } from "@smithy/types";
+import type { StandardRetryToken } from "@smithy/types";
 
 import { MAXIMUM_RETRY_DELAY } from "./constants";
 

--- a/packages/util-stream-browser/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream-browser/src/getAwsChunkedEncodingStream.ts
@@ -1,4 +1,4 @@
-import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
+import type { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/util-stream-browser/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.spec.ts
@@ -1,6 +1,6 @@
 // @jest-environment jsdom
 import { streamCollector } from "@smithy/fetch-http-handler";
-import { SdkStreamMixin } from "@smithy/types";
+import type { SdkStreamMixin } from "@smithy/types";
 import { toBase64 } from "@smithy/util-base64";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUtf8 } from "@smithy/util-utf8";

--- a/packages/util-stream-browser/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.ts
@@ -1,5 +1,5 @@
 import { streamCollector } from "@smithy/fetch-http-handler";
-import { SdkStream, SdkStreamMixin } from "@smithy/types";
+import type { SdkStream, SdkStreamMixin } from "@smithy/types";
 import { toBase64 } from "@smithy/util-base64";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUtf8 } from "@smithy/util-utf8";

--- a/packages/util-stream-node/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream-node/src/getAwsChunkedEncodingStream.ts
@@ -1,4 +1,4 @@
-import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
+import type { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
 import { Readable } from "stream";
 
 /**

--- a/packages/util-stream-node/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream-node/src/sdk-stream-mixin.spec.ts
@@ -1,6 +1,7 @@
-import { SdkStreamMixin } from "@smithy/types";
+import type { SdkStreamMixin } from "@smithy/types";
 import { fromArrayBuffer } from "@smithy/util-buffer-from";
-import { PassThrough, Readable, Writable } from "stream";
+import type { Writable } from "stream";
+import { PassThrough, Readable } from "stream";
 import util from "util";
 
 import { sdkStreamMixin } from "./sdk-stream-mixin";

--- a/packages/util-stream-node/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-node/src/sdk-stream-mixin.ts
@@ -1,5 +1,5 @@
 import { streamCollector } from "@smithy/node-http-handler";
-import { SdkStream, SdkStreamMixin } from "@smithy/types";
+import type { SdkStream, SdkStreamMixin } from "@smithy/types";
 import { fromArrayBuffer } from "@smithy/util-buffer-from";
 import { Readable } from "stream";
 import { TextDecoder } from "util";

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.browser.ts
@@ -1,4 +1,4 @@
-import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
+import type { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
 
 /**
  * @internal

--- a/packages/util-stream/src/getAwsChunkedEncodingStream.ts
+++ b/packages/util-stream/src/getAwsChunkedEncodingStream.ts
@@ -1,4 +1,4 @@
-import { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
+import type { GetAwsChunkedEncodingStream, GetAwsChunkedEncodingStreamOptions } from "@smithy/types";
 import { Readable } from "stream";
 
 /**

--- a/packages/util-stream/src/sdk-stream-mixin.browser.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.browser.spec.ts
@@ -1,6 +1,6 @@
 // @jest-environment jsdom
 import { streamCollector } from "@smithy/fetch-http-handler";
-import { SdkStreamMixin } from "@smithy/types";
+import type { SdkStreamMixin } from "@smithy/types";
 import { toBase64 } from "@smithy/util-base64";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUtf8 } from "@smithy/util-utf8";

--- a/packages/util-stream/src/sdk-stream-mixin.browser.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.browser.ts
@@ -1,5 +1,5 @@
 import { streamCollector } from "@smithy/fetch-http-handler";
-import { SdkStream, SdkStreamMixin } from "@smithy/types";
+import type { SdkStream, SdkStreamMixin } from "@smithy/types";
 import { toBase64 } from "@smithy/util-base64";
 import { toHex } from "@smithy/util-hex-encoding";
 import { toUtf8 } from "@smithy/util-utf8";

--- a/packages/util-stream/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.spec.ts
@@ -1,6 +1,7 @@
-import { SdkStreamMixin } from "@smithy/types";
+import type { SdkStreamMixin } from "@smithy/types";
 import { fromArrayBuffer } from "@smithy/util-buffer-from";
-import { PassThrough, Readable, Writable } from "stream";
+import type { Writable } from "stream";
+import { PassThrough, Readable } from "stream";
 import util from "util";
 
 import { sdkStreamMixin } from "./sdk-stream-mixin";

--- a/packages/util-stream/src/sdk-stream-mixin.ts
+++ b/packages/util-stream/src/sdk-stream-mixin.ts
@@ -1,5 +1,5 @@
 import { streamCollector } from "@smithy/node-http-handler";
-import { SdkStream, SdkStreamMixin } from "@smithy/types";
+import type { SdkStream, SdkStreamMixin } from "@smithy/types";
 import { fromArrayBuffer } from "@smithy/util-buffer-from";
 import { Readable } from "stream";
 import { TextDecoder } from "util";

--- a/packages/util-stream/src/util-stream.integ.spec.ts
+++ b/packages/util-stream/src/util-stream.integ.spec.ts
@@ -1,5 +1,6 @@
-import { HttpHandler, HttpResponse } from "@smithy/protocol-http";
-import { HttpRequest as IHttpRequest } from "@smithy/types";
+import type { HttpHandler } from "@smithy/protocol-http";
+import { HttpResponse } from "@smithy/protocol-http";
+import type { HttpRequest as IHttpRequest } from "@smithy/types";
 import { Uint8ArrayBlobAdapter } from "@smithy/util-stream";
 import { requireRequestsFrom } from "@smithy/util-test";
 import { fromUtf8 } from "@smithy/util-utf8";

--- a/packages/util-waiter/src/createWaiter.spec.ts
+++ b/packages/util-waiter/src/createWaiter.spec.ts
@@ -1,6 +1,7 @@
 import { AbortController } from "@smithy/abort-controller";
 
-import { WaiterOptions, WaiterState } from "./waiter";
+import type { WaiterOptions } from "./waiter";
+import { WaiterState } from "./waiter";
 
 const mockValidate = jest.fn();
 jest.mock("./utils/validate", () => ({

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -1,8 +1,9 @@
-import { AbortSignal } from "@smithy/types";
+import type { AbortSignal } from "@smithy/types";
 
 import { runPolling } from "./poller";
 import { validateWaiterOptions } from "./utils";
-import { WaiterOptions, WaiterResult, waiterServiceDefaults, WaiterState } from "./waiter";
+import type { WaiterOptions, WaiterResult } from "./waiter";
+import { waiterServiceDefaults, WaiterState } from "./waiter";
 
 const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
   return new Promise((resolve) => {

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -2,7 +2,8 @@ import { AbortController } from "@smithy/abort-controller";
 
 import { runPolling } from "./poller";
 import { sleep } from "./utils/sleep";
-import { WaiterOptions, WaiterState } from "./waiter";
+import type { WaiterOptions } from "./waiter";
+import { WaiterState } from "./waiter";
 
 jest.mock("./utils/sleep");
 

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -1,5 +1,6 @@
 import { sleep } from "./utils/sleep";
-import { WaiterOptions, WaiterResult, WaiterState } from "./waiter";
+import type { WaiterOptions, WaiterResult } from "./waiter";
+import { WaiterState } from "./waiter";
 
 /**
  * @internal

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -1,4 +1,4 @@
-import { WaiterOptions } from "../waiter";
+import type { WaiterOptions } from "../waiter";
 import { validateWaiterOptions } from "./validate";
 
 describe(validateWaiterOptions.name, () => {

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -1,4 +1,4 @@
-import { WaiterOptions } from "../waiter";
+import type { WaiterOptions } from "../waiter";
 
 /**
  * @internal

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -1,4 +1,4 @@
-import { WaiterConfiguration as WaiterConfiguration__ } from "@smithy/types";
+import type { WaiterConfiguration as WaiterConfiguration__ } from "@smithy/types";
 
 /**
  * @internal

--- a/private/util-test/src/test-http-handler.ts
+++ b/private/util-test/src/test-http-handler.ts
@@ -1,5 +1,5 @@
-import { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { Client, HttpHandlerOptions, RequestHandler, RequestHandlerOutput } from "@smithy/types";
+import type { HttpHandler, HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { Client, HttpHandlerOptions, RequestHandler, RequestHandlerOutput } from "@smithy/types";
 
 /**
  * Instructs {@link TestHttpHandler} how to match the handled request and the expected request.

--- a/smithy-typescript-ssdk-libs/server-apigateway/src/lambda.ts
+++ b/smithy-typescript-ssdk-libs/server-apigateway/src/lambda.ts
@@ -13,9 +13,10 @@
  *  permissions and limitations under the License.
  */
 
-import { HeaderBag, HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { QueryParameterBag } from "@smithy/types";
-import {
+import type { HeaderBag, HttpResponse } from "@smithy/protocol-http";
+import { HttpRequest } from "@smithy/protocol-http";
+import type { QueryParameterBag } from "@smithy/types";
+import type {
   APIGatewayProxyEvent,
   APIGatewayProxyEventHeaders,
   APIGatewayProxyEventMultiValueHeaders,

--- a/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.ts
@@ -13,9 +13,9 @@
  *  permissions and limitations under the License.
  */
 
-import { HttpRequest } from "@smithy/protocol-http";
+import type { HttpRequest } from "@smithy/protocol-http";
 
-import { Mux, ServiceCoordinate } from "..";
+import type { Mux, ServiceCoordinate } from "..";
 
 export interface PathLiteralSegment {
   type: "path_literal";

--- a/smithy-typescript-ssdk-libs/server-common/src/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/index.ts
@@ -19,10 +19,10 @@ export * from "./errors";
 export * from "./validation";
 export * from "./unique";
 
-import { HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { SerdeContext } from "@smithy/types";
+import type { HttpRequest, HttpResponse } from "@smithy/protocol-http";
+import type { SerdeContext } from "@smithy/types";
 
-import { ServiceException } from "./errors";
+import type { ServiceException } from "./errors";
 
 export type Operation<I, O, Context = {}> = (input: I, context: Context) => Promise<O>;
 

--- a/smithy-typescript-ssdk-libs/server-common/src/unique.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/unique.spec.ts
@@ -15,7 +15,8 @@
 
 import * as util from "util";
 
-import { findDuplicates, Input } from "./unique";
+import type { Input } from "./unique";
+import { findDuplicates } from "./unique";
 
 describe("findDuplicates", () => {
   describe("finds duplicates in", () => {

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.spec.ts
@@ -13,16 +13,15 @@
  *  permissions and limitations under the License.
  */
 
-import {
+import type {
   EnumValidationFailure,
-  generateValidationMessage,
   IntegerEnumValidationFailure,
   LengthValidationFailure,
   PatternValidationFailure,
   RangeValidationFailure,
-  RequiredValidationFailure,
   UniqueItemsValidationFailure,
 } from "./index";
+import { generateValidationMessage, RequiredValidationFailure } from "./index";
 
 describe("message formatting", () => {
   it("does not return very large inputs", () => {

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/index.ts
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-import { ServiceException } from "../errors";
+import type { ServiceException } from "../errors";
 
 export * from "./validators";
 

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.spec.ts
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 
+import type { SingleConstraintValidator } from "./validators";
 import {
   CompositeValidator,
   EnumValidator,
@@ -21,7 +22,6 @@ import {
   PatternValidator,
   RangeValidator,
   SensitiveConstraintValidator,
-  SingleConstraintValidator,
   UniqueItemsValidator,
 } from "./validators";
 

--- a/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
+++ b/smithy-typescript-ssdk-libs/server-common/src/validation/validators.ts
@@ -16,16 +16,16 @@
 import { RE2 } from "re2-wasm";
 
 import { findDuplicates } from "../unique";
-import {
+import type {
   EnumValidationFailure,
   IntegerEnumValidationFailure,
   LengthValidationFailure,
   PatternValidationFailure,
   RangeValidationFailure,
-  RequiredValidationFailure,
   UniqueItemsValidationFailure,
   ValidationFailure,
 } from ".";
+import { RequiredValidationFailure } from ".";
 
 export class CompositeValidator<T> implements MultiConstraintValidator<T> {
   private readonly validators: SingleConstraintValidator<T, any>[];

--- a/smithy-typescript-ssdk-libs/server-node/src/index.spec.ts
+++ b/smithy-typescript-ssdk-libs/server-node/src/index.spec.ts
@@ -4,10 +4,11 @@
  */
 
 import { mkdtemp } from "fs/promises";
-import { createServer, IncomingMessage, request, RequestOptions, Server, ServerResponse } from "http";
+import type { IncomingMessage, RequestOptions, Server, ServerResponse } from "http";
+import { createServer, request } from "http";
 import * as os from "os";
 import * as path from "path";
-import { Readable } from "stream";
+import type { Readable } from "stream";
 
 import { convertRequest } from "./node";
 

--- a/smithy-typescript-ssdk-libs/server-node/src/node.ts
+++ b/smithy-typescript-ssdk-libs/server-node/src/node.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HeaderBag, HttpRequest, HttpResponse } from "@smithy/protocol-http";
-import { QueryParameterBag } from "@smithy/types";
-import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
-import { URL, URLSearchParams } from "url";
+import type { HeaderBag, HttpResponse } from "@smithy/protocol-http";
+import { HttpRequest } from "@smithy/protocol-http";
+import type { QueryParameterBag } from "@smithy/types";
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
+import type { URLSearchParams } from "url";
+import { URL } from "url";
 
 function convertHeaders(headers: IncomingHttpHeaders): HeaderBag {
   // TODO make this proper


### PR DESCRIPTION
this PR auto-fixes import statements to use import-type when the imported elements are types.

This is quite optional. There are some edge case benefits explained here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export

- [x] verified downlevel types does not use `import type`
