### PR TITLE
Populate subsection using dot separator in section key when parsing INI files

### DIFF
--- a/.changeset/few-panthers-impress.md
+++ b/.changeset/few-panthers-impress.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": minor
+---
+
+Populate subsection using dot separator in section key when parsing INI files

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -91,20 +91,33 @@ describe(parseIni.name, () => {
     });
 
     it("returns data from main section, and not subsection", () => {
-      const mockMainSettings = { key: "value1" };
-      const mockProfileDataWithSubSettings = { ...mockMainSettings, "sub-settings-name": { key: "subValue1" } };
+      const mockProfileDataWithSubSettings = {
+        key: "value",
+        subSection: { subKey: "subValue" },
+      };
       const mockInput = getMockProfileContent(mockProfileName, mockProfileDataWithSubSettings);
       expect(parseIni(mockInput)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
+        [mockProfileName]: {
+          key: "value",
+          "subSection.subKey": "subValue",
+        },
       });
 
       const mockProfileName2 = "mock_profile_name_2";
-      const mockMainSettings2 = { key: "value2" };
-      const mockProfileDataWithSubSettings2 = { ...mockMainSettings2, "sub-settings-name": { key: "subValue2" } };
+      const mockProfileDataWithSubSettings2 = {
+        key: "value2",
+        subSection: { subKey: "subValue2" },
+      };
       const mockInput2 = getMockProfileContent(mockProfileName2, mockProfileDataWithSubSettings2);
       expect(parseIni(`${mockInput}${mockInput2}`)).toStrictEqual({
-        [mockProfileName]: mockMainSettings,
-        [mockProfileName2]: mockMainSettings2,
+        [mockProfileName]: {
+          key: "value",
+          "subSection.subKey": "subValue",
+        },
+        [mockProfileName2]: {
+          key: "value2",
+          "subSection.subKey": "subValue2",
+        },
       });
     });
   });

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -26,10 +26,10 @@ export const parseIni = (iniData: string): ParsedIniData => {
         ];
         if (value === "") {
           currentSubSection = name;
-        } else if (currentSubSection === undefined) {
-          // ToDo: populate subsection in future PR, when IniSection is updated to support subsections.
+        } else {
           map[currentSection] = map[currentSection] || {};
-          map[currentSection][name] = value;
+          const key = currentSubSection ? `${currentSubSection}.${name}` : name;
+          map[currentSection][key] = value;
         }
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
* Fixes: https://github.com/awslabs/smithy-typescript/issues/985
* Alternative to https://github.com/awslabs/smithy-typescript/pull/988 without breaking changes

*Description of changes:*
Populates subsection using dot separator in section key when parsing INI files

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
