### PR TITLE
Populate subsections when parsing INI files

### DIFF
--- a/.changeset/fast-cows-dream.md
+++ b/.changeset/fast-cows-dream.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": minor
+---
+
+Allow subsections in IniSection type

--- a/.changeset/fast-cows-dream.md
+++ b/.changeset/fast-cows-dream.md
@@ -1,6 +1,7 @@
 ---
 "@smithy/types": minor
 "@smithy/util-config-provider": patch
+"@smithy/config-resolver": patch
 ---
 
 Allow subsections in IniSection type

--- a/.changeset/fast-cows-dream.md
+++ b/.changeset/fast-cows-dream.md
@@ -1,5 +1,6 @@
 ---
 "@smithy/types": minor
+"@smithy/util-config-provider": patch
 ---
 
 Allow subsections in IniSection type

--- a/.changeset/fast-cows-dream.md
+++ b/.changeset/fast-cows-dream.md
@@ -2,6 +2,7 @@
 "@smithy/types": minor
 "@smithy/util-config-provider": patch
 "@smithy/config-resolver": patch
+"@smithy/credential-provider-imds": patch
 ---
 
 Allow subsections in IniSection type

--- a/.changeset/fast-cows-dream.md
+++ b/.changeset/fast-cows-dream.md
@@ -3,6 +3,7 @@
 "@smithy/util-config-provider": patch
 "@smithy/config-resolver": patch
 "@smithy/credential-provider-imds": patch
+"@smithy/middleware-retry": patch
 ---
 
 Allow subsections in IniSection type

--- a/.changeset/ninety-rabbits-march.md
+++ b/.changeset/ninety-rabbits-march.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": minor
+---
+
+Populate subsections when parsing INI files

--- a/packages/config-resolver/src/regionConfig/config.ts
+++ b/packages/config-resolver/src/regionConfig/config.ts
@@ -14,7 +14,8 @@ export const REGION_INI_NAME = "region";
  */
 export const NODE_REGION_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
   environmentVariableSelector: (env) => env[REGION_ENV_NAME],
-  configFileSelector: (profile) => profile[REGION_INI_NAME],
+  configFileSelector: (profile) =>
+    typeof profile[REGION_INI_NAME] === "string" ? profile[REGION_INI_NAME] : undefined,
   default: () => {
     throw new Error("Region is missing");
   },

--- a/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointConfigOptions.ts
@@ -14,6 +14,7 @@ export const CONFIG_ENDPOINT_NAME = "ec2_metadata_service_endpoint";
  */
 export const ENDPOINT_CONFIG_OPTIONS: LoadedConfigSelectors<string | undefined> = {
   environmentVariableSelector: (env) => env[ENV_ENDPOINT_NAME],
-  configFileSelector: (profile) => profile[CONFIG_ENDPOINT_NAME],
+  configFileSelector: (profile) =>
+    typeof profile[CONFIG_ENDPOINT_NAME] === "string" ? profile[CONFIG_ENDPOINT_NAME] : undefined,
   default: undefined,
 };

--- a/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
+++ b/packages/credential-provider-imds/src/config/EndpointModeConfigOptions.ts
@@ -16,6 +16,7 @@ export const CONFIG_ENDPOINT_MODE_NAME = "ec2_metadata_service_endpoint_mode";
  */
 export const ENDPOINT_MODE_CONFIG_OPTIONS: LoadedConfigSelectors<string | undefined> = {
   environmentVariableSelector: (env) => env[ENV_ENDPOINT_MODE_NAME],
-  configFileSelector: (profile) => profile[CONFIG_ENDPOINT_MODE_NAME],
+  configFileSelector: (profile) =>
+    typeof profile[CONFIG_ENDPOINT_MODE_NAME] === "string" ? profile[CONFIG_ENDPOINT_MODE_NAME] : undefined,
   default: EndpointMode.IPv4,
 };

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -24,7 +24,7 @@ export const NODE_MAX_ATTEMPT_CONFIG_OPTIONS: LoadedConfigSelectors<number> = {
   },
   configFileSelector: (profile) => {
     const value = profile[CONFIG_MAX_ATTEMPTS];
-    if (!value) return undefined;
+    if (typeof value !== "string") return undefined;
     const maxAttempt = parseInt(value);
     if (Number.isNaN(maxAttempt)) {
       throw new Error(`Shared config file entry ${CONFIG_MAX_ATTEMPTS} mast be a number, got "${value}"`);
@@ -91,6 +91,7 @@ export const CONFIG_RETRY_MODE = "retry_mode";
 
 export const NODE_RETRY_MODE_CONFIG_OPTIONS: LoadedConfigSelectors<string> = {
   environmentVariableSelector: (env) => env[ENV_RETRY_MODE],
-  configFileSelector: (profile) => profile[CONFIG_RETRY_MODE],
+  configFileSelector: (profile) =>
+    typeof profile[CONFIG_RETRY_MODE] === "string" ? profile[CONFIG_RETRY_MODE] : undefined,
   default: DEFAULT_RETRY_MODE,
 };

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -91,20 +91,18 @@ describe(parseIni.name, () => {
     });
 
     it("returns data from main section, and not subsection", () => {
-      const mockMainSettings = { key: "value1" };
-      const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "subValue1" } };
+      const mockProfileDataWithSubSettings = { key: "value1", "sub-settings-name": { key: "subValue1" } };
       const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithSubSettings);
       expect(parseIni(mockInput)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
+        [mockProfileName]: mockProfileDataWithSubSettings,
       });
 
       const mockProfileName2 = "mock_profile_name_2";
-      const mockMainSettings2 = { key: "value2" };
-      const mockProfileDataWithSubSettings2 = { ...mockMainSettings2, "sub-settings-name": { key: "subValue2" } };
+      const mockProfileDataWithSubSettings2 = { key: "value2", "sub-settings-name": { key: "subValue2" } };
       const mockInput2 = getMockProfileContent(mockProfileName2, mockProfileDataWithSubSettings2);
       expect(parseIni(`${mockInput}${mockInput2}`)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
-        [mockProfileName2]: mockMainSettings2,
+        [mockProfileName]: mockProfileDataWithSubSettings,
+        [mockProfileName2]: mockProfileDataWithSubSettings2,
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -27,19 +27,13 @@ export const parseIni = (iniData: string): ParsedIniData => {
         if (value === "") {
           currentSubSectionName = name;
         } else {
-          if (map[currentSectionName] === undefined) {
-            map[currentSectionName] = {};
-          }
-          const currentSection = map[currentSectionName];
+          const currentSection = map[currentSectionName] || {};
           if (currentSubSectionName === undefined) {
             currentSection[name] = value;
           } else {
-            if (currentSection[currentSubSectionName] === undefined) {
-              currentSection[currentSubSectionName] = {};
-            }
-            const currentSubSection = currentSection[currentSubSectionName];
+            const currentSubSection = currentSection[currentSubSectionName] || {};
             if (typeof currentSubSection !== "string") {
-              currentSubSection[name] = value;
+              (currentSubSection as Record<string, string>)[name] = value;
             }
           }
         }

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -35,7 +35,9 @@ export const parseIni = (iniData: string): ParsedIniData => {
             if (typeof currentSubSection !== "string") {
               (currentSubSection as Record<string, string>)[name] = value;
             }
+            currentSection[currentSubSectionName] = currentSubSection;
           }
+          map[currentSectionName] = currentSection;
         }
       }
     }

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -26,10 +26,15 @@ export const parseIni = (iniData: string): ParsedIniData => {
         ];
         if (value === "") {
           currentSubSection = name;
-        } else if (currentSubSection === undefined) {
+        } else {
           // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
           map[currentSection] = map[currentSection] || {};
-          map[currentSection][name] = value;
+          if (currentSubSection === undefined) {
+            map[currentSection][name] = value;
+          } else {
+            map[currentSection][currentSubSection] = map[currentSection][currentSubSection] || {};
+            map[currentSection][currentSubSection][name] = value;
+          }
         }
       }
     }

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,7 +1,7 @@
 /**
  * @public
  */
-export type IniSection = Record<string, string | undefined>;
+export type IniSection = Record<string, string | Record<string, string> | undefined>;
 
 /**
  * @public

--- a/packages/util-config-provider/src/booleanSelector.ts
+++ b/packages/util-config-provider/src/booleanSelector.ts
@@ -11,7 +11,7 @@ export enum SelectorType {
  *
  * @internal
  */
-export const booleanSelector = (obj: Record<string, string | undefined>, key: string, type: SelectorType) => {
+export const booleanSelector = (obj: Record<string, any>, key: string, type: SelectorType) => {
   if (!(key in obj)) return undefined;
   if (obj[key] === "true") return true;
   if (obj[key] === "false") return false;


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/985

*Description of changes:*
Populates subsections when parsing INI files

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
