### PR TITLE
Re-export existing endpoint types

### DIFF
--- a/.changeset/many-pillows-add.md
+++ b/.changeset/many-pillows-add.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-endpoints": patch
+---
+
+Re-export existing types

--- a/packages/util-endpoints/src/types/EndpointRuleObject.ts
+++ b/packages/util-endpoints/src/types/EndpointRuleObject.ts
@@ -1,18 +1,14 @@
-import { EndpointObjectProperty } from "@smithy/types";
+import {
+  EndpointObject as __EndpointObject,
+  EndpointObjectHeaders as __EndpointObjectHeaders,
+  EndpointObjectProperties as __EndpointObjectProperties,
+  EndpointObjectProperty,
+  EndpointRuleObject as __EndpointRuleObject,
+} from "@smithy/types";
 
-import { ConditionObject, Expression } from "./shared";
+export type EndpointObjectProperties = __EndpointObjectProperties;
 
-export type EndpointObjectProperties = Record<string, EndpointObjectProperty>;
-export type EndpointObjectHeaders = Record<string, Expression[]>;
-export type EndpointObject = {
-  url: Expression;
-  properties?: EndpointObjectProperties;
-  headers?: EndpointObjectHeaders;
-};
+export type EndpointObjectHeaders = __EndpointObjectHeaders;
+export type EndpointObject = __EndpointObject;
 
-export type EndpointRuleObject = {
-  type: "endpoint";
-  conditions?: ConditionObject[];
-  endpoint: EndpointObject;
-  documentation?: string;
-};
+export type EndpointRuleObject = __EndpointRuleObject;

--- a/packages/util-endpoints/src/types/ErrorRuleObject.ts
+++ b/packages/util-endpoints/src/types/ErrorRuleObject.ts
@@ -1,8 +1,3 @@
-import { ConditionObject, Expression } from "./shared";
+import { ErrorRuleObject as __ErrorRuleObject } from "@smithy/types";
 
-export type ErrorRuleObject = {
-  type: "error";
-  conditions?: ConditionObject[];
-  error: Expression;
-  documentation?: string;
-};
+export type ErrorRuleObject = __ErrorRuleObject;

--- a/packages/util-endpoints/src/types/RuleSetObject.ts
+++ b/packages/util-endpoints/src/types/RuleSetObject.ts
@@ -1,22 +1,11 @@
-import { RuleSetRules } from "./TreeRuleObject";
+import {
+  DeprecatedObject as __DeprecatedObject,
+  ParameterObject as __ParameterObject,
+  RuleSetObject as __RuleSetObject,
+} from "@smithy/types";
 
-export type DeprecatedObject = {
-  message?: string;
-  since?: string;
-};
+export type DeprecatedObject = __DeprecatedObject;
 
-export type ParameterObject = {
-  type: "String" | "Boolean";
-  default?: string | boolean;
-  required?: boolean;
-  documentation?: string;
-  builtIn?: string;
-  deprecated?: DeprecatedObject;
-};
+export type ParameterObject = __ParameterObject;
 
-export type RuleSetObject = {
-  version: string;
-  serviceId?: string;
-  parameters: Record<string, ParameterObject>;
-  rules: RuleSetRules;
-};
+export type RuleSetObject = __RuleSetObject;

--- a/packages/util-endpoints/src/types/TreeRuleObject.ts
+++ b/packages/util-endpoints/src/types/TreeRuleObject.ts
@@ -1,12 +1,5 @@
-import { EndpointRuleObject } from "./EndpointRuleObject";
-import { ErrorRuleObject } from "./ErrorRuleObject";
-import { ConditionObject } from "./shared";
+import { RuleSetRules as __RuleSetRules, TreeRuleObject as __TreeRuleObject } from "@smithy/types";
 
-export type RuleSetRules = Array<EndpointRuleObject | ErrorRuleObject | TreeRuleObject>;
+export type RuleSetRules = __RuleSetRules;
 
-export type TreeRuleObject = {
-  type: "tree";
-  conditions?: ConditionObject[];
-  rules: RuleSetRules;
-  documentation?: string;
-};
+export type TreeRuleObject = __TreeRuleObject;


### PR DESCRIPTION
Fix for CI error encountered on https://github.com/awslabs/smithy-typescript/pull/1044 due to discrepancy in endpoint types after change in https://github.com/awslabs/smithy-typescript/pull/1050.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
