### PR TITLE
Pass configuration file as second parameter to configSelector

### DIFF
--- a/.changeset/fast-colts-drive.md
+++ b/.changeset/fast-colts-drive.md
@@ -1,0 +1,5 @@
+---
+"@smithy/node-config-provider": minor
+---
+
+Pass configuration file as second parameter to configSelector

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,6 +1,6 @@
 import { CredentialsProviderError } from "@smithy/property-provider";
 import { getProfileName, loadSharedConfigFiles, SourceProfileInit } from "@smithy/shared-ini-file-loader";
-import { Profile, Provider } from "@smithy/types";
+import { ParsedIniData, Profile, Provider } from "@smithy/types";
 
 export interface SharedConfigInit extends SourceProfileInit {
   /**
@@ -11,7 +11,7 @@ export interface SharedConfigInit extends SourceProfileInit {
   preferredFile?: "config" | "credentials";
 }
 
-export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
+export type GetterFromConfig<T> = (profile: Profile, configFile: ParsedIniData) => T | undefined;
 
 /**
  * Get config value from the shared config files with inferred profile name.
@@ -31,7 +31,8 @@ export const fromSharedConfigFiles = <T = string>(
       : { ...profileFromConfig, ...profileFromCredentials };
 
   try {
-    const configValue = configSelector(mergedProfile);
+    const cfgFile = preferredFile === "config" ? configFile : credentialsFile;
+    const configValue = configSelector(mergedProfile, cfgFile);
     if (configValue === undefined) {
       throw new Error();
     }

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -11,7 +11,7 @@ export interface SharedConfigInit extends SourceProfileInit {
   preferredFile?: "config" | "credentials";
 }
 
-export type GetterFromConfig<T> = (profile: Profile, configFile: ParsedIniData) => T | undefined;
+export type GetterFromConfig<T> = (profile: Profile, configFile?: ParsedIniData) => T | undefined;
 
 /**
  * Get config value from the shared config files with inferred profile name.


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-4281

*Description of changes:*
Pass configuration file as second parameter to configSelector.
This is required if other sections from the configuration need to be read.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
