### PR TITLE
fix(experimentalIdentityAndAuth): add await to `signer.sign()` in `httpSigningMiddleware`

### DIFF
--- a/.changeset/silent-colts-flow.md
+++ b/.changeset/silent-colts-flow.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Await `signer.sign()` in `httpSigningMiddleware`

--- a/packages/experimental-identity-and-auth/src/middleware-http-signing/httpSigningMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-signing/httpSigningMiddleware.ts
@@ -52,6 +52,6 @@ export const httpSigningMiddleware = <Input extends object, Output extends objec
   } = scheme;
   return next({
     ...args,
-    request: signer.sign(args.request, identity, signingProperties || {}),
+    request: await signer.sign(args.request, identity, signingProperties || {}),
   });
 };


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add await to `signer.sign()` in `httpSigningMiddleware`).

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
