### PR TITLE
feat(credential-provider-imds): add flag for blocking imds v1 fallback behavior

### DIFF
--- a/.changeset/afraid-teachers-grab.md
+++ b/.changeset/afraid-teachers-grab.md
@@ -1,0 +1,5 @@
+---
+"@smithy/credential-provider-imds": minor
+---
+
+Add IMDSv1 toggle.

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wrapper/
 
 # local scripting
 Makefile
+workspace
 
 # Visual Studio Code
 .vscode/*

--- a/packages/credential-provider-imds/src/error/InstanceMetadataV1FallbackError.ts
+++ b/packages/credential-provider-imds/src/error/InstanceMetadataV1FallbackError.ts
@@ -1,0 +1,16 @@
+import { CredentialsProviderError } from "@smithy/property-provider";
+
+/**
+ * @public
+ *
+ * A specific sub-case of CredentialsProviderError, when the IMDSv1 fallback
+ * has been attempted but shut off by SDK configuration.
+ */
+export class InstanceMetadataV1FallbackError extends CredentialsProviderError {
+  public name = "InstanceMetadataV1FallbackError";
+
+  constructor(message: string, public readonly tryNextLink: boolean = true) {
+    super(message, tryNextLink);
+    Object.setPrototypeOf(this, InstanceMetadataV1FallbackError.prototype);
+  }
+}

--- a/packages/credential-provider-imds/src/fromInstanceMetadata.ts
+++ b/packages/credential-provider-imds/src/fromInstanceMetadata.ts
@@ -116,9 +116,6 @@ const getInstanceImdsProvider = (init: RemoteProviderInit) => {
       let token: string;
       try {
         token = (await getMetadataToken({ ...endpoint, timeout })).toString();
-        throw {
-          statusCode: 404,
-        };
       } catch (error) {
         if (error?.statusCode === 400) {
           throw Object.assign(error, {

--- a/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
+++ b/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts
@@ -13,7 +13,7 @@ export const DEFAULT_TIMEOUT = 1000;
 export const DEFAULT_MAX_RETRIES = 0;
 
 /**
- * @internal
+ * @public
  */
 export interface RemoteProviderConfig {
   /**
@@ -28,10 +28,18 @@ export interface RemoteProviderConfig {
 }
 
 /**
- * @internal
+ * @public
  */
 export interface RemoteProviderInit extends Partial<RemoteProviderConfig> {
   logger?: Logger;
+  /**
+   * Only used in the IMDS credential provider.
+   */
+  ec2MetadataV1Disabled?: boolean;
+  /**
+   * AWS_PROFILE.
+   */
+  profile?: string;
 }
 
 /**

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
@@ -1,6 +1,5 @@
 import { Logger, Provider } from "@smithy/types";
 
-import { InstanceMetadataV1FallbackError } from "../error/InstanceMetadataV1FallbackError";
 import { InstanceMetadataCredentials } from "../types";
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 
@@ -33,7 +32,7 @@ export const staticStabilityProvider = (
         credentials = getExtendedInstanceMetadataCredentials(credentials, logger);
       }
     } catch (e) {
-      if (pastCredentials && !(e instanceof InstanceMetadataV1FallbackError)) {
+      if (pastCredentials) {
         logger.warn("Credential renew failed: ", e);
         credentials = getExtendedInstanceMetadataCredentials(pastCredentials, logger);
       } else {

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
@@ -1,5 +1,6 @@
-import { AwsCredentialIdentity, Logger, Provider } from "@smithy/types";
+import { Logger, Provider } from "@smithy/types";
 
+import { InstanceMetadataV1FallbackError } from "../error/InstanceMetadataV1FallbackError";
 import { InstanceMetadataCredentials } from "../types";
 import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
 
@@ -32,7 +33,7 @@ export const staticStabilityProvider = (
         credentials = getExtendedInstanceMetadataCredentials(credentials, logger);
       }
     } catch (e) {
-      if (pastCredentials) {
+      if (pastCredentials && !(e instanceof InstanceMetadataV1FallbackError)) {
         logger.warn("Credential renew failed: ", e);
         credentials = getExtendedInstanceMetadataCredentials(pastCredentials, logger);
       } else {


### PR DESCRIPTION
this is an AWS-specific feature but the code package is housed here in Smithy-TS at least for the time being.

this PR adds 3 locations from which to shut off the IMDS v1 fallback behavior:
- runtime code initialization of the IMDS or upstream chained credential providers
- AWS config file profile setting
- process environment variable