### PR TITLE
feat(experimentalIdentityAndAuth): add partial support for `aws.auth#sigv4a`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
@@ -82,6 +82,15 @@ public final class AuthUtils {
                 effectiveAuthSchemes.put(shapeId, authIndex.getHttpAuthScheme(shapeId));
             }
         }
+        // TODO(experimentalIdentityAndAuth): remove after @aws.auth#sigv4a is fully supported
+        // BEGIN
+        HttpAuthScheme effectiveSigv4Scheme = effectiveAuthSchemes.get(ShapeId.from("aws.auth#sigv4"));
+        HttpAuthScheme effectiveSigv4aScheme = effectiveAuthSchemes.get(ShapeId.from("aws.auth#sigv4a"));
+        HttpAuthScheme supportedSigv4aScheme = authIndex.getHttpAuthScheme(ShapeId.from("aws.auth#sigv4a"));
+        if (effectiveSigv4Scheme != null && effectiveSigv4aScheme == null && supportedSigv4aScheme != null) {
+            effectiveAuthSchemes.put(supportedSigv4aScheme.getSchemeId(), supportedSigv4aScheme);
+        }
+        // END
         return effectiveAuthSchemes;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add partial support for `aws.auth#sigv4a`.

If `@aws.auth#sigv4` is effective, and `aws.auth#sigv4a` has a registered supported `HttpAuthScheme`, then add the `aws.auth#sigv4a` auth scheme.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
