### PR TITLE
Enable cache for yarn in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 16
+          cache: "yarn"
       - name: Install dependencies
         run: yarn
       - name: Run eslint
@@ -48,7 +49,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 14
+          cache: "yarn"
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -73,7 +75,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 16
+          cache: "yarn"
       - name: Install dependencies
         run: yarn
       - name: Run the code formatter
@@ -97,6 +100,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: "yarn"
       - name: Install
         run: yarn
       - name: Ensure changesets exist for each changed package

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "yarn"
       - name: Install dependencies
         run: yarn install
       - name: Version

--- a/.github/workflows/release-npm-ssdk-libs.yml
+++ b/.github/workflows/release-npm-ssdk-libs.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "yarn"
       - name: Install dependencies
         run: yarn install
       - name: Configure AWS Credentials

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smithy-typescript",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Smithy TypeScript packages",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smithy-typescript",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Smithy TypeScript packages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
*Issue #, if available:*
Similar to how it was done in https://github.com/awslabs/aws-sdk-js-codemod/pull/151

*Description of changes:*
Enable cache for yarn to save couple of minutes in CI

Before cache:
Installation step takes `1m49s`: https://github.com/awslabs/smithy-typescript/actions/runs/6330932816/job/17194434431?pr=967

<details>
<summary>Screenshot</summary>

![before](https://github.com/awslabs/smithy-typescript/assets/16024985/d1f14c25-a568-41bf-8e32-6fa18682ac3d)

</details>

After cache:
Installation step takes `25s`: https://github.com/awslabs/smithy-typescript/actions/runs/6331017142/job/17194690623?pr=967
Verified that dependencies are used from cache

<details>
<summary>Screenshot</summary>

![after](https://github.com/awslabs/smithy-typescript/assets/16024985/22df4018-777c-47dc-84a6-476a5a454f45)

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
