### PR TITLE
fix: default keepalive=false for fetch

### DIFF
--- a/.changeset/sixty-scissors-bake.md
+++ b/.changeset/sixty-scissors-bake.md
@@ -1,0 +1,5 @@
+---
+"@smithy/fetch-http-handler": patch
+---
+
+set keepalive default to false in fetch handler

--- a/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.browser.spec.ts
@@ -28,7 +28,7 @@ describe(FetchHttpHandler.name, () => {
       const requestArgs = winReqSpy.calls.argsFor(0);
       expect(requestArgs[0]).toEqual(expectedUrl);
       expect(requestArgs[1].method).toEqual(mockHttpRequest.method);
-      expect(requestArgs[1].keepalive).toEqual(true);
+      expect(requestArgs[1].keepalive).toEqual(false);
     });
 
     for (const method of ["GET", "HEAD"]) {
@@ -45,15 +45,15 @@ describe(FetchHttpHandler.name, () => {
       });
     }
 
-    it(`sets keepalive to false if explicitly requested`, async () => {
-      const fetchHttpHandler = new FetchHttpHandler({ keepAlive: false });
+    it(`sets keepalive to true if explicitly requested`, async () => {
+      const fetchHttpHandler = new FetchHttpHandler({ keepAlive: true });
       const winReqSpy = spyOn(window, "Request");
 
       const mockHttpRequest = getMockHttpRequest({});
       await fetchHttpHandler.handle(mockHttpRequest);
 
       const requestArgs = winReqSpy.calls.argsFor(0);
-      expect(requestArgs[1].keepalive).toEqual(false);
+      expect(requestArgs[1].keepalive).toEqual(true);
     });
 
     it(`builds querystring if provided`, async () => {

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -361,7 +361,7 @@ describe(FetchHttpHandler.name, () => {
   });
 
   describe("keepalive", () => {
-    it("will pass keepalive as true by default to request if supported", async () => {
+    it("will pass keepalive as false by default to request if supported", async () => {
       const mockResponse = {
         headers: {
           entries: jest.fn().mockReturnValue([
@@ -379,7 +379,7 @@ describe(FetchHttpHandler.name, () => {
       keepAliveSupport.supported = true;
       await fetchHttpHandler.handle({} as any, {});
 
-      expect(mockRequest.mock.calls[0][1].keepalive).toBe(true);
+      expect(mockRequest.mock.calls[0][1].keepalive).toBe(false);
     });
 
     it("will pass keepalive to request if supported", async () => {
@@ -395,12 +395,12 @@ describe(FetchHttpHandler.name, () => {
       const mockFetch = jest.fn().mockResolvedValue(mockResponse);
       (global as any).fetch = mockFetch;
 
-      const fetchHttpHandler = new FetchHttpHandler({ keepAlive: false });
+      const fetchHttpHandler = new FetchHttpHandler({ keepAlive: true });
 
       keepAliveSupport.supported = true;
       await fetchHttpHandler.handle({} as any, {});
 
-      expect(mockRequest.mock.calls[0][1].keepalive).toBe(false);
+      expect(mockRequest.mock.calls[0][1].keepalive).toBe(true);
     });
 
     it("will not have keepalive property in request if not supported", async () => {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -17,7 +17,13 @@ export interface FetchHttpHandlerOptions {
   requestTimeout?: number;
 
   /**
-   * Whether to allow the request to outlive the page. Default value is true
+   * Whether to allow the request to outlive the page. Default value is false.
+   *
+   * There may be limitations to the payload size, number of concurrent requests,
+   * request duration etc. when using keepalive in browsers.
+   *
+   * These may change over time, so look for up to date information about
+   * these limitations before enabling keepalive.
    */
   keepAlive?: boolean;
 }
@@ -59,7 +65,7 @@ export class FetchHttpHandler implements HttpHandler<FetchHttpHandlerConfig> {
       this.config = await this.configProvider;
     }
     const requestTimeoutInMs = this.config!.requestTimeout;
-    const keepAlive = this.config!.keepAlive ?? true;
+    const keepAlive = this.config!.keepAlive === true;
 
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {


### PR DESCRIPTION
fixes https://github.com/aws/aws-sdk-js-v3/issues/5334

sets fetch keepalive default to false.
keepalive for fetch has limitations in Chrome described in https://github.com/whatwg/fetch/issues/679
