### PR TITLE
Parse profile name with invalid '@' character

### DIFF
--- a/.changeset/rude-mice-retire.md
+++ b/.changeset/rude-mice-retire.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Parse profile name with invalid '@' character

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -58,6 +58,17 @@ describe(parseIni.name, () => {
       }
     );
 
+    // Character `@` is not allowed in profile name, but some customers are using it.
+    // Refs: https://github.com/awslabs/smithy-typescript/issues/1026
+    it.each(["-", "_", "@"])("returns data for character '%s' in profile name", (specialChar: string) => {
+      const mockProfileName = ["profile", "stage"].join(specialChar);
+      const mockSectionFullName = ["profile", mockProfileName].join(" ");
+      const mockInput = getMockProfileContent(mockSectionFullName, mockProfileData);
+      expect(parseIni(mockInput)).toStrictEqual({
+        [["profile", mockProfileName].join(CONFIG_PREFIX_SEPARATOR)]: mockProfileData,
+      });
+    });
+
     it("returns data for two profiles", () => {
       const mockProfile1 = getMockProfileContent(mockProfileName, mockProfileData);
 

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -2,7 +2,9 @@ import { IniSectionType, ParsedIniData } from "@smithy/types";
 
 import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 
-const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-]+)\2$/;
+// Character `@` is not allowed in profile name, but some customers are using it.
+// Refs: https://github.com/awslabs/smithy-typescript/issues/1026
+const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@]+)\2$/;
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/1026

*Description of changes:*
Add support to parse profile name with invalid '@' character from ini file

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
