### PR TITLE
fix(experimentalIdentityAndAuth): remove extra `$` from `HttpApiKeyAuthSigner`

### DIFF
--- a/.changeset/silver-comics-fetch.md
+++ b/.changeset/silver-comics-fetch.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Remove extra `$` from `HttpApiKeyAuthSigner`

--- a/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
@@ -37,7 +37,7 @@ export class HttpApiKeyAuthSigner implements HttpSigner {
       clonedRequest.query[signingProperties.name] = identity.apiKey;
     } else if (signingProperties.in === HttpApiKeyAuthLocation.HEADER) {
       clonedRequest.headers[signingProperties.name] = signingProperties.scheme
-        ? `$${signingProperties.scheme} $${identity.apiKey}`
+        ? `${signingProperties.scheme} ${identity.apiKey}`
         : identity.apiKey;
     } else {
       throw new Error(


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Remove extra `$` from `HttpApiKeyAuthSigner`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
