### PR TITLE
chore(experimentalIdentityAndAuth): rename to `generateDefaultHttpAuthSchemeProviderFunction()`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -81,7 +81,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
         generateDefaultHttpAuthSchemeParametersProviderFunction();
         generateHttpAuthOptionFunctions();
         generateHttpAuthSchemeProviderInterface();
-        generateHttpAuthSchemeProviderDefaultFunction();
+        generateDefaultHttpAuthSchemeProviderFunction();
     }
 
     /*
@@ -259,7 +259,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
         return options;
     };
     */
-    private void generateHttpAuthSchemeProviderDefaultFunction() {
+    private void generateDefaultHttpAuthSchemeProviderFunction() {
         delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_PROVIDER_PATH, w -> {
             w.openBlock("""
             /**


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Rename to `generateDefaultHttpAuthSchemeProviderFunction()` from `generateHttpAuthSchemeProviderDefaultFunction()`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
