### PR TITLE
feat(experimentalIdentityAndAuth): add aliases for `httpSigningMiddleware`

### DIFF
--- a/.changeset/mighty-teachers-double.md
+++ b/.changeset/mighty-teachers-double.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add aliases for `httpSigningMiddleware`

--- a/packages/experimental-identity-and-auth/src/middleware-http-signing/getHttpSigningMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-signing/getHttpSigningMiddleware.ts
@@ -10,6 +10,7 @@ export const httpSigningMiddlewareOptions: FinalizeRequestHandlerOptions & Relat
   step: "finalizeRequest",
   tags: ["HTTP_SIGNING"],
   name: "httpSigningMiddleware",
+  aliases: ["apiKeyMiddleware", "tokenMiddleware", "awsAuthMiddleware"],
   override: true,
   relation: "after",
   toMiddleware: retryMiddlewareOptions.name!,


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add aliases for `httpSigningMiddleware`:

- `@httpApiKeyAuth`: `apiKeyMiddleware`
- `@httpBearerAuth`: `tokenMiddleware`
- `@aws.auth#sigv4`: `awsAuthMiddleware`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
