### PR TITLE
Add `-p` for `mkdir` in `build-generated-test-packages`

### DIFF
--- a/scripts/build-generated-test-packages.js
+++ b/scripts/build-generated-test-packages.js
@@ -42,7 +42,7 @@ const buildAndCopyToNodeModules = async (packageName, codegenDir, nodeModulesDir
     // it can be used in integration tests by other packages within the monorepo.
     await spawnProcess("yarn", ["pack"], { cwd: codegenDir });
     await spawnProcess("rm", ["-rf", packageName], { cwd: nodeModulesDir });
-    await spawnProcess("mkdir", [packageName], { cwd: nodeModulesDir });
+    await spawnProcess("mkdir", ["-p", packageName], { cwd: nodeModulesDir });
     const targetPackageDir = path.join(nodeModulesDir, packageName);
     await spawnProcess("tar", ["-xf", "package.tgz", "-C", targetPackageDir, "--strip-components", "1"], { cwd: codegenDir });
 };


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add `-p` for `mkdir` in `build-generated-test-packages`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
