### PR TITLE
feat(experimentalIdentityAndAuth): add `createEndpointRuleSetHttpAuthSchemeParametersProvider()` for `@smithy.rules#endpointRuleSet`

### DIFF
--- a/.changeset/strange-shrimps-turn.md
+++ b/.changeset/strange-shrimps-turn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `createEndpointRuleSetHttpAuthSchemeParametersProvider()` to generically create `HttpAuthSchemeParametersProvider`s for `@smithy.rules#endpointRuleSet`

--- a/packages/experimental-identity-and-auth/src/index.ts
+++ b/packages/experimental-identity-and-auth/src/index.ts
@@ -4,7 +4,7 @@ export * from "./HttpSigner";
 export * from "./IdentityProviderConfig";
 export * from "./SigV4Signer";
 export * from "./apiKeyIdentity";
-export * from "./createEndpointRuleSetHttpAuthSchemeProvider";
+export * from "./endpointRuleSet";
 export * from "./httpApiKeyAuth";
 export * from "./httpBearerAuth";
 export * from "./memoizeIdentityProvider";


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `createEndpointRuleSetHttpAuthSchemeParametersProvider()` to generically create `HttpAuthSchemeParametersProvider`s for `@smithy.rules#endpointRuleSet`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
