### PR TITLE
feat(experimentalIdentityAndAuth): allow extracting config properties for identity and auth

### DIFF
--- a/.changeset/wild-swans-hang.md
+++ b/.changeset/wild-swans-hang.md
@@ -1,0 +1,5 @@
+---
+"@smithy/experimental-identity-and-auth": patch
+---
+
+Allow extracting config properties for identity and auth.

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -37,6 +37,12 @@ export interface HttpAuthOption {
   schemeId: HttpAuthSchemeId;
   identityProperties?: Record<string, unknown>;
   signingProperties?: Record<string, unknown>;
+  configPropertiesExtractor?: (
+    config: Record<string, unknown>
+  ) => {
+    identityProperties?: Record<string, unknown>;
+    signingProperties?: Record<string, unknown>;
+  };
 }
 
 /**

--- a/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/experimental-identity-and-auth/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -1,6 +1,5 @@
 import {
   HandlerExecutionContext,
-  MetadataBearer,
   SerializeHandler,
   SerializeHandlerArguments,
   SerializeHandlerOutput,
@@ -92,10 +91,13 @@ export const httpAuthSchemeMiddleware = <
       failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` did not have an IdentityProvider configured.`);
       continue;
     }
-    const identity = await identityProvider(option.identityProperties || {});
+    const { identityProperties = {}, signingProperties = {} } =
+      option.configPropertiesExtractor?.(config as Record<string, unknown>) || {};
+    option.identityProperties = Object.assign(option.identityProperties || {}, identityProperties);
+    option.signingProperties = Object.assign(option.signingProperties || {}, signingProperties);
     smithyContext.selectedHttpAuthScheme = {
       httpAuthOption: option,
-      identity,
+      identity: await identityProvider(option.identityProperties),
       signer: scheme.signer,
     };
     break;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.typescript.codegen.auth.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
@@ -35,6 +36,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     private final List<ConfigField> configFields;
     private final List<HttpAuthSchemeParameter> httpAuthSchemeParameters;
     private final List<HttpAuthOptionProperty> httpAuthOptionProperties;
+    private final Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor;
 
     private HttpAuthScheme(Builder builder) {
         this.schemeId = SmithyBuilder.requiredState(
@@ -52,6 +54,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             "httpAuthSchemeParameters", builder.httpAuthSchemeParameters.copy());
         this.httpAuthOptionProperties = SmithyBuilder.requiredState(
             "httpAuthOptionProperties", builder.httpAuthOptionProperties.copy());
+        this.httpAuthOptionConfigPropertiesExtractor =
+            builder.httpAuthOptionConfigPropertiesExtractor;
     }
 
     /**
@@ -128,6 +132,14 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     }
 
     /**
+     * Gets the writer for the config properties extractor.
+     * @return optional of config properties extractor
+     */
+    public Optional<Consumer<TypeScriptWriter>> getHttpAuthOptionConfigPropertiesExtractor() {
+        return Optional.ofNullable(httpAuthOptionConfigPropertiesExtractor);
+    }
+
+    /**
      * Creates a {@link Builder}.
      * @return a builder
      */
@@ -149,7 +161,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             .defaultSigners(defaultSigners)
             .configFields(configFields)
             .httpAuthSchemeParameters(httpAuthSchemeParameters)
-            .httpAuthOptionProperties(httpAuthOptionProperties);
+            .httpAuthOptionProperties(httpAuthOptionProperties)
+            .httpAuthOptionConfigPropertiesExtractor(httpAuthOptionConfigPropertiesExtractor);
     }
 
     /**
@@ -169,6 +182,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             BuilderRef.forList();
         private BuilderRef<List<HttpAuthOptionProperty>> httpAuthOptionProperties =
             BuilderRef.forList();
+        private Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor;
 
         private Builder() {}
 
@@ -341,6 +355,17 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
          */
         public Builder addHttpAuthOptionProperty(HttpAuthOptionProperty httpAuthOptionProperty) {
             this.httpAuthOptionProperties.get().add(httpAuthOptionProperty);
+            return this;
+        }
+
+        /**
+         * Sets the httpAuthOptionConfigPropertiesExtractor.
+         * @param httpAuthOptionConfigPropertiesExtractor writer for properties extractor
+         * @return the builder
+         */
+        public Builder httpAuthOptionConfigPropertiesExtractor(
+            Consumer<TypeScriptWriter> httpAuthOptionConfigPropertiesExtractor) {
+            this.httpAuthOptionConfigPropertiesExtractor = httpAuthOptionConfigPropertiesExtractor;
             return this;
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -246,6 +246,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                             }
                         });
                     }
+                    authScheme.getHttpAuthOptionConfigPropertiesExtractor()
+                        .ifPresent(extractor -> w.write("configPropertiesExtractor: $C", extractor));
                 });
             });
         });

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -102,6 +102,12 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
                         w.write("authParameters.region");
                     })
                     .build())
+                .httpAuthOptionConfigPropertiesExtractor(w -> w.write("""
+                    (config: Record<string, unknown>) => ({
+                      signingProperties: {
+                        sha256: config.sha256,
+                      },
+                    }),"""))
                 .build());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Allow extracting config properties for identity and auth:

- Update `httpAuthSchemeMiddleware` to check for `configPropertiesExtractor()` on `HttpAuthOption`.
- Add codegen for `configPropertiesExtractor()` in `HttpAuthScheme`
- Add codegen for `@aws.auth#sigv4` `configPropertiesExtractor()`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
