### PR TITLE
feat(experimentalIdentityAndAuth): add customizing default `httpAuthSchemeProvider` and `httpAuthSchemeParametersProvider`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
@@ -31,6 +31,7 @@ public final class SupportedHttpAuthSchemesIndex {
 
     private final Map<ShapeId, HttpAuthScheme> supportedHttpAuthSchemes = new HashMap<>();
     private Optional<Symbol> defaultHttpAuthSchemeProvider = Optional.empty();
+    private Optional<Symbol> defaultHttpAuthSchemeParametersProvider = Optional.empty();
 
     /**
      * Creates an index from registered {@link HttpAuthScheme}s in {@link TypeScriptIntegration}s.
@@ -58,6 +59,18 @@ public final class SupportedHttpAuthSchemesIndex {
                         + "`");
                 }
                 defaultHttpAuthSchemeProvider = override;
+            }
+            if (httpAuthIntegration.getDefaultHttpAuthSchemeParametersProvider().isPresent()) {
+                Optional<Symbol> override =
+                    httpAuthIntegration.getDefaultHttpAuthSchemeParametersProvider();
+                if (defaultHttpAuthSchemeParametersProvider.isPresent()) {
+                    LOGGER.warning("An existing `HttpAuthSchemeParametersProvider` registration `"
+                        + defaultHttpAuthSchemeParametersProvider.get()
+                        + "` is being overwritten by `"
+                        + override.get()
+                        + "`");
+                }
+                defaultHttpAuthSchemeParametersProvider = override;
             }
         }
     }
@@ -104,5 +117,13 @@ public final class SupportedHttpAuthSchemesIndex {
      */
     public Optional<Symbol> getDefaultHttpAuthSchemeProvider() {
         return defaultHttpAuthSchemeProvider;
+    }
+
+    /**
+     * Gets the default {@code HttpAuthSchemeParametersProvider} symbol.
+     * @return an optional with the symbol or empty.
+     */
+    public Optional<Symbol> getDefaultHttpAuthSchemeParametersProvider() {
+        return defaultHttpAuthSchemeParametersProvider;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.typescript.codegen.auth.http.integration;
 
 import java.util.Optional;
+import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -33,5 +34,14 @@ public interface HttpAuthTypeScriptIntegration extends TypeScriptIntegration {
      * @param supportedHttpAuthSchemesIndex index to mutate.
      */
     default void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
+    }
+
+    /**
+     * feat(experimentalIdentityAndAuth): Register an {@link Symbol} that points to an {@code HttpAuthSchemeProvider}
+     * implementation.
+     * @return an empty optional.
+     */
+    default Optional<Symbol> getDefaultHttpAuthSchemeProvider() {
+        return Optional.empty();
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
@@ -44,4 +44,13 @@ public interface HttpAuthTypeScriptIntegration extends TypeScriptIntegration {
     default Optional<Symbol> getDefaultHttpAuthSchemeProvider() {
         return Optional.empty();
     }
+
+    /**
+     * feat(experimentalIdentityAndAuth): Register an {@link Symbol} that points to an
+     * {@code HttpAuthSchemeParametersProvider} implementation.
+     * @return an empty optional.
+     */
+    default Optional<Symbol> getDefaultHttpAuthSchemeParametersProvider() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add customizing default `httpAuthSchemeProvider` and `httpAuthSchemeParametersProvider`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
