### PR TITLE
fix(experimentalIdentityAndAuth): fix `@httpApiKeyAuth` `scheme` property writer

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -97,7 +97,7 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                     .source(t -> w -> {
                         HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
                         httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
-                            s -> w.write(s),
+                            s -> w.write("$S", s),
                             () -> w.write("undefined"));
                     })
                     .build())


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Fix `@httpApiKeyAuth` `scheme` property writer.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
