### PR TITLE
Add logging for `buildAndCopyToNodeModules()`

### DIFF
--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -32,6 +32,7 @@ const weatherSsdkDir = path.join(
 const nodeModulesDir = path.join(root, "node_modules");
 
 const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir) => {
+    console.log(`Building and copying package \`${packageName}\` in \`${codegenDir}\` to \`${nodeModulesDir}\``);
     // Yarn detects that the generated TypeScript package is nested beneath the
     // top-level package.json. Adding an empty lock file allows it to be treated
     // as its own package.


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add logging for `buildAndCopyToNodeModules()`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
