### PR TITLE
add logging to middleware stack

### DIFF
--- a/.changeset/light-foxes-repair.md
+++ b/.changeset/light-foxes-repair.md
@@ -1,0 +1,6 @@
+---
+"@smithy/middleware-stack": patch
+"@smithy/types": patch
+---
+
+add debug method to middlewareStack

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -257,10 +257,7 @@ export const constructStack = <Input extends object, Output extends object>(): M
     },
 
     identifyOnResolve(toggle?: boolean) {
-      if (typeof toggle !== "boolean") {
-        return identifyOnResolve;
-      }
-      identifyOnResolve = !!toggle;
+      if (typeof toggle === "boolean") identifyOnResolve = toggle;
       return identifyOnResolve;
     },
 

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -466,6 +466,18 @@ export interface MiddlewareStack<Input extends object, Output extends object> ex
   identify(): string[];
 
   /**
+   * @internal
+   *
+   * When an operation is called using this stack,
+   * it will log its list of middleware to the console using
+   * the identify function.
+   *
+   * @param toggle - set whether to log on resolve.
+   *                 If no argument given, returns the current value.
+   */
+  identifyOnResolve(toggle?: boolean): boolean;
+
+  /**
    * Builds a single handler function from zero or more middleware classes and
    * a core handler. The core handler is meant to send command objects to AWS
    * services and return promises that will resolve with the operation result


### PR DESCRIPTION
adds a method `identifyOnResolve(boolean): boolean` to `MiddlewareStack`.

This is useful when needing to see what order the middlewareStack resolves to. This information is not known entirely until the resolve function on the stack is called during an operation.

It can only be logged and not returned because the reference to the cloned stack used to resolve the request is inaccessible.

Example:
```js
import "@aws-sdk/signature-v4-crt";

import { S3, PutObjectCommand } from "@aws-sdk/client-s3";

const client = new S3({
  region: "us-west-2",
});

const command = new PutObjectCommand({
  Bucket: "arn:aws:s3::....:accesspoint/.....mrap",
  Key: "1",
  Body: "abcd",
});

command.middlewareStack.identifyOnResolve(true);

try {
  const response = await client.send(command);
  console.log(response);
} catch (err) {
  console.error(err);
}

client.middlewareStack.identifyOnResolve(true);
await client.listBuckets({});

```
output:
```
[
  'loggerMiddleware - initialize',
  'validateBucketNameMiddleware - initialize',
  'ssecMiddleware - initialize',
  'endpointV2Middleware - serialize',
  'serializerMiddleware - serialize',
  'contentLengthMiddleware - build',
  'addExpectContinueMiddleware - build',
  'flexibleChecksumsMiddleware - build',
  'hostHeaderMiddleware - build',
  'recursionDetectionMiddleware - build',
  'getUserAgentMiddleware - build',
  'retryMiddleware - finalizeRequest',
  'awsAuthMiddleware - after retryMiddleware',
  'getCheckContentLengthHeaderPlugin - finalizeRequest',
  'deserializerMiddleware - deserialize',
  'flexibleChecksumsResponseMiddleware - after deserializerMiddleware'
]
{
  '$metadata': {
    httpStatusCode: 200,
    requestId: '...',
    extendedRequestId: '.../...',
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  ETag: '"..."',
  ServerSideEncryption: '...',
  VersionId: '...'
}
[
  'loggerMiddleware - initialize',
  'validateBucketNameMiddleware - initialize',
  'endpointV2Middleware - serialize',
  'serializerMiddleware - serialize',
  'contentLengthMiddleware - build',
  'addExpectContinueMiddleware - build',
  'hostHeaderMiddleware - build',
  'recursionDetectionMiddleware - build',
  'getUserAgentMiddleware - build',
  'retryMiddleware - finalizeRequest',
  'awsAuthMiddleware - after retryMiddleware',
  'deserializerMiddleware - deserialize'
]
```