### PR TITLE
fix(experimentalIdentityAndAuth): fix typo in `httpAuthSchemeMiddleware`

### DIFF
--- a/.changeset/weak-pots-know.md
+++ b/.changeset/weak-pots-know.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Fix typo in `HttpAuthScheme` not enabled message in `httpAuthSchemeMiddleware`.

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -84,7 +84,7 @@ export const httpAuthSchemeMiddleware = <
   for (const option of options) {
     const scheme = authSchemes.get(option.schemeId);
     if (!scheme) {
-      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enable for this service.`);
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enabled for this service.`);
       continue;
     }
     const identityProvider = scheme.identityProvider(config.identityProviderConfig);


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Fix typo in `HttpAuthScheme` not enabled message in `httpAuthSchemeMiddleware`.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
