### PR TITLE
fix(experimentalIdentityAndAuth): add strict check for `apiKey` in `HttpApiKeyAuthSigner`

### DIFF
--- a/.changeset/tasty-fishes-explain.md
+++ b/.changeset/tasty-fishes-explain.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Add strict check for `apiKey` in `HttpApiKeyAuthSigner`.

--- a/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
+++ b/packages/experimental-identity-and-auth/src/httpApiKeyAuth.ts
@@ -32,6 +32,9 @@ export class HttpApiKeyAuthSigner implements HttpSigner {
     if (!signingProperties.in) {
       throw new Error("request could not be signed with `apiKey` since the `in` signer property is missing");
     }
+    if (!identity.apiKey) {
+      throw new Error("request could not be signed with `apiKey` since the `apiKey` is not defined");
+    }
     const clonedRequest = httpRequest.clone();
     if (signingProperties.in === HttpApiKeyAuthLocation.QUERY) {
       clonedRequest.query[signingProperties.name] = identity.apiKey;


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Add strict check for `apiKey` in `HttpApiKeyAuthSigner`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
