### PR TITLE
chore(experimentalIdentityAndAuth): refactor `HttpAuthScheme` properties to builders

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ConfigField.java
@@ -6,7 +6,9 @@
 package software.amazon.smithy.typescript.codegen;
 
 import java.util.function.Consumer;
+import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Definition of a Config field.
@@ -14,16 +16,19 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * Currently used to populate the ClientDefaults interface in `experimentalIdentityAndAuth`.
  *
  * @param name name of the config field
- * @param source writer for the type of the config field
+ * @param type whether the config field is main or auxiliary
+ * @param inputType writer for the input type of the config field
+ * @param resolvedType writer for the resolved type of the config field
  * @param docs writer for the docs of the config field
  */
 @SmithyUnstableApi
 public final record ConfigField(
     String name,
     Type type,
-    Consumer<TypeScriptWriter> source,
+    Consumer<TypeScriptWriter> inputType,
+    Consumer<TypeScriptWriter> resolvedType,
     Consumer<TypeScriptWriter> docs
-) {
+) implements ToSmithyBuilder<ConfigField> {
     /**
      * Defines the type of the config field.
      */
@@ -37,5 +42,62 @@ public final record ConfigField(
          * Specifies the property is auxiliary, e.g. {@code region} for {@code @aws.auth#sigv4}
          */
         AUXILIARY
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder()
+            .name(name)
+            .type(type)
+            .inputType(inputType)
+            .resolvedType(resolvedType)
+            .docs(docs);
+    }
+
+    public static final class Builder implements SmithyBuilder<ConfigField> {
+        private String name;
+        private Type type;
+        private Consumer<TypeScriptWriter> inputType;
+        private Consumer<TypeScriptWriter> resolvedType;
+        private Consumer<TypeScriptWriter> docs;
+
+        @Override
+        public ConfigField build() {
+            return new ConfigField(
+                SmithyBuilder.requiredState("name", name),
+                SmithyBuilder.requiredState("type", type),
+                SmithyBuilder.requiredState("inputType", inputType),
+                SmithyBuilder.requiredState("resolvedType", resolvedType),
+                SmithyBuilder.requiredState("docs", docs));
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder inputType(Consumer<TypeScriptWriter> inputType) {
+            this.inputType = inputType;
+            return this;
+        }
+
+        public Builder resolvedType(Consumer<TypeScriptWriter> resolvedType) {
+            this.resolvedType = resolvedType;
+            return this;
+        }
+
+        public Builder docs(Consumer<TypeScriptWriter> docs) {
+            this.docs = docs;
+            return this;
+        }
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -335,7 +335,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
                     httpAuthIntegration.getHttpAuthScheme().ifPresent(authScheme -> {
                         for (ConfigField configField : authScheme.getConfigFields()) {
                             writer.writeDocs(() -> writer.write("$C", configField.docs()));
-                            writer.write("$L?: $C;\n", configField.name(), configField.source());
+                            writer.write("$L?: $C;\n", configField.name(), configField.inputType());
                         }
                     });
                 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
@@ -9,7 +9,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Definition of an HttpAuthOptionProperty.
@@ -24,7 +26,7 @@ public final record HttpAuthOptionProperty(
     String name,
     Type type,
     Function<Trait, Consumer<TypeScriptWriter>> source
-) {
+) implements ToSmithyBuilder<HttpAuthOptionProperty> {
     /**
      * Defines the type of the auth option property.
      */
@@ -37,5 +39,46 @@ public final record HttpAuthOptionProperty(
          * Specifies the property should be included in {@code signingProperties}.
          */
         SIGNING
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public SmithyBuilder<HttpAuthOptionProperty> toBuilder() {
+        return builder()
+            .name(name)
+            .type(type)
+            .source(source);
+    }
+
+    public static final class Builder implements SmithyBuilder<HttpAuthOptionProperty> {
+        private String name;
+        private Type type;
+        private Function<Trait, Consumer<TypeScriptWriter>> source;
+
+        @Override
+        public HttpAuthOptionProperty build() {
+            return new HttpAuthOptionProperty(
+                SmithyBuilder.requiredState("name", name),
+                SmithyBuilder.requiredState("type", type),
+                SmithyBuilder.requiredState("source", source));
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder source(Function<Trait, Consumer<TypeScriptWriter>> source) {
+            this.source = source;
+            return this;
+        }
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeParameter.java
@@ -7,7 +7,9 @@ package software.amazon.smithy.typescript.codegen.auth.http;
 
 import java.util.function.Consumer;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
  * Definition of an HttpAuthSchemeParameter.
@@ -23,4 +25,46 @@ public final record HttpAuthSchemeParameter(
     String name,
     Consumer<TypeScriptWriter> type,
     Consumer<TypeScriptWriter> source
-) {}
+) implements ToSmithyBuilder<HttpAuthSchemeParameter> {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public SmithyBuilder<HttpAuthSchemeParameter> toBuilder() {
+        return builder()
+            .name(name)
+            .type(type)
+            .source(source);
+    }
+
+    public static final class Builder implements SmithyBuilder<HttpAuthSchemeParameter> {
+        private String name;
+        private Consumer<TypeScriptWriter> type;
+        private Consumer<TypeScriptWriter> source;
+
+        @Override
+        public HttpAuthSchemeParameter build() {
+            return new HttpAuthSchemeParameter(
+                SmithyBuilder.requiredState("name", name),
+                SmithyBuilder.requiredState("type", type),
+                SmithyBuilder.requiredState("source", source));
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder type(Consumer<TypeScriptWriter> type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder source(Consumer<TypeScriptWriter> source) {
+            this.source = source;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -46,39 +46,61 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
         return Optional.of(HttpAuthScheme.builder()
                 .schemeId(HttpApiKeyAuthTrait.ID)
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
-                .addConfigField(new ConfigField("apiKey", ConfigField.Type.MAIN, w -> {
-                    w.addImport("ApiKeyIdentity", null,
-                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    w.addImport("ApiKeyIdentityProvider", null,
-                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    w.write("ApiKeyIdentity | ApiKeyIdentityProvider");
-                }, w -> w.write("The API key to use when making requests.")))
-                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "name", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
-                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                    w.write("$S", httpApiKeyAuthTrait.getName());
-                }))
-                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "in", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
-                    w.addImport("HttpApiKeyAuthLocation", null,
-                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                    if (httpApiKeyAuthTrait.getIn().equals(Location.HEADER)) {
-                        w.write("HttpApiKeyAuthLocation.HEADER");
-                    } else if (httpApiKeyAuthTrait.getIn().equals(Location.QUERY)) {
-                        w.write("HttpApiKeyAuthLocation.QUERY");
-                    } else {
-                        throw new CodegenException("Encountered invalid `in` property on `@httpApiKeyAuth`: "
-                        + httpApiKeyAuthTrait.getIn());
-                    }
-                }))
-                .addHttpAuthOptionProperty(new HttpAuthOptionProperty(
-                    "scheme", HttpAuthOptionProperty.Type.SIGNING, t -> w -> {
-                    HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                    httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
-                        s -> w.write(s),
-                        () -> w.write("undefined"));
-                }))
+                .addConfigField(ConfigField.builder()
+                    .name("apiKey")
+                    .type(ConfigField.Type.MAIN)
+                    .docs(w -> w.write("The API key to use when making requests."))
+                    .inputType(w -> {
+                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("ApiKeyIdentity", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("ApiKeyIdentityProvider", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.write("ApiKeyIdentity | ApiKeyIdentityProvider");
+                    })
+                    .resolvedType(w -> {
+                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("ApiKeyIdentityProvider", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.write("ApiKeyIdentityProvider");
+                    })
+                    .build())
+                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
+                    .name("name")
+                    .type(HttpAuthOptionProperty.Type.SIGNING)
+                    .source(t -> w -> {
+                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                        w.write("$S", httpApiKeyAuthTrait.getName());
+                    })
+                    .build())
+                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
+                    .name("in")
+                    .type(HttpAuthOptionProperty.Type.SIGNING)
+                    .source(t -> w -> {
+                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("HttpApiKeyAuthLocation", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                        if (httpApiKeyAuthTrait.getIn().equals(Location.HEADER)) {
+                            w.write("HttpApiKeyAuthLocation.HEADER");
+                        } else if (httpApiKeyAuthTrait.getIn().equals(Location.QUERY)) {
+                            w.write("HttpApiKeyAuthLocation.QUERY");
+                        } else {
+                            throw new CodegenException("Encountered invalid `in` property on `@httpApiKeyAuth`: "
+                            + httpApiKeyAuthTrait.getIn());
+                        }
+                    })
+                    .build())
+                .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
+                    .name("scheme")
+                    .type(HttpAuthOptionProperty.Type.SIGNING)
+                    .source(t -> w -> {
+                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
+                        httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
+                            s -> w.write(s),
+                            () -> w.write("undefined"));
+                    })
+                    .build())
                 .putDefaultSigner(LanguageTarget.SHARED, HTTP_API_KEY_AUTH_SIGNER)
                 .build());
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
@@ -44,14 +44,25 @@ public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegrat
         return Optional.of(HttpAuthScheme.builder()
                 .schemeId(HttpBearerAuthTrait.ID)
                 .applicationProtocol(ApplicationProtocol.createDefaultHttpApplicationProtocol())
-                .addConfigField(new ConfigField("token", Type.MAIN, w -> {
-                    w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    w.addImport("TokenIdentity", null,
-                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    w.addImport("TokenIdentityProvider", null,
-                        TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                    w.write("TokenIdentity | TokenIdentityProvider");
-                }, w -> w.write("The token used to authenticate requests.")))
+                .addConfigField(ConfigField.builder()
+                    .name("token")
+                    .type(Type.MAIN)
+                    .docs(w -> w.write("The token used to authenticate requests."))
+                    .inputType(w -> {
+                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("TokenIdentity", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("TokenIdentityProvider", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.write("TokenIdentity | TokenIdentityProvider");
+                    })
+                    .resolvedType(w -> {
+                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addImport("TokenIdentityProvider", null,
+                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.write("TokenIdentityProvider");
+                    })
+                    .build())
                 .putDefaultSigner(LanguageTarget.SHARED, HTTP_BEARER_AUTH_SIGNER)
                 .build());
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -139,8 +139,8 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                             continue;
                         }
                         String capitalizedName = StringUtils.capitalize(configField.name());
-                        w.write("set$L($L: $C): void;", capitalizedName, configField.name(), configField.source());
-                        w.write("$L(): $C | undefined;", configField.name(), configField.source());
+                        w.write("set$L($L: $C): void;", capitalizedName, configField.name(), configField.inputType());
+                        w.write("$L(): $C | undefined;", configField.name(), configField.inputType());
                     }
                 }
             });
@@ -201,7 +201,7 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                         if (!configField.type().equals(ConfigField.Type.MAIN)) {
                             continue;
                         }
-                        w.write("$L: $C;", configField.name(), configField.source());
+                        w.write("$L: $C;", configField.name(), configField.inputType());
                     }
                 }
             });
@@ -330,9 +330,9 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                                 $L(): $C | undefined {
                                   return _$L;
                                 },""",
-                                capitalizedName, configField.name(), configField.source(),
+                                capitalizedName, configField.name(), configField.inputType(),
                                 configField.name(), configField.name(),
-                                configField.name(), configField.source(),
+                                configField.name(), configField.inputType(),
                                 configField.name());
                         }
                     }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Refactor `HttpAuthScheme` properties to builders:

- `ConfigField`
- `HttpAuthOptionProperty`
- `HttpAuthSchemeParameter`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
