### PR TITLE
feat(experimentalIdentityAndAuth): add `createEndpointRuleSetHttpAuthSchemeProvider()` for `@smithy.rules#endpointRuleSet`

### DIFF
--- a/.changeset/witty-planes-reply.md
+++ b/.changeset/witty-planes-reply.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `createEndpointRuleSetHttpAuthSchemeProvider()` to generically create `HttpAuthSchemeProvider`s for `@smithy.rules#endpointRuleSet`

--- a/packages/experimental-identity-and-auth/src/createEndpointRuleSetHttpAuthSchemeProvider.ts
+++ b/packages/experimental-identity-and-auth/src/createEndpointRuleSetHttpAuthSchemeProvider.ts
@@ -1,0 +1,80 @@
+import { EndpointParameters, EndpointV2, Logger } from "@smithy/types";
+
+import { HttpAuthOption } from "./HttpAuthScheme";
+import { HttpAuthSchemeParameters, HttpAuthSchemeProvider } from "./HttpAuthSchemeProvider";
+
+/**
+ * @internal
+ */
+export interface EndpointRuleSetHttpAuthSchemeProvider<
+  EndpointParametersT extends EndpointParameters = EndpointParameters,
+  HttpAuthSchemeParametersT extends HttpAuthSchemeParameters = HttpAuthSchemeParameters
+> extends HttpAuthSchemeProvider<EndpointParametersT & HttpAuthSchemeParametersT> {}
+
+/**
+ * @internal
+ */
+export interface DefaultEndpointResolver<EndpointParametersT extends EndpointParameters = EndpointParameters> {
+  (params: EndpointParametersT, context?: { logger?: Logger }): EndpointV2;
+}
+
+/**
+ * @internal
+ */
+export interface CreateEndpointRuleSetHttpAuthSchemeProvider<
+  EndpointParametersT extends EndpointParameters = EndpointParameters,
+  HttpAuthSchemeParametersT extends HttpAuthSchemeParameters = HttpAuthSchemeParameters
+> {
+  (
+    defaultEndpointResolver: DefaultEndpointResolver<EndpointParametersT>,
+    defaultHttpAuthSchemeResolver: HttpAuthSchemeProvider<HttpAuthSchemeParametersT>
+  ): EndpointRuleSetHttpAuthSchemeProvider;
+}
+
+/**
+ * @internal
+ */
+export const createEndpointRuleSetHttpAuthSchemeProvider: CreateEndpointRuleSetHttpAuthSchemeProvider = <
+  EndpointParametersT extends EndpointParameters = EndpointParameters,
+  HttpAuthSchemeParametersT extends HttpAuthSchemeParameters = HttpAuthSchemeParameters
+>(
+  defaultEndpointResolver: DefaultEndpointResolver<EndpointParametersT>,
+  defaultHttpAuthSchemeResolver: HttpAuthSchemeProvider<HttpAuthSchemeParametersT>
+) => {
+  const endpointRuleSetHttpAuthSchemeProvider: EndpointRuleSetHttpAuthSchemeProvider<
+    EndpointParametersT,
+    HttpAuthSchemeParametersT
+  > = (authParameters) => {
+    const endpoint: EndpointV2 = defaultEndpointResolver(authParameters);
+    const authSchemes = endpoint.properties?.authSchemes;
+    if (!authSchemes) {
+      return defaultHttpAuthSchemeResolver(authParameters);
+    }
+    const options: HttpAuthOption[] = [];
+    for (const scheme of authSchemes) {
+      const { name: resolvedName, properties = {}, ...rest } = scheme;
+      const name = resolvedName.toLowerCase();
+      if (resolvedName !== name) {
+        console.warn(`HttpAuthScheme has been normalized with lowercasing: \`${resolvedName}\` to \`${name}\``);
+      }
+      let schemeId;
+      if (name === "sigv4") {
+        schemeId = "aws.auth#sigv4";
+      } else if (name === "sigv4a") {
+        schemeId = "aws.auth#sigv4a";
+      } else {
+        throw new Error(`Unknown HttpAuthScheme found in \`@smithy.rules#endpointRuleSet\`: \`${name}\``);
+      }
+      options.push({
+        schemeId,
+        signingProperties: {
+          ...rest,
+          ...properties,
+        },
+      });
+    }
+    return options;
+  };
+
+  return endpointRuleSetHttpAuthSchemeProvider;
+};

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -4,6 +4,7 @@ export * from "./HttpSigner";
 export * from "./IdentityProviderConfig";
 export * from "./SigV4Signer";
 export * from "./apiKeyIdentity";
+export * from "./createEndpointRuleSetHttpAuthSchemeProvider";
 export * from "./httpApiKeyAuth";
 export * from "./httpBearerAuth";
 export * from "./middleware-http-signing";


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `createEndpointRuleSetHttpAuthSchemeProvider()` to generically create `HttpAuthSchemeProvider`s for `@smithy.rules#endpointRuleSet`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
