### PR TITLE
Allow dot, solidus, percent and colon characters in profile names

### DIFF
--- a/.changeset/shiny-beans-wink.md
+++ b/.changeset/shiny-beans-wink.md
@@ -2,4 +2,4 @@
 "@smithy/shared-ini-file-loader": patch
 ---
 
-Parse profile name with invalid '.' and '/' characters
+Allow dot, solidus, percent and colon characters in profile names

--- a/.changeset/shiny-beans-wink.md
+++ b/.changeset/shiny-beans-wink.md
@@ -1,0 +1,5 @@
+---
+"@smithy/shared-ini-file-loader": patch
+---
+
+Parse profile name with invalid '.' and './' characters

--- a/.changeset/shiny-beans-wink.md
+++ b/.changeset/shiny-beans-wink.md
@@ -2,4 +2,4 @@
 "@smithy/shared-ini-file-loader": patch
 ---
 
-Parse profile name with invalid '.' and './' characters
+Parse profile name with invalid '.' and '/' characters

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -63,7 +63,9 @@ describe(parseIni.name, () => {
     // `+` https://github.com/aws/aws-sdk-js-v3/issues/5373
     // `.` https://github.com/aws/aws-sdk-js-v3/issues/5449
     // `/` https://github.com/awslabs/smithy-typescript/issues/1053
-    it.each(["-", "_", "@", "+", ".", "/"])(
+    // `%` https://github.com/aws/aws-sdk-java-v2/pull/1538
+    // `:` https://github.com/aws/aws-sdk-java-v2/pull/1898
+    it.each(["-", "_", "@", "+", ".", "/", "%", ":"])(
       "returns data for character '%s' in profile name",
       (specialChar: string) => {
         const mockProfileName = ["profile", "stage"].join(specialChar);

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -63,14 +63,17 @@ describe(parseIni.name, () => {
     // `+` https://github.com/aws/aws-sdk-js-v3/issues/5373
     // `.` https://github.com/aws/aws-sdk-js-v3/issues/5449
     // `/` https://github.com/awslabs/smithy-typescript/issues/1053
-    it.each(["-", "_", "@", "+", ".", "/"])("returns data for character '%s' in profile name", (specialChar: string) => {
-      const mockProfileName = ["profile", "stage"].join(specialChar);
-      const mockSectionFullName = ["profile", mockProfileName].join(" ");
-      const mockInput = getMockProfileContent(mockSectionFullName, mockProfileData);
-      expect(parseIni(mockInput)).toStrictEqual({
-        [["profile", mockProfileName].join(CONFIG_PREFIX_SEPARATOR)]: mockProfileData,
-      });
-    });
+    it.each(["-", "_", "@", "+", ".", "/"])(
+      "returns data for character '%s' in profile name",
+      (specialChar: string) => {
+        const mockProfileName = ["profile", "stage"].join(specialChar);
+        const mockSectionFullName = ["profile", mockProfileName].join(" ");
+        const mockInput = getMockProfileContent(mockSectionFullName, mockProfileData);
+        expect(parseIni(mockInput)).toStrictEqual({
+          [["profile", mockProfileName].join(CONFIG_PREFIX_SEPARATOR)]: mockProfileData,
+        });
+      }
+    );
 
     it("returns data for two profiles", () => {
       const mockProfile1 = getMockProfileContent(mockProfileName, mockProfileData);

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -61,7 +61,9 @@ describe(parseIni.name, () => {
     // Some characters are not allowed in profile name, but we parse them as customers use them.
     // `@` https://github.com/awslabs/smithy-typescript/issues/1026
     // `+` https://github.com/aws/aws-sdk-js-v3/issues/5373
-    it.each(["-", "_", "@", "+"])("returns data for character '%s' in profile name", (specialChar: string) => {
+    // `.` https://github.com/aws/aws-sdk-js-v3/issues/5449
+    // `/` https://github.com/awslabs/smithy-typescript/issues/1053
+    it.each(["-", "_", "@", "+", ".", "/"])("returns data for character '%s' in profile name", (specialChar: string) => {
       const mockProfileName = ["profile", "stage"].join(specialChar);
       const mockSectionFullName = ["profile", mockProfileName].join(" ");
       const mockInput = getMockProfileContent(mockSectionFullName, mockProfileData);

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -2,7 +2,7 @@ import { IniSectionType, ParsedIniData } from "@smithy/types";
 
 import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 
-const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@\+]+)\2$/;
+const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@\+\./]+)\2$/;
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {

--- a/packages/shared-ini-file-loader/src/parseIni.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.ts
@@ -2,7 +2,7 @@ import { IniSectionType, ParsedIniData } from "@smithy/types";
 
 import { CONFIG_PREFIX_SEPARATOR } from "./loadSharedConfigFiles";
 
-const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@\+\./]+)\2$/;
+const prefixKeyRegex = /^([\w-]+)\s(["'])?([\w-@\+\.%:/]+)\2$/;
 const profileNameBlockList = ["__proto__", "profile __proto__"];
 
 export const parseIni = (iniData: string): ParsedIniData => {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/5449
Fixes: https://github.com/awslabs/smithy-typescript/issues/1053
Refs: https://github.com/aws/aws-sdk-java-v2/pull/1538
Refs: https://github.com/aws/aws-sdk-java-v2/pull/1898

*Description of changes:*
Allow dot, solidus, percent and colon characters in profile names

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
