### PR TITLE
feat(experimentalIdentityAndAuth): add `collect*()` methods to dedupe `ConfigField`s and `HttpAuthSchemeParameter`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -49,6 +49,7 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
     private final ServiceShape serviceShape;
     private final Symbol serviceSymbol;
     private final String serviceName;
+    private final Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters;
 
     /**
      * Create an HttpAuthSchemeProviderGenerator.
@@ -73,6 +74,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
         this.serviceShape = settings.getService(model);
         this.serviceSymbol = symbolProvider.toSymbol(serviceShape);
         this.serviceName = CodegenUtils.getServiceName(settings, model, symbolProvider);
+        this.httpAuthSchemeParameters =
+            AuthUtils.collectHttpAuthSchemeParameters(authIndex.getSupportedHttpAuthSchemes().values());
     }
 
     @Override
@@ -103,10 +106,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 export interface $LHttpAuthSchemeParameters extends HttpAuthSchemeParameters {""", "}",
                 serviceName,
                 () -> {
-                for (HttpAuthScheme authScheme : authIndex.getSupportedHttpAuthSchemes().values()) {
-                    for (HttpAuthSchemeParameter parameter : authScheme.getHttpAuthSchemeParameters()) {
-                        w.write("$L?: $C;", parameter.name(), parameter.type());
-                    }
+                for (HttpAuthSchemeParameter parameter : httpAuthSchemeParameters.values()) {
+                    w.write("$L?: $C;", parameter.name(), parameter.type());
                 }
             });
         });
@@ -145,10 +146,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 () -> {
                 w.openBlock("return {", "};", () -> {
                     w.write("operation: getSmithyContext(context).operation as string,");
-                    for (HttpAuthScheme authScheme : authIndex.getSupportedHttpAuthSchemes().values()) {
-                        for (HttpAuthSchemeParameter parameter : authScheme.getHttpAuthSchemeParameters()) {
-                            w.write("$L: $C,", parameter.name(), parameter.source());
-                        }
+                    for (HttpAuthSchemeParameter parameter : httpAuthSchemeParameters.values()) {
+                        w.write("$L: $C,", parameter.name(), parameter.source());
                     }
                 });
             });


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `collect*()` methods to dedupe `ConfigField`s and `HttpAuthSchemeParameter`.

This behavior could have better deduping logic, but that can be addressed in later PRs.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
