### PR TITLE
Populate subsections when reading INI files

### DIFF
--- a/.changeset/serious-fans-hear.md
+++ b/.changeset/serious-fans-hear.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Read values from main settings when parsing INI files

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -14,9 +14,9 @@ describe(parseIni.name, () => {
 
     const getMockProfileDataEntries = (profileData: Record<string, string | Record<string, string>>) =>
       Object.entries(profileData).map(([key, value]) => {
-        let result = `${key} =`;
+        let result = `${key}=`;
         if (typeof value === "string") {
-          result += ` ${value}`;
+          result += `${value}`;
         } else {
           result += `\n    ${getMockProfileDataEntries(value).join("\n    ")}`;
         }
@@ -25,6 +25,15 @@ describe(parseIni.name, () => {
 
     const getMockProfileContent = (profileName: string, profileData: Record<string, string | Record<string, string>>) =>
       `[${profileName}]\n${getMockProfileDataEntries(profileData).join("\n")}\n`;
+
+    it("trims data from key/value", () => {
+      const mockInput = `[${mockProfileName}]\n  ${Object.entries(mockProfileData)
+        .map(([key, value]) => ` ${key} = ${value} `)
+        .join("\n")}`;
+      expect(parseIni(mockInput)).toStrictEqual({
+        [mockProfileName]: mockProfileData,
+      });
+    });
 
     it("returns data for one profile", () => {
       const mockInput = getMockProfileContent(mockProfileName, mockProfileData);

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -91,20 +91,18 @@ describe(parseIni.name, () => {
     });
 
     it("returns data from main section, and not subsection", () => {
-      const mockMainSettings = { key: "value1" };
-      const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "subValue1" } };
+      const mockProfileDataWithSubSettings = { key: "value1", "sub-settings-name": { key: "subValue1" } };
       const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithSubSettings);
       expect(parseIni(mockInput)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
+        [mockProfileName]: mockProfileDataWithSubSettings,
       });
 
       const mockProfileName2 = "mock_profile_name_2";
-      const mockMainSettings2 = { key: "value2" };
-      const mockProfileDataWithSubSettings2 = { ...mockMainSettings2, "sub-settings-name": { key: "subValue2" } };
+      const mockProfileDataWithSubSettings2 = { key: "value2", "sub-settings-name": { key: "subValue2" } };
       const mockInput2 = getMockProfileContent(mockProfileName2, mockProfileDataWithSubSettings2);
       expect(parseIni(`${mockInput}${mockInput2}`)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
-        [mockProfileName2]: mockMainSettings2,
+        [mockProfileName]: mockProfileDataWithSubSettings,
+        [mockProfileName2]: mockProfileDataWithSubSettings2,
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -35,6 +35,14 @@ describe(parseIni.name, () => {
       });
     });
 
+    it("returns value with equals sign", () => {
+      const mockProfileDataWithEqualsSign = { key: "value=value" };
+      const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithEqualsSign);
+      expect(parseIni(mockInput)).toStrictEqual({
+        [mockProfileName]: mockProfileDataWithEqualsSign,
+      });
+    });
+
     it("returns data for one profile", () => {
       const mockInput = getMockProfileContent(mockProfileName, mockProfileData);
       expect(parseIni(mockInput)).toStrictEqual({

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -77,7 +77,6 @@ describe(parseIni.name, () => {
       const mockMainSettings = { key: "value1" };
       const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "value2" } };
       const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithSubSettings);
-      console.log({ mockInput });
       expect(parseIni(mockInput)).toStrictEqual({
         [mockProfileName]: mockMainSettings,
       });

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -73,12 +73,21 @@ describe(parseIni.name, () => {
       });
     });
 
-    it.only("returns data from main settings, and not subsettings", () => {
+    it("returns data from main section, and not subsection", () => {
       const mockMainSettings = { key: "value1" };
-      const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "value2" } };
+      const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "subValue1" } };
       const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithSubSettings);
       expect(parseIni(mockInput)).toStrictEqual({
         [mockProfileName]: mockMainSettings,
+      });
+
+      const mockProfileName2 = "mock_profile_name_2";
+      const mockMainSettings2 = { key: "value2" };
+      const mockProfileDataWithSubSettings2 = { ...mockMainSettings2, "sub-settings-name": { key: "subValue2" } };
+      const mockInput2 = getMockProfileContent(mockProfileName2, mockProfileDataWithSubSettings2);
+      expect(parseIni(`${mockInput}${mockInput2}`)).toStrictEqual({
+        [mockProfileName]: mockMainSettings,
+        [mockProfileName2]: mockMainSettings2,
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -18,22 +18,13 @@ export const parseIni = (iniData: string): ParsedIniData => {
         throw new Error(`Found invalid profile name "${currentSection}"`);
       }
     } else if (currentSection) {
-      const [key, value] = line.split("=").map((item) => item.trim());
+      const [name, value] = line.split("=").map((item) => item.trim());
       if (value === "") {
-        currentSubSection = key;
+        currentSubSection = name;
       }
       if (currentSubSection === undefined) {
         // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
-        const indexOfEqualsSign = line.indexOf("=");
-        const start = 0;
-        const end: number = line.length - 1;
-        const isAssignment: boolean =
-          indexOfEqualsSign !== -1 && indexOfEqualsSign !== start && indexOfEqualsSign !== end;
-        if (isAssignment) {
-          const [name, value]: [string, string] = [
-            line.substring(0, indexOfEqualsSign).trim(),
-            line.substring(indexOfEqualsSign + 1).trim(),
-          ];
+        if (name !== "" && value !== "") {
           map[currentSection] = map[currentSection] || {};
           map[currentSection][name] = value;
         }

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -19,14 +19,16 @@ export const parseIni = (iniData: string): ParsedIniData => {
       }
     } else if (currentSection) {
       const [name, value] = line.split("=").map((item) => item.trim());
-      if (value === "") {
-        currentSubSection = name;
-      }
-      if (currentSubSection === undefined) {
-        // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
-        if (name !== "" && value !== "") {
-          map[currentSection] = map[currentSection] || {};
-          map[currentSection][name] = value;
+      if (name !== "") {
+        if (value === "") {
+          currentSubSection = name;
+        }
+        if (currentSubSection === undefined) {
+          // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
+          if (value !== "") {
+            map[currentSection] = map[currentSection] || {};
+            map[currentSection][name] = value;
+          }
         }
       }
     }

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -18,17 +18,18 @@ export const parseIni = (iniData: string): ParsedIniData => {
         throw new Error(`Found invalid profile name "${currentSection}"`);
       }
     } else if (currentSection) {
-      const [name, value] = line.split("=").map((item) => item.trim());
-      if (name !== "") {
+      const indexOfEqualsSign = line.indexOf("=");
+      if (![0, -1].includes(indexOfEqualsSign)) {
+        const [name, value]: [string, string] = [
+          line.substring(0, indexOfEqualsSign).trim(),
+          line.substring(indexOfEqualsSign + 1).trim(),
+        ];
         if (value === "") {
           currentSubSection = name;
-        }
-        if (currentSubSection === undefined) {
+        } else if (currentSubSection === undefined) {
           // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
-          if (value !== "") {
-            map[currentSection] = map[currentSection] || {};
-            map[currentSection][name] = value;
-          }
+          map[currentSection] = map[currentSection] || {};
+          map[currentSection][name] = value;
         }
       }
     }

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -4,29 +4,39 @@ const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {
   const map: ParsedIniData = {};
+
   let currentSection: string | undefined;
+  let currentSubSection: string | undefined;
 
   for (let line of iniData.split(/\r?\n/)) {
     line = line.split(/(^|\s)[;#]/)[0].trim(); // remove comments and trim
     const isSection: boolean = line[0] === "[" && line[line.length - 1] === "]";
     if (isSection) {
+      currentSubSection = undefined;
       currentSection = line.substring(1, line.length - 1);
       if (profileNameBlockList.includes(currentSection)) {
         throw new Error(`Found invalid profile name "${currentSection}"`);
       }
     } else if (currentSection) {
-      const indexOfEqualsSign = line.indexOf("=");
-      const start = 0;
-      const end: number = line.length - 1;
-      const isAssignment: boolean =
-        indexOfEqualsSign !== -1 && indexOfEqualsSign !== start && indexOfEqualsSign !== end;
-      if (isAssignment) {
-        const [name, value]: [string, string] = [
-          line.substring(0, indexOfEqualsSign).trim(),
-          line.substring(indexOfEqualsSign + 1).trim(),
-        ];
-        map[currentSection] = map[currentSection] || {};
-        map[currentSection][name] = value;
+      const [key, value] = line.split("=").map((item) => item.trim());
+      if (value === "") {
+        currentSubSection = key;
+      }
+      if (currentSubSection === undefined) {
+        // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
+        const indexOfEqualsSign = line.indexOf("=");
+        const start = 0;
+        const end: number = line.length - 1;
+        const isAssignment: boolean =
+          indexOfEqualsSign !== -1 && indexOfEqualsSign !== start && indexOfEqualsSign !== end;
+        if (isAssignment) {
+          const [name, value]: [string, string] = [
+            line.substring(0, indexOfEqualsSign).trim(),
+            line.substring(indexOfEqualsSign + 1).trim(),
+          ];
+          map[currentSection] = map[currentSection] || {};
+          map[currentSection][name] = value;
+        }
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/985

*Description of changes:*
Populates subsections when reading INI files

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
