### PR TITLE
Parse profile name with invalid '+' character

### DIFF
--- a/.changeset/pretty-yaks-fix.md
+++ b/.changeset/pretty-yaks-fix.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Parse profile name with invalid '+' character

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -58,9 +58,10 @@ describe(parseIni.name, () => {
       }
     );
 
-    // Character `@` is not allowed in profile name, but some customers are using it.
-    // Refs: https://github.com/awslabs/smithy-typescript/issues/1026
-    it.each(["-", "_", "@"])("returns data for character '%s' in profile name", (specialChar: string) => {
+    // Some characters are not allowed in profile name, but we parse them as customers use them.
+    // `@` https://github.com/awslabs/smithy-typescript/issues/1026
+    // `+` https://github.com/aws/aws-sdk-js-v3/issues/5373
+    it.each(["-", "_", "@", "+"])("returns data for character '%s' in profile name", (specialChar: string) => {
       const mockProfileName = ["profile", "stage"].join(specialChar);
       const mockSectionFullName = ["profile", mockProfileName].join(" ");
       const mockInput = getMockProfileContent(mockSectionFullName, mockProfileData);

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -2,9 +2,7 @@ import { IniSectionType, ParsedIniData } from "@smithy/types";
 
 import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 
-// Character `@` is not allowed in profile name, but some customers are using it.
-// Refs: https://github.com/awslabs/smithy-typescript/issues/1026
-const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@]+)\2$/;
+const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@\+]+)\2$/;
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5373

*Description of changes:*
Add support to parse profile name with invalid '+' character from ini file

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
