### PR TITLE
fix(experimentalIdentityAndAuth): move `@smithy/util-test` to `devDependencies`

### DIFF
--- a/.changeset/moody-eggs-kiss.md
+++ b/.changeset/moody-eggs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Move `@smithy/util-test` to `devDependencies`.

--- a/packages/experimental-identity-and-auth/package.json
+++ b/packages/experimental-identity-and-auth/package.json
@@ -30,7 +30,6 @@
     "@smithy/protocol-http": "workspace:^",
     "@smithy/signature-v4": "workspace:^",
     "@smithy/types": "workspace:^",
-    "@smithy/util-test": "workspace:^",
     "tslib": "^2.5.0"
   },
   "engines": {
@@ -53,6 +52,7 @@
     "directory": "packages/experimental-identity-and-auth"
   },
   "devDependencies": {
+    "@smithy/util-test": "workspace:^",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Move `@smithy/util-test` to `devDependencies`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
