### PR TITLE
fix: check for existence of browser types

### DIFF
--- a/.changeset/tricky-parrots-join.md
+++ b/.changeset/tricky-parrots-join.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+check for existence of browser Blob/ReadableStream types in payload union

--- a/packages/types/src/blob/blob-payload-input-types.ts
+++ b/packages/types/src/blob/blob-payload-input-types.ts
@@ -1,5 +1,7 @@
 import { Readable } from "stream";
 
+import type { BlobOptionalType, ReadableStreamOptionalType } from "../externals-check/browser-externals-check";
+
 /**
  * @public
  *
@@ -40,7 +42,7 @@ export type NodeJsRuntimeBlobTypes = Readable | Buffer;
  *
  * Additional blob types for the browser environment.
  */
-export type BrowserRuntimeBlobTypes = Blob | ReadableStream;
+export type BrowserRuntimeBlobTypes = BlobOptionalType | ReadableStreamOptionalType;
 
 /**
  * @deprecated renamed to BlobPayloadInputTypes.

--- a/packages/types/src/externals-check/browser-externals-check.ts
+++ b/packages/types/src/externals-check/browser-externals-check.ts
@@ -1,0 +1,40 @@
+import type { Exact } from "../transform/exact";
+
+/**
+ * @public
+ *
+ * A checked type that resolves to Blob if it is defined as more than a stub, otherwise
+ * resolves to 'never' so as not to widen the type of unions containing Blob
+ * excessively.
+ */
+export type BlobOptionalType = BlobDefined extends true ? Blob : Unavailable;
+
+/**
+ * @public
+ *
+ * A checked type that resolves to ReadableStream if it is defined as more than a stub, otherwise
+ * resolves to 'never' so as not to widen the type of unions containing ReadableStream
+ * excessively.
+ */
+export type ReadableStreamOptionalType = ReadableStreamDefined extends true ? ReadableStream : Unavailable;
+
+/**
+ * @public
+ *
+ * Indicates a type is unavailable if it resolves to this.
+ */
+export type Unavailable = never;
+
+/**
+ * @internal
+ *
+ * Whether the global types define more than a stub for ReadableStream.
+ */
+export type ReadableStreamDefined = Exact<ReadableStream, {}> extends true ? false : true;
+
+/**
+ * @internal
+ *
+ * Whether the global types define more than a stub for Blob.
+ */
+export type BlobDefined = Exact<Blob, {}> extends true ? false : true;

--- a/packages/types/src/streaming-payload/streaming-blob-common-types.ts
+++ b/packages/types/src/streaming-payload/streaming-blob-common-types.ts
@@ -1,5 +1,7 @@
 import type { Readable } from "stream";
 
+import type { BlobOptionalType, ReadableStreamOptionalType } from "../externals-check/browser-externals-check";
+
 /**
  * @public
  *
@@ -31,4 +33,4 @@ export type NodeJsRuntimeStreamingBlobTypes = Readable;
  *
  * Browser streaming blob types.
  */
-export type BrowserRuntimeStreamingBlobTypes = ReadableStream | Blob;
+export type BrowserRuntimeStreamingBlobTypes = ReadableStreamOptionalType | BlobOptionalType;

--- a/packages/types/src/streaming-payload/streaming-blob-payload-input-types.ts
+++ b/packages/types/src/streaming-payload/streaming-blob-payload-input-types.ts
@@ -1,5 +1,7 @@
 import type { Readable } from "stream";
 
+import type { BlobOptionalType, ReadableStreamOptionalType } from "../externals-check/browser-externals-check";
+
 /**
  * @public
  *
@@ -61,4 +63,8 @@ export type NodeJsRuntimeStreamingBlobPayloadInputTypes = string | Uint8Array | 
  * Streaming payload input types in the browser environment.
  * These are derived from the types compatible with fetch's Request.body.
  */
-export type BrowserRuntimeStreamingBlobPayloadInputTypes = string | Uint8Array | ReadableStream | Blob;
+export type BrowserRuntimeStreamingBlobPayloadInputTypes =
+  | string
+  | Uint8Array
+  | ReadableStreamOptionalType
+  | BlobOptionalType;

--- a/packages/types/src/streaming-payload/streaming-blob-payload-output-types.ts
+++ b/packages/types/src/streaming-payload/streaming-blob-payload-output-types.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "http";
 import type { Readable } from "stream";
 
+import type { BlobOptionalType, ReadableStreamOptionalType } from "../externals-check/browser-externals-check";
 import type { SdkStream } from "../serde";
 
 /**
@@ -53,4 +54,4 @@ export type NodeJsRuntimeStreamingBlobPayloadOutputTypes = SdkStream<IncomingMes
  * The SdkStreamMixin adds methods on this type to help transform (collect) it to
  * other formats.
  */
-export type BrowserRuntimeStreamingBlobPayloadOutputTypes = SdkStream<ReadableStream | Blob>;
+export type BrowserRuntimeStreamingBlobPayloadOutputTypes = SdkStream<ReadableStreamOptionalType | BlobOptionalType>;

--- a/packages/types/src/transform/client-payload-blob-type-narrow.spec.ts
+++ b/packages/types/src/transform/client-payload-blob-type-narrow.spec.ts
@@ -6,8 +6,7 @@ import type { MetadataBearer } from "../response";
 import type { SdkStream } from "../serde";
 import type { StreamingBlobPayloadOutputTypes } from "../streaming-payload/streaming-blob-payload-output-types";
 import type { BrowserClient, NodeJsClient } from "./client-payload-blob-type-narrow";
-
-type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+import type { Exact } from "./exact";
 
 // it should narrow operational methods and the generic send method
 

--- a/packages/types/src/transform/exact.ts
+++ b/packages/types/src/transform/exact.ts
@@ -1,0 +1,6 @@
+/**
+ * @internal
+ *
+ * Checks that A and B extend each other.
+ */
+export type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;

--- a/packages/types/src/transform/type-transform.spec.ts
+++ b/packages/types/src/transform/type-transform.spec.ts
@@ -1,7 +1,6 @@
 import type { Transform as DownlevelTransform } from "../downlevel-ts3.4/transform/type-transform";
+import type { Exact } from "./exact";
 import type { Transform } from "./type-transform";
-
-type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 
 type A = {
   a: string;


### PR DESCRIPTION
this resolves the union `ReadableStream | Blob` to `never` if those types are only stubs. 

fixes https://github.com/aws/aws-sdk-js-v3/issues/5237