### PR TITLE
Fix operation index file codegen

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -531,8 +531,12 @@ final class CommandGenerator implements Runnable {
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        for (OperationShape operation : containedOperations) {
-            writer.write("export * from \"./$L\";", symbolProvider.toSymbol(operation).getName());
+        if (containedOperations.isEmpty()) {
+            writer.write("export {};");
+        } else {
+            for (OperationShape operation : containedOperations) {
+                writer.write("export * from \"./$L\";", symbolProvider.toSymbol(operation).getName());
+            }
         }
 
         fileManifest.writeFile(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/DirectedTypeScriptCodegen.java
@@ -300,18 +300,24 @@ final class DirectedTypeScriptCodegen
         ProtocolGenerator protocolGenerator = directive.context().protocolGenerator();
         ApplicationProtocol applicationProtocol = directive.context().applicationProtocol();
 
+        // Write operation index files
+        if (settings.generateClient()) {
+            CommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
+        }
+        if (settings.generateServerSdk()) {
+            ServerCommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
+        }
+
         // Generate each operation for the service.
         for (OperationShape operation : directive.operations()) {
             // Right now this only generates stubs
             if (settings.generateClient()) {
-                CommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
                 delegator.useShapeWriter(operation, commandWriter -> new CommandGenerator(
                         settings, model, operation, symbolProvider, commandWriter,
                         runtimePlugins, protocolGenerator, applicationProtocol).run());
             }
 
             if (settings.generateServerSdk()) {
-                ServerCommandGenerator.writeIndex(model, service, symbolProvider, fileManifest);
                 delegator.useShapeWriter(operation, commandWriter -> new ServerCommandGenerator(
                         settings, model, operation, symbolProvider, commandWriter,
                         protocolGenerator, applicationProtocol).run());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServerCommandGenerator.java
@@ -240,8 +240,12 @@ final class ServerCommandGenerator implements Runnable {
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        for (OperationShape operation : containedOperations) {
-            writer.write("export * from \"./$L\";", symbolProvider.toSymbol(operation).getName());
+        if (containedOperations.isEmpty()) {
+            writer.write("export {};");
+        } else {
+            for (OperationShape operation : containedOperations) {
+                writer.write("export * from \"./$L\";", symbolProvider.toSymbol(operation).getName());
+            }
         }
 
         fileManifest.writeFile(

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/ServiceBareBonesClientGenerator.java
@@ -142,7 +142,7 @@ final class ServiceBareBonesClientGenerator implements Runnable {
         writer.write("export type $L = ", typeName);
         writer.indent();
         // If we have less symbols than operations, at least one doesn't have a type, so add the default.
-        if (containedOperations.size() != symbols.size()) {
+        if (containedOperations.size() != symbols.size() || containedOperations.isEmpty()) {
             defaultTypeGenerator.accept(writer);
         }
         for (int i = 0; i < symbols.size(); i++) {


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Fix operation index file codegen:

- For services with no operations, export an empty module and use
  default service input/output types
- Move operation index writing outside of operation loop

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
