### PR TITLE
feat(experimentalIdentityAndAuth): add `@httpApiKeyAuth` integration tests

### DIFF
--- a/.changeset/little-doors-live.md
+++ b/.changeset/little-doors-live.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add `@httpApiKeyAuth` integration tests.

--- a/.changeset/tasty-fishes-explain.md
+++ b/.changeset/tasty-fishes-explain.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add strict check for `apiKey` in `HttpApiKeyAuthSigner`.

--- a/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
@@ -32,6 +32,9 @@ export class HttpApiKeyAuthSigner implements HttpSigner {
     if (!signingProperties.in) {
       throw new Error("request could not be signed with `apiKey` since the `in` signer property is missing");
     }
+    if (!identity.apiKey) {
+      throw new Error("request could not be signed with `apiKey` since the `apiKey` is not defined");
+    }
     const clonedRequest = httpRequest.clone();
     if (signingProperties.in === HttpApiKeyAuthLocation.QUERY) {
       clonedRequest.query[signingProperties.name] = identity.apiKey;

--- a/packages/experimental-identity-and-auth/src/integration/httpApiKeyAuth.integ.spec.ts
+++ b/packages/experimental-identity-and-auth/src/integration/httpApiKeyAuth.integ.spec.ts
@@ -1,0 +1,215 @@
+import {
+  HttpApiKeyAuthServiceClient,
+  OnlyHttpApiKeyAuthCommand,
+  OnlyHttpApiKeyAuthOptionalCommand,
+  SameAsServiceCommand,
+} from "@smithy/identity-and-auth-http-api-key-auth-service";
+import { requireRequestsFrom } from "@smithy/util-test";
+
+describe("@httpApiKeyAuth integration tests", () => {
+  // TODO(experimentalIdentityAndAuth): should match `HttpApiKeyAuthService` `@httpApiKeyAuth` trait
+  const MOCK_API_KEY_NAME = "Authorization";
+  const MOCK_API_KEY_SCHEME = "ApiKey";
+  const MOCK_API_KEY = "APIKEY_123";
+
+  // Arbitrary mock endpoint (`requireRequestsFrom()` intercepts network requests)
+  const MOCK_ENDPOINT = "https://foo.bar";
+
+  describe("Operation requires `@httpApiKeyAuth`", () => {
+    it("Request is thrown when `apiKey` is not configured", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new OnlyHttpApiKeyAuthCommand({}))).rejects.toThrow(
+        "HttpAuthScheme `smithy.api#httpApiKeyAuth` did not have an IdentityProvider configured."
+      );
+    });
+
+    it("Request is thrown when `apiKey` is configured incorrectly", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {} as any,
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new OnlyHttpApiKeyAuthCommand({}))).rejects.toThrow(
+        "request could not be signed with `apiKey` since the `apiKey` is not defined"
+      );
+    });
+
+    it("Request is thrown given configured `apiKey` identity provider throws", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => {
+          throw new Error("IdentityProvider throws this error");
+        },
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new OnlyHttpApiKeyAuthCommand({}))).rejects.toThrow(
+        "IdentityProvider throws this error"
+      );
+    });
+
+    it("Request is signed given configured `apiKey` identity provider", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => ({
+          apiKey: MOCK_API_KEY,
+        }),
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new OnlyHttpApiKeyAuthCommand({}));
+    });
+
+    it("Request is signed given configured `apiKey` identity", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {
+          apiKey: MOCK_API_KEY,
+        },
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new OnlyHttpApiKeyAuthCommand({}));
+    });
+  });
+
+  describe("Operation has `@httpApiKeyAuth` and `@optionalAuth`", () => {
+    it("Request is NOT thrown and NOT signed when `apiKey` is not configured", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: (value) => expect(value).toBeUndefined(),
+        },
+      });
+      await client.send(new OnlyHttpApiKeyAuthOptionalCommand({}));
+    });
+
+    it("Request is thrown when `apiKey` is configured incorrectly", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {} as any,
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new OnlyHttpApiKeyAuthOptionalCommand({}))).rejects.toThrow(
+        "request could not be signed with `apiKey` since the `apiKey` is not defined"
+      );
+    });
+
+    it("Request is thrown given configured `apiKey` identity provider throws", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => {
+          throw new Error("IdentityProvider throws this error");
+        },
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new OnlyHttpApiKeyAuthOptionalCommand({}))).rejects.toThrow(
+        "IdentityProvider throws this error"
+      );
+    });
+
+    it("Request is signed given configured `apiKey` identity provider", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => ({
+          apiKey: MOCK_API_KEY,
+        }),
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new OnlyHttpApiKeyAuthOptionalCommand({}));
+    });
+
+    it("Request is signed given configured `apiKey` identity", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {
+          apiKey: MOCK_API_KEY,
+        },
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new OnlyHttpApiKeyAuthOptionalCommand({}));
+    });
+  });
+
+  describe("Service has `@httpApiKeyAuth`", () => {
+    it("Request is thrown when `apiKey` is not configured", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
+        "HttpAuthScheme `smithy.api#httpApiKeyAuth` did not have an IdentityProvider configured."
+      );
+    });
+
+    it("Request is thrown when `apiKey` is configured incorrectly", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {} as any,
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow(
+        "request could not be signed with `apiKey` since the `apiKey` is not defined"
+      );
+    });
+
+    it("Request is thrown given configured `apiKey` identity provider throws", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => {
+          throw new Error("IdentityProvider throws this error");
+        },
+      });
+      requireRequestsFrom(client).toMatch({});
+      await expect(client.send(new SameAsServiceCommand({}))).rejects.toThrow("IdentityProvider throws this error");
+    });
+
+    it("Request is signed given configured `apiKey` identity provider", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: async () => ({
+          apiKey: MOCK_API_KEY,
+        }),
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new SameAsServiceCommand({}));
+    });
+
+    it("Request is signed given configured `apiKey` identity", async () => {
+      const client = new HttpApiKeyAuthServiceClient({
+        endpoint: MOCK_ENDPOINT,
+        apiKey: {
+          apiKey: MOCK_API_KEY,
+        },
+      });
+      requireRequestsFrom(client).toMatch({
+        headers: {
+          [MOCK_API_KEY_NAME]: `${MOCK_API_KEY_SCHEME} ${MOCK_API_KEY}`,
+        },
+      });
+      await client.send(new SameAsServiceCommand({}));
+    });
+  });
+});

--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -36,6 +36,13 @@ const weatherSsdkDir = path.join(
     "typescript-ssdk-codegen"
 )
 
+// TODO(experimentalIdentityAndAuth): add `@httpApiKeyAuth` client for integration tests
+const httpApiKeyAuthClientDir = path.join(
+    codegenTestDir,
+    "identity-and-auth-http-api-key-auth",
+    "typescript-codegen"
+);
+
 const nodeModulesDir = path.join(root, "node_modules");
 
 const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir) => {
@@ -61,6 +68,8 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
     await buildAndCopyToNodeModules("weather-ssdk", weatherSsdkDir, nodeModulesDir);
     // TODO(experimentalIdentityAndAuth): build generic client for integration tests
     await buildAndCopyToNodeModules("@smithy/weather-experimental-identity-and-auth", weatherExperimentalIdentityAndAuthClientDir, nodeModulesDir);
+    // TODO(experimentalIdentityAndAuth): add `@httpApiKeyAuth` client for integration tests
+    await buildAndCopyToNodeModules("@smithy/identity-and-auth-http-api-key-auth-service", httpApiKeyAuthClientDir, nodeModulesDir);
  } catch (e) {
     console.log(e);
     process.exit(1);

--- a/smithy-typescript-codegen-test/model/identity-and-auth/httpApiKeyAuth/HttpApiKeyAuthService.smithy
+++ b/smithy-typescript-codegen-test/model/identity-and-auth/httpApiKeyAuth/HttpApiKeyAuthService.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace identity.auth.httpApiKeyAuth
+
+use common#fakeProtocol
+
+@fakeProtocol
+@httpApiKeyAuth(scheme: "ApiKey", name: "Authorization", in: "header")
+service HttpApiKeyAuthService {
+    operations: [
+        OnlyHttpApiKeyAuth
+        OnlyHttpApiKeyAuthOptional
+        SameAsService
+    ]
+}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAuth")
+@auth([httpApiKeyAuth])
+operation OnlyHttpApiKeyAuth {}
+
+@http(method: "GET", uri: "/OnlyHttpApiKeyAuthOptional")
+@auth([httpApiKeyAuth])
+@optionalAuth
+operation OnlyHttpApiKeyAuthOptional {}
+
+@http(method: "GET", uri: "/SameAsService")
+operation SameAsService {}

--- a/smithy-typescript-codegen-test/smithy-build.json
+++ b/smithy-typescript-codegen-test/smithy-build.json
@@ -74,6 +74,29 @@
                     }
                 }
             }
+        },
+        "identity-and-auth-http-api-key-auth": {
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["identity.auth.httpApiKeyAuth#HttpApiKeyAuthService"]
+                    }
+                }
+            ],
+            "plugins": {
+                "typescript-codegen": {
+                    "service": "identity.auth.httpApiKeyAuth#HttpApiKeyAuthService",
+                    "targetNamespace": "HttpApiKeyAuthService",
+                    "package": "@smithy/identity-and-auth-http-api-key-auth-service",
+                    "packageVersion": "0.0.1",
+                    "packageJson": {
+                        "license": "Apache-2.0",
+                        "private": true
+                    },
+                    "experimentalIdentityAndAuth": true
+                }
+            }
         }
     },
     "plugins": {


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

*Dependent on: https://github.com/awslabs/smithy-typescript/pull/1018, https://github.com/awslabs/smithy-typescript/pull/1021, https://github.com/awslabs/smithy-typescript/pull/1023*

Add `@httpApiKeyAuth` integration tests.

*Testing:*

1. Ran `yarn test:integration`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
