### PR TITLE
feat(experimentalIdentityAndAuth): add `getEndpointParameterInstructions()` to smithy context

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -50,6 +50,7 @@ import software.amazon.smithy.typescript.codegen.endpointsV2.EndpointsParamNameM
 import software.amazon.smithy.typescript.codegen.endpointsV2.RuleSetParameterFinder;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.sections.SmithyContextCodeSection;
 import software.amazon.smithy.typescript.codegen.validation.SensitiveDataFinder;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -361,6 +362,10 @@ final class CommandGenerator implements Runnable {
                 writer.openBlock("[SMITHY_CONTEXT_KEY]: {", "},", () -> {
                     writer.write("service: $S,", service.toShapeId().getName());
                     writer.write("operation: $S,", operation.toShapeId().getName());
+                    writer.injectSection(SmithyContextCodeSection.builder()
+                        .service(service)
+                        .operation(operation)
+                        .build());
                 });
             });
             writer.write("const { requestHandler } = configuration;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEndpointRuleSetIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/AddEndpointRuleSetIntegration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.integration;
+
+import java.util.List;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.typescript.codegen.sections.SmithyContextCodeSection;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public class AddEndpointRuleSetIntegration implements TypeScriptIntegration {
+    @Override
+    public List<? extends CodeInterceptor<? extends CodeSection, TypeScriptWriter>> interceptors(
+        TypeScriptCodegenContext codegenContext
+    ) {
+        return List.of(CodeInterceptor.appender(SmithyContextCodeSection.class, (w, s) -> {
+            if (s.getService().hasTrait(EndpointRuleSetTrait.ID)) {
+                w.openBlock("endpointRuleSet: {", "},", () -> {
+                    w.write("getEndpointParameterInstructions: $T.getEndpointParameterInstructions,",
+                        codegenContext.symbolProvider().toSymbol(s.getOperation()));
+                });
+            }
+        }));
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/SmithyContextCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/SmithyContextCodeSection.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.sections;
+
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public class SmithyContextCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final OperationShape operation;
+
+    private SmithyContextCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        operation = SmithyBuilder.requiredState("operation", builder.operation);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public OperationShape getOperation() {
+        return operation;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<SmithyContextCodeSection>{
+        private ServiceShape service;
+        private OperationShape operation;
+
+        @Override
+        public SmithyContextCodeSection build() {
+            return new SmithyContextCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder operation(OperationShape operation) {
+            this.operation = operation;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/smithy-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -13,3 +13,4 @@ software.amazon.smithy.typescript.codegen.integration.AddHttpApiKeyAuthPlugin
 software.amazon.smithy.typescript.codegen.integration.AddBaseServiceExceptionClass
 software.amazon.smithy.typescript.codegen.integration.AddSdkStreamMixinDependency
 software.amazon.smithy.typescript.codegen.integration.DefaultReadmeGenerator
+software.amazon.smithy.typescript.codegen.integration.AddEndpointRuleSetIntegration


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `getEndpointParameterInstructions()` to smithy context.

*Testing:*

*Note: all of the changes are gated by `experimentalIdentityAndAuth` flag*

The codegen diff adds the `endpointRuleSet` context with the `getEndpointParameterInstructions` per operation, and will be used in the `S3` and `EventBridge` `@endpointRuleset` `HttpAuthSchemeProvider`s in https://github.com/aws/aws-sdk-js-v3/pull/5231.

```diff
diff --color -Nur /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts
--- /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts	2023-09-24 00:00:25
+++ /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/commands/CreateCityCommand.ts	2023-09-24 00:02:02
@@ -101,6 +101,9 @@
       [SMITHY_CONTEXT_KEY]: {
         service: "Weather",
         operation: "CreateCity",
+        endpointRuleSet: {
+          getEndpointParameterInstructions: CreateCityCommand.getEndpointParameterInstructions,
+        },
       },
     }
     const { requestHandler } = configuration;
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
