### PR TITLE
fix(experimentalIdentityAndAuth): add strict check for `token` in `HttpBearerAuthSigner`

### DIFF
--- a/.changeset/great-cycles-wave.md
+++ b/.changeset/great-cycles-wave.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add strict check for `token` in `HttpBearerAuthSigner`.

--- a/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpBearerAuth.ts
@@ -14,6 +14,9 @@ export class HttpBearerAuthSigner implements HttpSigner {
     signingProperties: Record<string, any>
   ): Promise<IHttpRequest> {
     const clonedRequest = httpRequest.clone();
+    if (!identity.token) {
+      throw new Error("request could not be signed with `token` since the `token` is not defined");
+    }
     clonedRequest.headers["Authorization"] = `Bearer ${identity.token}`;
     return clonedRequest;
   }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add strict check for `token` in `HttpBearerAuthSigner`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
