### PR TITLE
fix(experimentalIdentityAndAuth): add different `httpAuthSchemeMiddleware` plugins depending on `@endpointRuleSet`

### DIFF
--- a/.changeset/plenty-cycles-boil.md
+++ b/.changeset/plenty-cycles-boil.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add different `httpAuthSchemeMiddleware` plugins depending on `@endpointRuleSet`

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@smithy/middleware-endpoint": "workspace:^",
     "@smithy/middleware-retry": "workspace:^",
+    "@smithy/middleware-serde": "workspace:^",
     "@smithy/protocol-http": "workspace:^",
     "@smithy/signature-v4": "workspace:^",
     "@smithy/types": "workspace:^",

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/getHttpAuthSchemeEndpointRuleSetPlugin.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/getHttpAuthSchemeEndpointRuleSetPlugin.ts
@@ -1,4 +1,4 @@
-import { serializerMiddlewareOption } from "@smithy/middleware-serde";
+import { endpointMiddlewareOptions } from "@smithy/middleware-endpoint";
 import { HandlerExecutionContext, Pluggable, RelativeMiddlewareOptions, SerializeHandlerOptions } from "@smithy/types";
 
 import { HttpAuthSchemeParameters } from "../HttpAuthSchemeProvider";
@@ -7,19 +7,19 @@ import { httpAuthSchemeMiddleware, PreviouslyResolved } from "./httpAuthSchemeMi
 /**
  * @internal
  */
-export const httpAuthSchemeMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
+export const httpAuthSchemeEndpointRuleSetMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
   step: "serialize",
   tags: ["HTTP_AUTH_SCHEME"],
   name: "httpAuthSchemeMiddleware",
   override: true,
   relation: "before",
-  toMiddleware: serializerMiddlewareOption.name!,
+  toMiddleware: endpointMiddlewareOptions.name!,
 };
 
 /**
  * @internal
  */
-export const getHttpAuthSchemePlugin = <
+export const getHttpAuthSchemeEndpointRuleSetPlugin = <
   TConfig extends object,
   TContext extends HandlerExecutionContext,
   TParameters extends HttpAuthSchemeParameters,
@@ -28,6 +28,6 @@ export const getHttpAuthSchemePlugin = <
   config: TConfig & PreviouslyResolved<TConfig, TContext, TParameters, TInput>
 ): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
-    clientStack.addRelativeTo(httpAuthSchemeMiddleware(config), httpAuthSchemeMiddlewareOptions);
+    clientStack.addRelativeTo(httpAuthSchemeMiddleware(config), httpAuthSchemeEndpointRuleSetMiddlewareOptions);
   },
 });

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/index.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/index.ts
@@ -1,2 +1,3 @@
 export * from "./httpAuthSchemeMiddleware";
+export * from "./getHttpAuthSchemeEndpointRuleSetPlugin";
 export * from "./getHttpAuthSchemePlugin";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
@@ -5,8 +5,6 @@
 
 package software.amazon.smithy.typescript.codegen.auth.http.integration;
 
-import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +15,7 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.ConfigField;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
@@ -27,6 +26,7 @@ import software.amazon.smithy.typescript.codegen.auth.AuthUtils;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -46,10 +46,18 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
     public List<RuntimeClientPlugin> getClientPlugins() {
         return List.of(
             RuntimeClientPlugin.builder()
+                .servicePredicate((m, s) -> s.hasTrait(EndpointRuleSetTrait.ID))
+                .withConventions(
+                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                    "HttpAuthSchemeEndpointRuleSet",
+                    Convention.HAS_MIDDLEWARE)
+                .build(),
+            RuntimeClientPlugin.builder()
+                .servicePredicate((m, s) -> !s.hasTrait(EndpointRuleSetTrait.ID))
                 .withConventions(
                     TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
                     "HttpAuthScheme",
-                    HAS_MIDDLEWARE)
+                    Convention.HAS_MIDDLEWARE)
                 .build(),
             RuntimeClientPlugin.builder()
                 .inputConfig(Symbol.builder()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,7 @@ __metadata:
   dependencies:
     "@smithy/middleware-endpoint": "workspace:^"
     "@smithy/middleware-retry": "workspace:^"
+    "@smithy/middleware-serde": "workspace:^"
     "@smithy/protocol-http": "workspace:^"
     "@smithy/signature-v4": "workspace:^"
     "@smithy/types": "workspace:^"


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

*Dependent on: https://github.com/awslabs/smithy-typescript/pull/1002*

Add different `httpAuthSchemeMiddleware` plugins depending on `@endpointRuleSet`.

*Testing:*

```diff
diff --color -Nur /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts
--- /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build_old/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts	2023-10-10 09:54:04
+++ /Users/yuasteve/development/ts-ia/smithy-typescript/smithy-typescript-codegen-test/build/smithyprojections/smithy-typescript-codegen-test/client-experimental-identity-and-auth/typescript-codegen/src/WeatherClient.ts	2023-10-10 09:54:59
@@ -110,7 +110,7 @@
 } from "@smithy/eventstream-serde-config-resolver";
 import {
   HttpAuthScheme,
-  getHttpAuthSchemePlugin,
+  getHttpAuthSchemeEndpointRuleSetPlugin,
   getHttpSigningPlugin,
 } from "@smithy/experimental-identity-and-auth";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
@@ -407,7 +407,7 @@
     this.config = _config_8;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(getHttpAuthSchemePlugin(this.config));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config));
     this.middlewareStack.use(getHttpSigningPlugin(this.config));
   }
```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
