### PR TITLE
fix: allow lowercase type names for endpoint parameters

### DIFF
--- a/.changeset/wise-monkeys-leave.md
+++ b/.changeset/wise-monkeys-leave.md
@@ -1,0 +1,5 @@
+---
+"@smithy/types": patch
+---
+
+allow lowercase type names for endpoint parameter

--- a/.changeset/wise-monkeys-leave.md
+++ b/.changeset/wise-monkeys-leave.md
@@ -2,4 +2,4 @@
 "@smithy/types": patch
 ---
 
-allow lowercase type names for endpoint parameter
+Allow lowercase type names for endpoint parameter

--- a/packages/types/src/endpoints/RuleSetObject.ts
+++ b/packages/types/src/endpoints/RuleSetObject.ts
@@ -6,7 +6,7 @@ export type DeprecatedObject = {
 };
 
 export type ParameterObject = {
-  type: "String" | "Boolean";
+  type: "String" | "string" | "Boolean" | "boolean";
   default?: string | boolean;
   required?: boolean;
   documentation?: string;


### PR DESCRIPTION
I think this fixes https://github.com/awslabs/smithy-typescript/issues/1048

This catches up the TS types with a recent Java code update.