### PR TITLE
Add missing dependency of @smithy/shared-ini-file-loader

### DIFF
--- a/.changeset/grumpy-berries-learn.md
+++ b/.changeset/grumpy-berries-learn.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+Add missing dependency @smithy/shared-ini-file-loader

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@smithy/middleware-serde": "workspace:^",
     "@smithy/node-config-provider": "workspace:^",
+    "@smithy/shared-ini-file-loader": "workspace:^",
     "@smithy/types": "workspace:^",
     "@smithy/url-parser": "workspace:^",
     "@smithy/util-middleware": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,7 @@ __metadata:
   dependencies:
     "@smithy/middleware-serde": "workspace:^"
     "@smithy/node-config-provider": "workspace:^"
+    "@smithy/shared-ini-file-loader": "workspace:^"
     "@smithy/types": "workspace:^"
     "@smithy/url-parser": "workspace:^"
     "@smithy/util-middleware": "workspace:^"


### PR DESCRIPTION
*Issue #, if available:*
* Fixes: https://github.com/awslabs/smithy-typescript/issues/1019
* The dependency was used in https://github.com/awslabs/smithy-typescript/pull/1014, but wasn't added in package.json

*Description of changes:*
Add missing dependency of @smithy/shared-ini-file-loader

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
