### PR TITLE
Export CONFIG_PREFIX_SEPARATOR from loadSharedConfigFiles

### DIFF
--- a/.changeset/funny-hornets-dress.md
+++ b/.changeset/funny-hornets-dress.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Export CONFIG_PREFIX_SEPARATOR from loadSharedConfigFiles

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -30,6 +30,8 @@ export interface SharedConfigInit {
 
 const swallowError = () => ({});
 
+export const CONFIG_PREFIX_SEPARATOR = ".";
+
 export const loadSharedConfigFiles = async (init: SharedConfigInit = {}): Promise<SharedConfigFiles> => {
   const { filepath = getCredentialsFilepath(), configFilepath = getConfigFilepath() } = init;
 

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -1,3 +1,4 @@
+import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 import { parseIni } from "./parseIni";
 
 describe(parseIni.name, () => {
@@ -99,7 +100,7 @@ describe(parseIni.name, () => {
       expect(parseIni(mockInput)).toStrictEqual({
         [mockProfileName]: {
           key: "value",
-          "subSection.subKey": "subValue",
+          [["subSection", "subKey"].join(CONFIG_PREFIX_SEPARATOR)]: "subValue",
         },
       });
 
@@ -112,11 +113,11 @@ describe(parseIni.name, () => {
       expect(parseIni(`${mockInput}${mockInput2}`)).toStrictEqual({
         [mockProfileName]: {
           key: "value",
-          "subSection.subKey": "subValue",
+          [["subSection", "subKey"].join(CONFIG_PREFIX_SEPARATOR)]: "subValue",
         },
         [mockProfileName2]: {
           key: "value2",
-          "subSection.subKey": "subValue2",
+          [["subSection", "subKey"].join(CONFIG_PREFIX_SEPARATOR)]: "subValue2",
         },
       });
     });

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -1,5 +1,7 @@
 import { ParsedIniData } from "@smithy/types";
 
+import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
+
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {
@@ -28,7 +30,7 @@ export const parseIni = (iniData: string): ParsedIniData => {
           currentSubSection = name;
         } else {
           map[currentSection] = map[currentSection] || {};
-          const key = currentSubSection ? `${currentSubSection}.${name}` : name;
+          const key = currentSubSection ? [currentSubSection, name].join(CONFIG_PREFIX_SEPARATOR) : name;
           map[currentSection][key] = value;
         }
       }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/issues/991#issuecomment-1751201541

*Description of changes:*
Export CONFIG_PREFIX_SEPARATOR from loadSharedConfigFiles

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
