### PR TITLE
fix: use valid dummy URL for Node.js initialization of Request

### DIFF
--- a/.changeset/five-ravens-hide.md
+++ b/.changeset/five-ravens-hide.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+use valid dummy URL

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -29,7 +29,7 @@ type FetchHttpHandlerConfig = FetchHttpHandlerOptions;
  * Detection of keepalive support. Can be overridden for testing.
  */
 export const keepAliveSupport = {
-  supported: Boolean(typeof Request !== "undefined" && "keepalive" in new Request("")),
+  supported: Boolean(typeof Request !== "undefined" && "keepalive" in new Request("https://[::1]")),
 };
 
 /**


### PR DESCRIPTION
we don't intend for the fetch-http-client to be used in node, but `fetch` may become progressively more prevalent in Node.js

in browsers, initializing with a blank string does not throw, but in Node.js it does throw invalid URL. To prevent this, I want to initialize the dummy Request with a valid URL. This request is never sent, so any URL would be safe, but to avoid the appearance of preference perhaps we can use ipv6 localhost.