### PR TITLE
feat(experimentalIdentityAndAuth): add `@endpointRuleSet` signing properties to `selectedHttpAuthScheme`

### DIFF
--- a/.changeset/tiny-zebras-refuse.md
+++ b/.changeset/tiny-zebras-refuse.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+Add `@endpointRuleSet` signing properties to `selectedHttpAuthScheme`


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `@endpointRuleSet` signing properties to `selectedHttpAuthScheme`.

*More investigation needs to be done on how these signing properties are used*.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
