### PR TITLE
add script for enforcing pkg json standards

### DIFF
--- a/.changeset/five-houses-jam.md
+++ b/.changeset/five-houses-jam.md
@@ -1,0 +1,10 @@
+---
+"@smithy/util-defaults-mode-browser": patch
+"@smithy/middleware-endpoint": patch
+"@smithy/hash-blob-browser": patch
+"@smithy/util-base64": patch
+"@smithy/util-stream": patch
+"@smithy/util-utf8": patch
+---
+
+update bundler replacement directives in package.json

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:integration": "yarn build-test-packages && turbo run test:integration",
     "lint": "turbo run lint",
     "lint-fix": "turbo run lint -- --fix",
+    "lint:pkgJson": "node scripts/check-dev-dependencies.js",
     "format": "turbo run format --parallel",
     "stage-release": "turbo run stage-release",
     "extract:docs": "mkdir -p api-extractor-packages && turbo run extract:docs",
@@ -43,6 +44,7 @@
     "eslint-plugin-prettier": "3.4.1",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-tsdoc": "0.2.17",
+    "husky": "^4.2.3",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",
     "karma": "6.4.0",
@@ -70,5 +72,10 @@
     "smithy-typescript-ssdk-libs/*",
     "private/*"
   ],
-  "packageManager": "yarn@3.4.1"
+  "packageManager": "yarn@3.4.1",
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn lint:pkgJson"
+    }
+  }
 }

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -55,6 +55,9 @@
   "react-native": {
     "@smithy/chunked-blob-reader": "@smithy/chunked-blob-reader-native"
   },
+  "browser": {
+    "@smithy/chunked-blob-reader": "@smithy/chunked-blob-reader"
+  },
   "typesVersions": {
     "<4.0": {
       "dist-types/*": [

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -52,8 +52,8 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser",
-    "./dist-cjs/adaptors/getEndpointFromConfig": "./dist-cjs/adaptors/getEndpointFromConfig.browser"
+    "./dist-cjs/adaptors/getEndpointFromConfig": "./dist-cjs/adaptors/getEndpointFromConfig.browser",
+    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser"
   },
   "react-native": {
     "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser",

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -52,10 +52,12 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser"
+    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser",
+    "./dist-cjs/adaptors/getEndpointFromConfig": "./dist-cjs/adaptors/getEndpointFromConfig.browser"
   },
   "react-native": {
-    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser"
+    "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser",
+    "./dist-cjs/adaptors/getEndpointFromConfig": "./dist-cjs/adaptors/getEndpointFromConfig.browser"
   },
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/middleware-endpoint",
   "repository": {

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -52,7 +52,6 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-cjs/adaptors/getEndpointFromConfig": "./dist-cjs/adaptors/getEndpointFromConfig.browser",
     "./dist-es/adaptors/getEndpointFromConfig": "./dist-es/adaptors/getEndpointFromConfig.browser"
   },
   "react-native": {

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -48,10 +48,10 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/fromBase64": "./dist-es/fromBase64.browser",
-    "./dist-es/toBase64": "./dist-es/toBase64.browser",
     "./dist-cjs/fromBase64": "./dist-cjs/fromBase64.browser",
-    "./dist-cjs/toBase64": "./dist-cjs/toBase64.browser"
+    "./dist-cjs/toBase64": "./dist-cjs/toBase64.browser",
+    "./dist-es/fromBase64": "./dist-es/fromBase64.browser",
+    "./dist-es/toBase64": "./dist-es/toBase64.browser"
   },
   "react-native": {
     "./dist-es/fromBase64": "./dist-es/fromBase64.browser",

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -48,8 +48,6 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-cjs/fromBase64": "./dist-cjs/fromBase64.browser",
-    "./dist-cjs/toBase64": "./dist-cjs/toBase64.browser",
     "./dist-es/fromBase64": "./dist-es/fromBase64.browser",
     "./dist-es/toBase64": "./dist-es/toBase64.browser"
   },

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -49,11 +49,15 @@
   ],
   "browser": {
     "./dist-es/fromBase64": "./dist-es/fromBase64.browser",
-    "./dist-es/toBase64": "./dist-es/toBase64.browser"
+    "./dist-es/toBase64": "./dist-es/toBase64.browser",
+    "./dist-cjs/fromBase64": "./dist-cjs/fromBase64.browser",
+    "./dist-cjs/toBase64": "./dist-cjs/toBase64.browser"
   },
   "react-native": {
     "./dist-es/fromBase64": "./dist-es/fromBase64.browser",
-    "./dist-es/toBase64": "./dist-es/toBase64.browser"
+    "./dist-es/toBase64": "./dist-es/toBase64.browser",
+    "./dist-cjs/fromBase64": "./dist-cjs/fromBase64.browser",
+    "./dist-cjs/toBase64": "./dist-cjs/toBase64.browser"
   },
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-base64",
   "repository": {

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -66,7 +66,7 @@
     "directory": ".release/package"
   },
   "browser": {
-    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native",
-    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native"
+    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native",
+    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native"
   }
 }

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -49,10 +49,8 @@
   "files": [
     "dist-*/**"
   ],
-  "react-native": {
-    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native",
-    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native"
-  },
+  "react-native": {},
+  "browser": {},
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-defaults-mode-node",
   "repository": {
     "type": "git",
@@ -64,9 +62,5 @@
   },
   "publishConfig": {
     "directory": ".release/package"
-  },
-  "browser": {
-    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native",
-    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native"
   }
 }

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -50,7 +50,8 @@
     "dist-*/**"
   ],
   "react-native": {
-    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native"
+    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native",
+    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native"
   },
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-defaults-mode-node",
   "repository": {
@@ -63,5 +64,9 @@
   },
   "publishConfig": {
     "directory": ".release/package"
+  },
+  "browser": {
+    "./dist-es/resolveDefaultsModeConfig": "./dist-es/resolveDefaultsModeConfig.native",
+    "./dist-cjs/resolveDefaultsModeConfig": "./dist-cjs/resolveDefaultsModeConfig.native"
   }
 }

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -71,8 +71,6 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
-    "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser",
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
     "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser"
   },

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -72,11 +72,15 @@
   ],
   "browser": {
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
-    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser"
+    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
+    "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
+    "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser"
   },
   "react-native": {
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
-    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser"
+    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
+    "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
+    "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser"
   },
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-stream",
   "repository": {

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -71,10 +71,10 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
-    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser",
     "./dist-cjs/getAwsChunkedEncodingStream": "./dist-cjs/getAwsChunkedEncodingStream.browser",
-    "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser"
+    "./dist-cjs/sdk-stream-mixin": "./dist-cjs/sdk-stream-mixin.browser",
+    "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",
+    "./dist-es/sdk-stream-mixin": "./dist-es/sdk-stream-mixin.browser"
   },
   "react-native": {
     "./dist-es/getAwsChunkedEncodingStream": "./dist-es/getAwsChunkedEncodingStream.browser",

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -47,10 +47,10 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
-    "./dist-es/toUtf8": "./dist-es/toUtf8.browser",
     "./dist-cjs/fromUtf8": "./dist-cjs/fromUtf8.browser",
-    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser"
+    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser",
+    "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
+    "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
   },
   "react-native": {
     "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -47,8 +47,6 @@
     "dist-*/**"
   ],
   "browser": {
-    "./dist-cjs/fromUtf8": "./dist-cjs/fromUtf8.browser",
-    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser",
     "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
     "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
   },

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -48,11 +48,15 @@
   ],
   "browser": {
     "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
-    "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
+    "./dist-es/toUtf8": "./dist-es/toUtf8.browser",
+    "./dist-cjs/fromUtf8": "./dist-cjs/fromUtf8.browser",
+    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser"
   },
   "react-native": {
     "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
-    "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
+    "./dist-es/toUtf8": "./dist-es/toUtf8.browser",
+    "./dist-cjs/fromUtf8": "./dist-cjs/fromUtf8.browser",
+    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser"
   },
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-utf8",
   "repository": {

--- a/scripts/check-dev-dependencies.js
+++ b/scripts/check-dev-dependencies.js
@@ -9,10 +9,12 @@ const path = require("node:path");
 const root = path.join(__dirname, "..");
 const packages = path.join(root, "packages");
 const walk = require("./utils/walk");
+const pkgJsonEnforcement = require("./package-json-enforcement");
 
 (async () => {
   for (const folder of fs.readdirSync(packages)) {
     const pkgJsonPath = path.join(packages, folder, "package.json");
+    pkgJsonEnforcement(pkgJsonPath, true);
     const srcPath = path.join(packages, folder, "src");
     const pkgJson = require(pkgJsonPath);
 

--- a/scripts/check-dev-dependencies.js
+++ b/scripts/check-dev-dependencies.js
@@ -12,9 +12,10 @@ const walk = require("./utils/walk");
 const pkgJsonEnforcement = require("./package-json-enforcement");
 
 (async () => {
+  const errors = [];
   for (const folder of fs.readdirSync(packages)) {
     const pkgJsonPath = path.join(packages, folder, "package.json");
-    pkgJsonEnforcement(pkgJsonPath, true);
+    errors.push(...pkgJsonEnforcement(pkgJsonPath, true));
     const srcPath = path.join(packages, folder, "src");
     const pkgJson = require(pkgJsonPath);
 
@@ -42,5 +43,8 @@ const pkgJsonEnforcement = require("./package-json-enforcement");
         }
       }
     }
+  }
+  if (errors.length) {
+    throw new Error(errors.join("\n"));
   }
 })();

--- a/scripts/package-json-enforcement.js
+++ b/scripts/package-json-enforcement.js
@@ -77,6 +77,9 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
 
     if (Object.keys(browserCanonical).length !== Object.keys(pkgJson.browser).length) {
       errors.push(`${pkgJson.name} browser field is incomplete.`);
+      if (overwrite) {
+        pkgJson.browser = browserCanonical;
+      }
     }
 
     const reactNativeCanonical = [
@@ -97,15 +100,13 @@ module.exports = function (pkgJsonFilePath, overwrite = false) {
 
     if (Object.keys(reactNativeCanonical).length !== Object.keys(pkgJson["react-native"]).length) {
       errors.push(`${pkgJson.name} react-native field is incomplete.`);
-    }
-
-    if (overwrite) {
-      pkgJson.browser = browserCanonical;
-      pkgJson["react-native"] = reactNativeCanonical;
+      if (overwrite) {
+        pkgJson["react-native"] = reactNativeCanonical;
+      }
     }
   }
 
-  if (overwrite) {
+  if (overwrite && errors.length) {
     fs.writeFileSync(pkgJsonFilePath, JSON.stringify(pkgJson, null, 2) + "\n");
   }
 

--- a/scripts/package-json-enforcement.js
+++ b/scripts/package-json-enforcement.js
@@ -10,12 +10,15 @@ const fs = require("fs");
  * The script will enforce several things on a package json object:
  *
  * - main and module must be defined.
- *   In the future this may change. Browser is perhaps more standard than module.
+ *   In the future this may change. Browser is more standard than module, and
+ *   exports may be used for ESM (.mjs) support.
  *
- * - if react-native entry exists, browser and react native entries must have
- *   an identical set of keys for replacement directives
- * - when browser and react-native have file replacement directives, they must include both
- *   CJS and ESM dists.
+ * - If a react-native entry exists, browser and react native entries must be of the
+ *   same type (object replacement directives or string entry point).
+ *   If either is not defined, both must not be defined.
+ *
+ * - when react-native has file replacement directives, it must include both
+ *   CJS and ESM dist replacements.
  *
  * - exports must not be defined unless the package name is core.
  */

--- a/scripts/package-json-enforcement.js
+++ b/scripts/package-json-enforcement.js
@@ -1,11 +1,15 @@
 const fs = require("fs");
 
 /**
+ * This enforcement is not here to prevent adoption of newer
+ * package standards such as "exports". It is to ensure consistency in the
+ * monorepo until the time comes for those changes.
+ * ----
  *
- * Will enforce several things on a package json object:
+ * The script will enforce several things on a package json object:
  *
  * - main and module must be defined.
- *   Note: in the future this may change. Browser is perhaps more standard than module.
+ *   In the future this may change. Browser is perhaps more standard than module.
  *
  * - if react-native entry exists, browser and react native entries must have
  *   an identical set of keys for replacement directives

--- a/scripts/package-json-enforcement.js
+++ b/scripts/package-json-enforcement.js
@@ -1,0 +1,109 @@
+const fs = require("fs");
+
+/**
+ *
+ * Will enforce several things on a package json object:
+ *
+ * - main and module must be defined.
+ *   Note: in the future this may change. Browser is perhaps more standard than module.
+ *
+ * - if react-native entry exists, browser and react native entries must have
+ *   an identical set of keys for replacement directives
+ * - when browser and react-native have file replacement directives, they must include both
+ *   CJS and ESM dists.
+ *
+ * - exports must not be defined unless the package name is core.
+ */
+module.exports = function (pkgJsonFilePath, overwrite = false) {
+  const errors = [];
+
+  const pkgJson = require(pkgJsonFilePath);
+  if (!pkgJson.name.endsWith("/core")) {
+    if ("exports" in pkgJson) {
+      errors.push(`${pkgJson.name} must not have an 'exports' field.`);
+      if (overwrite) {
+        delete pkgJson.exports;
+      }
+    }
+  }
+
+  for (const requiredField of ["main", "module"]) {
+    if (!(requiredField in pkgJson)) {
+      errors.push(`${requiredField} field missing in ${pkgJson.name}`);
+      if (overwrite) {
+        switch (requiredField) {
+          case "main":
+            pkgJson[requiredField] = "./dist-cjs/index.js";
+            break;
+          case "module":
+            pkgJson[requiredField] = pkgJson.main.replace("dist-cjs", "dist-es");
+            break;
+        }
+      }
+    }
+  }
+
+  if (typeof pkgJson.browser !== typeof pkgJson["react-native"]) {
+    errors.push(`browser and react-native fields are different in ${pkgJson.name}`);
+    if (overwrite) {
+      if (typeof pkgJson.browser === "object") {
+        pkgJson["react-native"] = pkgJson.browser;
+      } else if (typeof pkgJson["react-native"] === "object") {
+        pkgJson.browser = pkgJson["react-native"];
+      }
+    }
+  }
+
+  if (typeof pkgJson.browser === "object" && typeof pkgJson["react-native"] === "object") {
+    const browserCanonical = [
+      ...new Set([
+        ...Object.entries(pkgJson.browser).map(([k, v]) => [
+          k.replace("dist-cjs", "dist-es"),
+          typeof v === "string" ? v.replace("dist-cjs", "dist-es") : v,
+        ]),
+        ...Object.entries(pkgJson.browser).map(([k, v]) => [
+          k.replace("dist-es", "dist-cjs"),
+          typeof v === "string" ? v.replace("dist-es", "dist-cjs") : v,
+        ]),
+      ]),
+    ].reduce((acc, [k, v]) => {
+      acc[k] = v;
+      return acc;
+    }, {});
+
+    if (Object.keys(browserCanonical).length !== Object.keys(pkgJson.browser).length) {
+      errors.push(`${pkgJson.name} browser field is incomplete.`);
+    }
+
+    const reactNativeCanonical = [
+      ...new Set([
+        ...Object.entries(pkgJson["react-native"]).map(([k, v]) => [
+          k.replace("dist-cjs", "dist-es"),
+          typeof v === "string" ? v.replace("dist-cjs", "dist-es") : v,
+        ]),
+        ...Object.entries(pkgJson["react-native"]).map(([k, v]) => [
+          k.replace("dist-es", "dist-cjs"),
+          typeof v === "string" ? v.replace("dist-es", "dist-cjs") : v,
+        ]),
+      ]),
+    ].reduce((acc, [k, v]) => {
+      acc[k] = v;
+      return acc;
+    }, {});
+
+    if (Object.keys(reactNativeCanonical).length !== Object.keys(pkgJson["react-native"]).length) {
+      errors.push(`${pkgJson.name} react-native field is incomplete.`);
+    }
+
+    if (overwrite) {
+      pkgJson.browser = browserCanonical;
+      pkgJson["react-native"] = reactNativeCanonical;
+    }
+  }
+
+  if (overwrite) {
+    fs.writeFileSync(pkgJsonFilePath, JSON.stringify(pkgJson, null, 2) + "\n");
+  }
+
+  return errors;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/parse-json@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "@types/parse-json@npm:4.0.2"
+  checksum: 5bf62eec37c332ad10059252fc0dab7e7da730764869c980b0714777ad3d065e490627be9f40fc52f238ffa3ac4199b19de4127196910576c2fe34dd47c7a470
+  languageName: node
+  linkType: hard
+
 "@types/parse5@npm:^6.0.3":
   version: 6.0.3
   resolution: "@types/parse5@npm:6.0.3"
@@ -4212,6 +4219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ci-info@npm:2.0.0"
+  checksum: 3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
+  languageName: node
+  linkType: hard
+
 "ci-info@npm:^3.1.0, ci-info@npm:^3.2.0":
   version: 3.8.0
   resolution: "ci-info@npm:3.8.0"
@@ -4405,6 +4419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compare-versions@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "compare-versions@npm:3.6.0"
+  checksum: 7492a50cdaa2c27f5254eee7c4b38856e1c164991bab3d98d7fd067fe4b570d47123ecb92523b78338be86aa221668fd3868bfe8caa5587dc3ebbe1a03d52b5d
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -4510,6 +4531,19 @@ __metadata:
     parse-json: ^5.0.0
     path-type: ^4.0.0
   checksum: b3d277bc3a8a9e649bf4c3fc9740f4c52bf07387481302aa79839f595045368903bf26ea24a8f7f7b8b180bf46037b027c5cb63b1391ab099f3f78814a147b2b
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "cosmiconfig@npm:7.1.0"
+  dependencies:
+    "@types/parse-json": ^4.0.0
+    import-fresh: ^3.2.1
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+    yaml: ^1.10.0
+  checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
   languageName: node
   linkType: hard
 
@@ -5675,6 +5709,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-versions@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "find-versions@npm:4.0.0"
+  dependencies:
+    semver-regex: ^3.1.2
+  checksum: 2b4c749dc33e3fa73a457ca4df616ac13b4b32c53f6297bc862b0814d402a6cfec93a0d308d5502eeb47f2c125906e0f861bf01b756f08395640892186357711
+  languageName: node
+  linkType: hard
+
 "find-yarn-workspace-root2@npm:1.2.16":
   version: 1.2.16
   resolution: "find-yarn-workspace-root2@npm:1.2.16"
@@ -6239,6 +6282,27 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^4.2.3":
+  version: 4.3.8
+  resolution: "husky@npm:4.3.8"
+  dependencies:
+    chalk: ^4.0.0
+    ci-info: ^2.0.0
+    compare-versions: ^3.6.0
+    cosmiconfig: ^7.0.0
+    find-versions: ^4.0.0
+    opencollective-postinstall: ^2.0.2
+    pkg-dir: ^5.0.0
+    please-upgrade-node: ^3.2.0
+    slash: ^3.0.0
+    which-pm-runs: ^1.0.0
+  bin:
+    husky-run: bin/run.js
+    husky-upgrade: lib/upgrader/bin.js
+  checksum: ac5e6c72053b2a25532f4137f4b036c9057a4b31980f41c7c2efe05e094d2e06b5c8adc0aafba5c6b70e204ab05d4a916233aec9dffc7a0ccfdd14d4b01c719b
   languageName: node
   linkType: hard
 
@@ -8398,6 +8462,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"opencollective-postinstall@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "opencollective-postinstall@npm:2.0.3"
+  bin:
+    opencollective-postinstall: index.js
+  checksum: 0a68c5cef135e46d11e665d5077398285d1ce5311c948e8327b435791c409744d4a6bb9c55bd6507fb5f2ef34b0ad920565adcdaf974cbdae701aead6f32b396
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.8.1":
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
@@ -8682,6 +8755,24 @@ __metadata:
   dependencies:
     find-up: ^4.0.0
   checksum: 9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
+  languageName: node
+  linkType: hard
+
+"pkg-dir@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pkg-dir@npm:5.0.0"
+  dependencies:
+    find-up: ^5.0.0
+  checksum: b167bb8dac7bbf22b1d5e30ec223e6b064b84b63010c9d49384619a36734caf95ed23ad23d4f9bd975e8e8082b60a83395f43a89bb192df53a7c25a38ecb57d9
+  languageName: node
+  linkType: hard
+
+"please-upgrade-node@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "please-upgrade-node@npm:3.2.0"
+  dependencies:
+    semver-compare: ^1.0.0
+  checksum: d87c41581a2a022fbe25965a97006238cd9b8cbbf49b39f78d262548149a9d30bd2bdf35fec3d810e0001e630cd46ef13c7e19c389dea8de7e64db271a2381bb
   languageName: node
   linkType: hard
 
@@ -9354,6 +9445,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver-compare@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "semver-compare@npm:1.0.0"
+  checksum: dd1d7e2909744cf2cf71864ac718efc990297f9de2913b68e41a214319e70174b1d1793ac16e31183b128c2b9812541300cb324db8168e6cf6b570703b171c68
+  languageName: node
+  linkType: hard
+
+"semver-regex@npm:^3.1.2":
+  version: 3.1.4
+  resolution: "semver-regex@npm:3.1.4"
+  checksum: 3962105908e326aa2cd5c851a2f6d4cc7340d1b06560afc35cd5348d9fa5b1cc0ac0cad7e7cef2072bc12b992c5ae654d9e8d355c19d75d4216fced3b6c5d8a7
+  languageName: node
+  linkType: hard
+
 "semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
@@ -9574,6 +9679,7 @@ __metadata:
     eslint-plugin-simple-import-sort: 7.0.0
     eslint-plugin-tsdoc: 0.2.17
     glob: ^7.1.6
+    husky: ^4.2.3
     jest: 28.1.1
     jest-environment-jsdom: 28.1.1
     karma: 6.4.0
@@ -10998,6 +11104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-pm-runs@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "which-pm-runs@npm:1.1.0"
+  checksum: 39a56ee50886fb33ec710e3b36dc9fe3d0096cac44850d9ca0c6186c4cb824d6c8125f013e0562e7c94744e1e8e4a6ab695592cdb12555777c7a4368143d822c
+  languageName: node
+  linkType: hard
+
 "which-pm@npm:2.0.0":
   version: 2.0.0
   resolution: "which-pm@npm:2.0.0"
@@ -11189,6 +11302,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.10.0":
+  version: 1.10.2
+  resolution: "yaml@npm:1.10.2"
+  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a pre-commit hook to audit the pkg json bundler directives.

Specifically, we don't know if a bundler is going to use the CJS or ES entrypoint, and thus the file replacement directives should account for either case.