### PR TITLE
Check method before calling external middlewareStack instance

### DIFF
--- a/.changeset/few-crews-brake.md
+++ b/.changeset/few-crews-brake.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-stack": patch
+---
+
+check calls to external instances of middlewareStack

--- a/packages/middleware-stack/src/MiddlewareStack.spec.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.spec.ts
@@ -370,6 +370,22 @@ describe("MiddlewareStack", () => {
     });
   });
 
+  it("checks identifyOnResolve calls to external instances due to version mismatching", () => {
+    const newStack = constructStack<input, output>();
+    const oldStack = constructStack<input, output>();
+
+    delete (oldStack as any).identifyOnResolve;
+    oldStack.clone = () => oldStack;
+    oldStack.concat = <S>(stack: S) => oldStack as S;
+    oldStack.applyToStack = () => void 0;
+
+    expect(oldStack.identifyOnResolve).toBeUndefined();
+    expect(() => {
+      newStack.concat(oldStack);
+      newStack.clone();
+    }).not.toThrow();
+  });
+
   describe("use", () => {
     it("should apply customizations from pluggables", async () => {
       const stack = constructStack<input, output>();

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -69,7 +69,7 @@ export const constructStack = <Input extends object, Output extends object>(): M
       //@ts-ignore
       toStack.addRelativeTo(entry.middleware, { ...entry });
     });
-    toStack.identifyOnResolve(stack.identifyOnResolve());
+    toStack.identifyOnResolve?.(stack.identifyOnResolve());
     return toStack;
   };
 
@@ -239,7 +239,9 @@ export const constructStack = <Input extends object, Output extends object>(): M
     ): MiddlewareStack<InputType, OutputType> => {
       const cloned = cloneTo(constructStack<InputType, OutputType>());
       cloned.use(from);
-      cloned.identifyOnResolve(identifyOnResolve || cloned.identifyOnResolve() || from.identifyOnResolve());
+      cloned.identifyOnResolve(
+        identifyOnResolve || cloned.identifyOnResolve() || (from.identifyOnResolve?.() ?? false)
+      );
       return cloned;
     },
 


### PR DESCRIPTION
in case of multiple versions of middlewareStack existing, external versions may be older and not have the latest method `identifyOnResolve`. 

This should be fixed by installing a consistent and recent version of SDK clients, or specifically `@smithy/middleware-stack`, but if needed, this check can be put in place.
