### PR TITLE
feat(experimentalIdentityAndAuth): finalize `experimentalIdentityAndAuth` feature

### DIFF
--- a/.changeset/spotty-jobs-juggle.md
+++ b/.changeset/spotty-jobs-juggle.md
@@ -1,0 +1,8 @@
+---
+"@smithy/core": major
+"@smithy/middleware-endpoint": minor
+"@smithy/types": minor
+"@smithy/experimental-identity-and-auth": patch
+---
+
+feat(experimentalIdentityAndAuth): move `experimentalIdentityAndAuth` types and interfaces to `@smithy/types` and `@smithy/core`

--- a/.changeset/tiny-zebras-refuse.md
+++ b/.changeset/tiny-zebras-refuse.md
@@ -1,0 +1,5 @@
+---
+"@smithy/middleware-endpoint": patch
+---
+
+Add `@endpointRuleSet` signing properties to `selectedHttpAuthScheme`

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,12 @@
+# @smithy/core
+
+[![NPM version](https://img.shields.io/npm/v/@smithy/core/latest.svg)](https://www.npmjs.com/package/@smithy/core)
+[![NPM downloads](https://img.shields.io/npm/dm/@smithy/core.svg)](https://www.npmjs.com/package/@smithy/core)
+
+> An internal package. You probably shouldn't use this package, at least directly.
+
+## Usage
+
+This package provides common or core functionality for generic Smithy clients.
+
+You do not need to explicitly install this package, since it will be installed during code generation if used.

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@smithy/core",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types && yarn build:types:downlevel'",
+    "build:cjs": "yarn g:tsc -p tsconfig.cjs.json",
+    "build:es": "yarn g:tsc -p tsconfig.es.json",
+    "build:types": "yarn g:tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "stage-release": "rimraf ./.release && yarn pack && mkdir ./.release && tar zxvf ./package.tgz --directory ./.release && rm ./package.tgz",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
+    "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
+    "test": "yarn g:jest"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "author": {
+    "name": "AWS Smithy Team",
+    "email": "",
+    "url": "https://smithy.io"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@smithy/middleware-endpoint": "workspace:^",
+    "@smithy/middleware-retry": "workspace:^",
+    "@smithy/middleware-serde": "workspace:^",
+    "@smithy/protocol-http": "workspace:^",
+    "@smithy/types": "workspace:^",
+    "tslib": "^2.5.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*/**"
+  ],
+  "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/awslabs/smithy-typescript.git",
+    "directory": "packages/core"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.23.23"
+  },
+  "typedoc": {
+    "entryPoint": "src/index.ts"
+  },
+  "publishConfig": {
+    "directory": ".release/package"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./middleware-http-auth-scheme";
+export * from "./middleware-http-signing";
+export * from "./util-identity-and-auth";

--- a/packages/core/src/middleware-http-auth-scheme/getHttpAuthSchemeEndpointRuleSetPlugin.ts
+++ b/packages/core/src/middleware-http-auth-scheme/getHttpAuthSchemeEndpointRuleSetPlugin.ts
@@ -1,0 +1,63 @@
+import { endpointMiddlewareOptions } from "@smithy/middleware-endpoint";
+import {
+  HandlerExecutionContext,
+  HttpAuthSchemeParameters,
+  HttpAuthSchemeParametersProvider,
+  IdentityProviderConfig,
+  Pluggable,
+  RelativeMiddlewareOptions,
+  SerializeHandlerOptions,
+} from "@smithy/types";
+
+import { httpAuthSchemeMiddleware, PreviouslyResolved } from "./httpAuthSchemeMiddleware";
+
+/**
+ * @internal
+ */
+export const httpAuthSchemeEndpointRuleSetMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
+  step: "serialize",
+  tags: ["HTTP_AUTH_SCHEME"],
+  name: "httpAuthSchemeMiddleware",
+  override: true,
+  relation: "before",
+  toMiddleware: endpointMiddlewareOptions.name!,
+};
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeEndpointRuleSetPluginOptions<
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+> {
+  httpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<TConfig, TContext, TParameters, TInput>;
+  identityProviderConfigProvider: (config: TConfig) => Promise<IdentityProviderConfig>;
+}
+
+/**
+ * @internal
+ */
+export const getHttpAuthSchemeEndpointRuleSetPlugin = <
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+>(
+  config: TConfig & PreviouslyResolved<TParameters>,
+  {
+    httpAuthSchemeParametersProvider,
+    identityProviderConfigProvider,
+  }: HttpAuthSchemeEndpointRuleSetPluginOptions<TConfig, TContext, TParameters, TInput>
+): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(
+      httpAuthSchemeMiddleware(config, {
+        httpAuthSchemeParametersProvider,
+        identityProviderConfigProvider,
+      }),
+      httpAuthSchemeEndpointRuleSetMiddlewareOptions
+    );
+  },
+});

--- a/packages/core/src/middleware-http-auth-scheme/getHttpAuthSchemePlugin.ts
+++ b/packages/core/src/middleware-http-auth-scheme/getHttpAuthSchemePlugin.ts
@@ -1,0 +1,63 @@
+import { serializerMiddlewareOption } from "@smithy/middleware-serde";
+import {
+  HandlerExecutionContext,
+  HttpAuthSchemeParameters,
+  HttpAuthSchemeParametersProvider,
+  IdentityProviderConfig,
+  Pluggable,
+  RelativeMiddlewareOptions,
+  SerializeHandlerOptions,
+} from "@smithy/types";
+
+import { httpAuthSchemeMiddleware, PreviouslyResolved } from "./httpAuthSchemeMiddleware";
+
+/**
+ * @internal
+ */
+export const httpAuthSchemeMiddlewareOptions: SerializeHandlerOptions & RelativeMiddlewareOptions = {
+  step: "serialize",
+  tags: ["HTTP_AUTH_SCHEME"],
+  name: "httpAuthSchemeMiddleware",
+  override: true,
+  relation: "before",
+  toMiddleware: serializerMiddlewareOption.name!,
+};
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemePluginOptions<
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+> {
+  httpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<TConfig, TContext, TParameters, TInput>;
+  identityProviderConfigProvider: (config: TConfig) => Promise<IdentityProviderConfig>;
+}
+
+/**
+ * @internal
+ */
+export const getHttpAuthSchemePlugin = <
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+>(
+  config: TConfig & PreviouslyResolved<TParameters>,
+  {
+    httpAuthSchemeParametersProvider,
+    identityProviderConfigProvider,
+  }: HttpAuthSchemePluginOptions<TConfig, TContext, TParameters, TInput>
+): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(
+      httpAuthSchemeMiddleware(config, {
+        httpAuthSchemeParametersProvider,
+        identityProviderConfigProvider,
+      }),
+      httpAuthSchemeMiddlewareOptions
+    );
+  },
+});

--- a/packages/core/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
+++ b/packages/core/src/middleware-http-auth-scheme/httpAuthSchemeMiddleware.ts
@@ -1,0 +1,114 @@
+import {
+  HandlerExecutionContext,
+  HttpAuthScheme,
+  HttpAuthSchemeId,
+  HttpAuthSchemeParameters,
+  HttpAuthSchemeParametersProvider,
+  HttpAuthSchemeProvider,
+  IdentityProviderConfig,
+  SelectedHttpAuthScheme,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
+  SMITHY_CONTEXT_KEY,
+} from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+
+/**
+ * @internal
+ */
+export interface PreviouslyResolved<TParameters extends HttpAuthSchemeParameters> {
+  httpAuthSchemes: HttpAuthScheme[];
+  httpAuthSchemeProvider: HttpAuthSchemeProvider<TParameters>;
+}
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeMiddlewareOptions<
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+> {
+  httpAuthSchemeParametersProvider: HttpAuthSchemeParametersProvider<TConfig, TContext, TParameters, TInput>;
+  identityProviderConfigProvider: (config: TConfig) => Promise<IdentityProviderConfig>;
+}
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeMiddlewareSmithyContext extends Record<string, unknown> {
+  selectedHttpAuthScheme?: SelectedHttpAuthScheme;
+}
+
+/**
+ * @internal
+ */
+interface HttpAuthSchemeMiddlewareHandlerExecutionContext extends HandlerExecutionContext {
+  [SMITHY_CONTEXT_KEY]?: HttpAuthSchemeMiddlewareSmithyContext;
+}
+
+/**
+ * @internal
+ * Later HttpAuthSchemes with the same HttpAuthSchemeId will overwrite previous ones.
+ */
+function convertHttpAuthSchemesToMap(httpAuthSchemes: HttpAuthScheme[]): Map<HttpAuthSchemeId, HttpAuthScheme> {
+  const map = new Map();
+  for (const scheme of httpAuthSchemes) {
+    map.set(scheme.schemeId, scheme);
+  }
+  return map;
+}
+
+/**
+ * @internal
+ */
+export const httpAuthSchemeMiddleware = <
+  TInput extends object,
+  Output extends object,
+  TConfig extends object,
+  TContext extends HttpAuthSchemeMiddlewareHandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters
+>(
+  config: TConfig & PreviouslyResolved<TParameters>,
+  mwOptions: HttpAuthSchemeMiddlewareOptions<TConfig, TContext, TParameters, TInput>
+): SerializeMiddleware<TInput, Output> => (
+  next: SerializeHandler<TInput, Output>,
+  context: HttpAuthSchemeMiddlewareHandlerExecutionContext
+): SerializeHandler<TInput, Output> => async (
+  args: SerializeHandlerArguments<TInput>
+): Promise<SerializeHandlerOutput<Output>> => {
+  const options = config.httpAuthSchemeProvider(
+    await mwOptions.httpAuthSchemeParametersProvider(config, context as TContext, args.input)
+  );
+  const authSchemes = convertHttpAuthSchemesToMap(config.httpAuthSchemes);
+  const smithyContext: HttpAuthSchemeMiddlewareSmithyContext = getSmithyContext(context);
+  const failureReasons = [];
+  for (const option of options) {
+    const scheme = authSchemes.get(option.schemeId);
+    if (!scheme) {
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` was not enabled for this service.`);
+      continue;
+    }
+    const identityProvider = scheme.identityProvider(await mwOptions.identityProviderConfigProvider(config));
+    if (!identityProvider) {
+      failureReasons.push(`HttpAuthScheme \`${option.schemeId}\` did not have an IdentityProvider configured.`);
+      continue;
+    }
+    const { identityProperties = {}, signingProperties = {} } = option.propertiesExtractor?.(config, context) || {};
+    option.identityProperties = Object.assign(option.identityProperties || {}, identityProperties);
+    option.signingProperties = Object.assign(option.signingProperties || {}, signingProperties);
+    smithyContext.selectedHttpAuthScheme = {
+      httpAuthOption: option,
+      identity: await identityProvider(option.identityProperties),
+      signer: scheme.signer,
+    };
+    break;
+  }
+  if (!smithyContext.selectedHttpAuthScheme) {
+    throw new Error(failureReasons.join("\n"));
+  }
+  return next(args);
+};

--- a/packages/core/src/middleware-http-auth-scheme/index.ts
+++ b/packages/core/src/middleware-http-auth-scheme/index.ts
@@ -1,0 +1,3 @@
+export * from "./httpAuthSchemeMiddleware";
+export * from "./getHttpAuthSchemeEndpointRuleSetPlugin";
+export * from "./getHttpAuthSchemePlugin";

--- a/packages/core/src/middleware-http-signing/getHttpSigningMiddleware.ts
+++ b/packages/core/src/middleware-http-signing/getHttpSigningMiddleware.ts
@@ -1,0 +1,28 @@
+import { retryMiddlewareOptions } from "@smithy/middleware-retry";
+import { FinalizeRequestHandlerOptions, Pluggable, RelativeMiddlewareOptions } from "@smithy/types";
+
+import { httpSigningMiddleware } from "./httpSigningMiddleware";
+
+/**
+ * @internal
+ */
+export const httpSigningMiddlewareOptions: FinalizeRequestHandlerOptions & RelativeMiddlewareOptions = {
+  step: "finalizeRequest",
+  tags: ["HTTP_SIGNING"],
+  name: "httpSigningMiddleware",
+  aliases: ["apiKeyMiddleware", "tokenMiddleware", "awsAuthMiddleware"],
+  override: true,
+  relation: "after",
+  toMiddleware: retryMiddlewareOptions.name!,
+};
+
+/**
+ * @internal
+ */
+export const getHttpSigningPlugin = <Input extends object, Output extends object>(
+  config: object
+): Pluggable<Input, Output> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(httpSigningMiddleware(config), httpSigningMiddlewareOptions);
+  },
+});

--- a/packages/core/src/middleware-http-signing/httpSigningMiddleware.ts
+++ b/packages/core/src/middleware-http-signing/httpSigningMiddleware.ts
@@ -1,0 +1,56 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import {
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  FinalizeRequestMiddleware,
+  HandlerExecutionContext,
+  SelectedHttpAuthScheme,
+  SMITHY_CONTEXT_KEY,
+} from "@smithy/types";
+import { getSmithyContext } from "@smithy/util-middleware";
+
+/**
+ * @internal
+ */
+interface HttpSigningMiddlewareSmithyContext extends Record<string, unknown> {
+  selectedHttpAuthScheme?: SelectedHttpAuthScheme;
+}
+
+/**
+ * @internal
+ */
+interface HttpSigningMiddlewareHandlerExecutionContext extends HandlerExecutionContext {
+  [SMITHY_CONTEXT_KEY]?: HttpSigningMiddlewareSmithyContext;
+}
+
+/**
+ * @internal
+ */
+export const httpSigningMiddleware = <Input extends object, Output extends object>(
+  config: object
+): FinalizeRequestMiddleware<Input, Output> => (
+  next: FinalizeHandler<Input, Output>,
+  context: HttpSigningMiddlewareHandlerExecutionContext
+): FinalizeHandler<Input, Output> => async (
+  args: FinalizeHandlerArguments<Input>
+): Promise<FinalizeHandlerOutput<Output>> => {
+  if (!HttpRequest.isInstance(args.request)) {
+    return next(args);
+  }
+
+  const smithyContext: HttpSigningMiddlewareSmithyContext = getSmithyContext(context);
+  const scheme = smithyContext.selectedHttpAuthScheme;
+  if (!scheme) {
+    throw new Error(`No HttpAuthScheme was selected: unable to sign request`);
+  }
+  const {
+    httpAuthOption: { signingProperties },
+    identity,
+    signer,
+  } = scheme;
+  return next({
+    ...args,
+    request: await signer.sign(args.request, identity, signingProperties || {}),
+  });
+};

--- a/packages/core/src/middleware-http-signing/index.ts
+++ b/packages/core/src/middleware-http-signing/index.ts
@@ -1,0 +1,2 @@
+export * from "./httpSigningMiddleware";
+export * from "./getHttpSigningMiddleware";

--- a/packages/core/src/util-identity-and-auth/DefaultIdentityProviderConfig.ts
+++ b/packages/core/src/util-identity-and-auth/DefaultIdentityProviderConfig.ts
@@ -1,0 +1,26 @@
+import { HttpAuthSchemeId, Identity, IdentityProvider, IdentityProviderConfig } from "@smithy/types";
+
+/**
+ * Default implementation of IdentityProviderConfig
+ * @internal
+ */
+export class DefaultIdentityProviderConfig implements IdentityProviderConfig {
+  private authSchemes: Map<HttpAuthSchemeId, IdentityProvider<Identity>> = new Map();
+
+  /**
+   * Creates an IdentityProviderConfig with a record of scheme IDs to identity providers.
+   *
+   * @param config scheme IDs and identity providers to configure
+   */
+  constructor(config: Record<HttpAuthSchemeId, IdentityProvider<Identity> | undefined>) {
+    for (const [key, value] of Object.entries(config)) {
+      if (value !== undefined) {
+        this.authSchemes.set(key, value);
+      }
+    }
+  }
+
+  public getIdentityProvider(schemeId: HttpAuthSchemeId): IdentityProvider<Identity> | undefined {
+    return this.authSchemes.get(schemeId);
+  }
+}

--- a/packages/core/src/util-identity-and-auth/httpAuthSchemes/httpApiKeyAuth.ts
+++ b/packages/core/src/util-identity-and-auth/httpAuthSchemes/httpApiKeyAuth.ts
@@ -1,0 +1,44 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import { ApiKeyIdentity, HttpApiKeyAuthLocation, HttpRequest as IHttpRequest, HttpSigner } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export class HttpApiKeyAuthSigner implements HttpSigner {
+  public async sign(
+    httpRequest: HttpRequest,
+    identity: ApiKeyIdentity,
+    signingProperties: Record<string, any>
+  ): Promise<IHttpRequest> {
+    if (!signingProperties) {
+      throw new Error(
+        "request could not be signed with `apiKey` since the `name` and `in` signer properties are missing"
+      );
+    }
+    if (!signingProperties.name) {
+      throw new Error("request could not be signed with `apiKey` since the `name` signer property is missing");
+    }
+    if (!signingProperties.in) {
+      throw new Error("request could not be signed with `apiKey` since the `in` signer property is missing");
+    }
+    if (!identity.apiKey) {
+      throw new Error("request could not be signed with `apiKey` since the `apiKey` is not defined");
+    }
+    const clonedRequest = httpRequest.clone();
+    if (signingProperties.in === HttpApiKeyAuthLocation.QUERY) {
+      clonedRequest.query[signingProperties.name] = identity.apiKey;
+    } else if (signingProperties.in === HttpApiKeyAuthLocation.HEADER) {
+      clonedRequest.headers[signingProperties.name] = signingProperties.scheme
+        ? `${signingProperties.scheme} ${identity.apiKey}`
+        : identity.apiKey;
+    } else {
+      throw new Error(
+        "request can only be signed with `apiKey` locations `query` or `header`, " +
+          "but found: `" +
+          signingProperties.in +
+          "`"
+      );
+    }
+    return clonedRequest;
+  }
+}

--- a/packages/core/src/util-identity-and-auth/httpAuthSchemes/httpBearerAuth.ts
+++ b/packages/core/src/util-identity-and-auth/httpAuthSchemes/httpBearerAuth.ts
@@ -1,0 +1,20 @@
+import { HttpRequest } from "@smithy/protocol-http";
+import { HttpRequest as IHttpRequest, HttpSigner, TokenIdentity } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export class HttpBearerAuthSigner implements HttpSigner {
+  public async sign(
+    httpRequest: HttpRequest,
+    identity: TokenIdentity,
+    signingProperties: Record<string, any>
+  ): Promise<IHttpRequest> {
+    const clonedRequest = httpRequest.clone();
+    if (!identity.token) {
+      throw new Error("request could not be signed with `token` since the `token` is not defined");
+    }
+    clonedRequest.headers["Authorization"] = `Bearer ${identity.token}`;
+    return clonedRequest;
+  }
+}

--- a/packages/core/src/util-identity-and-auth/httpAuthSchemes/index.ts
+++ b/packages/core/src/util-identity-and-auth/httpAuthSchemes/index.ts
@@ -1,0 +1,3 @@
+export * from "./httpApiKeyAuth";
+export * from "./httpBearerAuth";
+export * from "./noAuth";

--- a/packages/core/src/util-identity-and-auth/httpAuthSchemes/noAuth.ts
+++ b/packages/core/src/util-identity-and-auth/httpAuthSchemes/noAuth.ts
@@ -1,0 +1,15 @@
+import { HttpRequest, HttpSigner, Identity } from "@smithy/types";
+
+/**
+ * Signer for the synthetic @smithy.api#noAuth auth scheme.
+ * @internal
+ */
+export class NoAuthSigner implements HttpSigner {
+  async sign(
+    httpRequest: HttpRequest,
+    identity: Identity,
+    signingProperties: Record<string, unknown>
+  ): Promise<HttpRequest> {
+    return httpRequest;
+  }
+}

--- a/packages/core/src/util-identity-and-auth/index.ts
+++ b/packages/core/src/util-identity-and-auth/index.ts
@@ -1,0 +1,3 @@
+export * from "./DefaultIdentityProviderConfig";
+export * from "./httpAuthSchemes";
+export * from "./memoizeIdentityProvider";

--- a/packages/core/src/util-identity-and-auth/memoizeIdentityProvider.ts
+++ b/packages/core/src/util-identity-and-auth/memoizeIdentityProvider.ts
@@ -1,0 +1,92 @@
+import { Identity, IdentityProvider } from "@smithy/types";
+
+/**
+ * @internal
+ */
+export const createIsIdentityExpiredFunction = (expirationMs: number) => (identity: Identity) =>
+  doesIdentityRequireRefresh(identity) && identity.expiration!.getTime() - Date.now() < expirationMs;
+
+/**
+ * @internal
+ * This may need to be configurable in the future, but for now it is defaulted to 5min.
+ */
+export const EXPIRATION_MS = 300_000;
+
+/**
+ * @internal
+ */
+export const isIdentityExpired = createIsIdentityExpiredFunction(EXPIRATION_MS);
+
+/**
+ * @internal
+ */
+export const doesIdentityRequireRefresh = (identity: Identity) => identity.expiration !== undefined;
+
+/**
+ * @internal
+ */
+export interface MemoizedIdentityProvider<IdentityT extends Identity> {
+  (options?: Record<string, any> & { forceRefresh?: boolean }): Promise<IdentityT>;
+}
+
+/**
+ * @internal
+ */
+export const memoizeIdentityProvider = <IdentityT extends Identity>(
+  provider: IdentityT | IdentityProvider<IdentityT> | undefined,
+  isExpired: (resolved: Identity) => boolean,
+  requiresRefresh: (resolved: Identity) => boolean
+): MemoizedIdentityProvider<IdentityT> | undefined => {
+  if (provider === undefined) {
+    return undefined;
+  }
+  const normalizedProvider: IdentityProvider<IdentityT> =
+    typeof provider !== "function" ? async () => Promise.resolve(provider) : provider;
+  let resolved: IdentityT;
+  let pending: Promise<IdentityT> | undefined;
+  let hasResult: boolean;
+  let isConstant = false;
+  // Wrapper over supplied provider with side effect to handle concurrent invocation.
+  const coalesceProvider: MemoizedIdentityProvider<IdentityT> = async (options) => {
+    if (!pending) {
+      pending = normalizedProvider(options);
+    }
+    try {
+      resolved = await pending;
+      hasResult = true;
+      isConstant = false;
+    } finally {
+      pending = undefined;
+    }
+    return resolved;
+  };
+
+  if (isExpired === undefined) {
+    // This is a static memoization; no need to incorporate refreshing unless using forceRefresh;
+    return async (options) => {
+      if (!hasResult || options?.forceRefresh) {
+        resolved = await coalesceProvider(options);
+      }
+      return resolved;
+    };
+  }
+
+  return async (options) => {
+    if (!hasResult || options?.forceRefresh) {
+      resolved = await coalesceProvider(options);
+    }
+    if (isConstant) {
+      return resolved;
+    }
+
+    if (!requiresRefresh(resolved)) {
+      isConstant = true;
+      return resolved;
+    }
+    if (isExpired(resolved)) {
+      await coalesceProvider(options);
+      return resolved;
+    }
+    return resolved;
+  };
+};

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/core/tsconfig.es.json
+++ b/packages/core/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom"],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
+++ b/packages/experimental-identity-and-auth/src/HttpAuthScheme.ts
@@ -1,4 +1,4 @@
-import { Identity, IdentityProvider } from "@smithy/types";
+import { HandlerExecutionContext, Identity, IdentityProvider } from "@smithy/types";
 
 import { HttpSigner } from "./HttpSigner";
 import { IdentityProviderConfig } from "./IdentityProviderConfig";
@@ -37,6 +37,13 @@ export interface HttpAuthOption {
   schemeId: HttpAuthSchemeId;
   identityProperties?: Record<string, unknown>;
   signingProperties?: Record<string, unknown>;
+  propertiesExtractor?: <TConfig extends object, TContext extends HandlerExecutionContext>(
+    config: TConfig,
+    context: TContext
+  ) => {
+    identityProperties?: Record<string, unknown>;
+    signingProperties?: Record<string, unknown>;
+  };
 }
 
 /**

--- a/packages/experimental-identity-and-auth/src/memoizeIdentityProvider.ts
+++ b/packages/experimental-identity-and-auth/src/memoizeIdentityProvider.ts
@@ -2,6 +2,12 @@ import { Identity, IdentityProvider } from "@smithy/types";
 
 /**
  * @internal
+ */
+export const createIsIdentityExpiredFunction = (expirationMs: number) => (identity: Identity) =>
+  doesIdentityRequireRefresh(identity) && identity.expiration!.getTime() - Date.now() < expirationMs;
+
+/**
+ * @internal
  * This may need to be configurable in the future, but for now it is defaulted to 5min.
  */
 export const EXPIRATION_MS = 300_000;
@@ -9,8 +15,7 @@ export const EXPIRATION_MS = 300_000;
 /**
  * @internal
  */
-export const isIdentityExpired = (identity: Identity) =>
-  doesIdentityRequireRefresh(identity) && identity.expiration!.getTime() - Date.now() < EXPIRATION_MS;
+export const isIdentityExpired = createIsIdentityExpiredFunction(EXPIRATION_MS);
 
 /**
  * @internal

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -4,6 +4,7 @@ import {
   EndpointV2,
   HandlerExecutionContext,
   MetadataBearer,
+  SelectedHttpAuthScheme,
   SerializeHandler,
   SerializeHandlerArguments,
   SerializeHandlerOutput,
@@ -19,13 +20,7 @@ import { EndpointParameterInstructions } from "./types";
  * @internal
  */
 interface EndpointMiddlewareSmithyContext extends Record<string, unknown> {
-  // TODO(experimentalIdentityAndAuth): should be replaced with `SelectedHttpAuthScheme` interface
-  //                                    after it is moved to @smithy/types.
-  selectedHttpAuthScheme?: {
-    httpAuthOption?: {
-      signingProperties?: Record<string, unknown>;
-    };
-  };
+  selectedHttpAuthScheme?: SelectedHttpAuthScheme;
 }
 
 /**

--- a/packages/types/src/auth/HttpApiKeyAuth.ts
+++ b/packages/types/src/auth/HttpApiKeyAuth.ts
@@ -1,0 +1,7 @@
+/**
+ * @internal
+ */
+export enum HttpApiKeyAuthLocation {
+  HEADER = "header",
+  QUERY = "query",
+}

--- a/packages/types/src/auth/HttpAuthScheme.ts
+++ b/packages/types/src/auth/HttpAuthScheme.ts
@@ -1,0 +1,56 @@
+import { Identity, IdentityProvider } from "../identity/identity";
+import { HandlerExecutionContext } from "../middleware";
+import { HttpSigner } from "./HttpSigner";
+import { IdentityProviderConfig } from "./IdentityProviderConfig";
+
+/**
+ * ID for {@link HttpAuthScheme}
+ * @internal
+ */
+export type HttpAuthSchemeId = string;
+
+/**
+ * Interface that defines an HttpAuthScheme
+ * @internal
+ */
+export interface HttpAuthScheme {
+  /**
+   * ID for an HttpAuthScheme, typically the absolute shape ID of a Smithy auth trait.
+   */
+  schemeId: HttpAuthSchemeId;
+  /**
+   * Gets the IdentityProvider corresponding to an HttpAuthScheme.
+   */
+  identityProvider(config: IdentityProviderConfig): IdentityProvider<Identity> | undefined;
+  /**
+   * HttpSigner corresponding to an HttpAuthScheme.
+   */
+  signer: HttpSigner;
+}
+
+/**
+ * Interface that defines the identity and signing properties when selecting
+ * an HttpAuthScheme.
+ * @internal
+ */
+export interface HttpAuthOption {
+  schemeId: HttpAuthSchemeId;
+  identityProperties?: Record<string, unknown>;
+  signingProperties?: Record<string, unknown>;
+  propertiesExtractor?: <TConfig extends object, TContext extends HandlerExecutionContext>(
+    config: TConfig,
+    context: TContext
+  ) => {
+    identityProperties?: Record<string, unknown>;
+    signingProperties?: Record<string, unknown>;
+  };
+}
+
+/**
+ * @internal
+ */
+export interface SelectedHttpAuthScheme {
+  httpAuthOption: HttpAuthOption;
+  identity: Identity;
+  signer: HttpSigner;
+}

--- a/packages/types/src/auth/HttpAuthSchemeProvider.ts
+++ b/packages/types/src/auth/HttpAuthSchemeProvider.ts
@@ -1,0 +1,28 @@
+import { HandlerExecutionContext } from "../middleware";
+import { HttpAuthOption } from "./HttpAuthScheme";
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeParameters {
+  operation?: string;
+}
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeProvider<TParameters extends HttpAuthSchemeParameters> {
+  (authParameters: TParameters): HttpAuthOption[];
+}
+
+/**
+ * @internal
+ */
+export interface HttpAuthSchemeParametersProvider<
+  TConfig extends object,
+  TContext extends HandlerExecutionContext,
+  TParameters extends HttpAuthSchemeParameters,
+  TInput extends object
+> {
+  (config: TConfig, context: TContext, input: TInput): Promise<TParameters>;
+}

--- a/packages/types/src/auth/HttpSigner.ts
+++ b/packages/types/src/auth/HttpSigner.ts
@@ -1,0 +1,17 @@
+import { HttpRequest } from "../http";
+import { Identity } from "../identity/identity";
+
+/**
+ * Interface to sign identity and signing properties.
+ * @internal
+ */
+export interface HttpSigner {
+  /**
+   * Signs an HttpRequest with an identity and signing properties.
+   * @param httpRequest request to sign
+   * @param identity identity to sing the request with
+   * @param signingProperties property bag for signing
+   * @returns signed request in a promise
+   */
+  sign(httpRequest: HttpRequest, identity: Identity, signingProperties: Record<string, unknown>): Promise<HttpRequest>;
+}

--- a/packages/types/src/auth/IdentityProviderConfig.ts
+++ b/packages/types/src/auth/IdentityProviderConfig.ts
@@ -1,0 +1,15 @@
+import { Identity, IdentityProvider } from "../identity/identity";
+import { HttpAuthSchemeId } from "./HttpAuthScheme";
+
+/**
+ * Interface to get an IdentityProvider for a specified HttpAuthScheme
+ * @internal
+ */
+export interface IdentityProviderConfig {
+  /**
+   * Get the IdentityProvider for a specified HttpAuthScheme.
+   * @param schemeId schemeId of the HttpAuthScheme
+   * @returns IdentityProvider or undefined if HttpAuthScheme is not found
+   */
+  getIdentityProvider(schemeId: HttpAuthSchemeId): IdentityProvider<Identity> | undefined;
+}

--- a/packages/types/src/auth/auth.ts
+++ b/packages/types/src/auth/auth.ts
@@ -30,6 +30,7 @@ export interface AuthScheme {
 
 /**
  * @internal
+ * @deprecated
  */
 export interface HttpAuthDefinition {
   /**
@@ -47,8 +48,10 @@ export interface HttpAuthDefinition {
    */
   scheme?: string;
 }
+
 /**
  * @internal
+ * @deprecated
  */
 export enum HttpAuthLocation {
   HEADER = "header",

--- a/packages/types/src/auth/index.ts
+++ b/packages/types/src/auth/index.ts
@@ -1,0 +1,6 @@
+export * from "./auth";
+export * from "./HttpApiKeyAuth";
+export * from "./HttpAuthScheme";
+export * from "./HttpAuthSchemeProvider";
+export * from "./HttpSigner";
+export * from "./IdentityProviderConfig";

--- a/packages/types/src/endpoint.ts
+++ b/packages/types/src/endpoint.ts
@@ -1,4 +1,4 @@
-import { AuthScheme } from "./auth";
+import { AuthScheme } from "./auth/auth";
 
 /**
  * @public

--- a/packages/types/src/identity/apiKeyIdentity.ts
+++ b/packages/types/src/identity/apiKeyIdentity.ts
@@ -1,0 +1,16 @@
+import { Identity, IdentityProvider } from "../identity/identity";
+
+/**
+ * @public
+ */
+export interface ApiKeyIdentity extends Identity {
+  /**
+   * The literal API Key
+   */
+  readonly apiKey: string;
+}
+
+/**
+ * @public
+ */
+export type ApiKeyIdentityProvider = IdentityProvider<ApiKeyIdentity>;

--- a/packages/types/src/identity/index.ts
+++ b/packages/types/src/identity/index.ts
@@ -1,2 +1,4 @@
+export * from "./apiKeyIdentity";
 export * from "./awsCredentialIdentity";
 export * from "./identity";
+export * from "./tokenIdentity";

--- a/packages/types/src/identity/tokenIdentity.ts
+++ b/packages/types/src/identity/tokenIdentity.ts
@@ -1,0 +1,16 @@
+import { Identity, IdentityProvider } from "../identity/identity";
+
+/**
+ * @internal
+ */
+export interface TokenIdentity extends Identity {
+  /**
+   * The literal token string
+   */
+  readonly token: string;
+}
+
+/**
+ * @internal
+ */
+export type TokenIdentityProvider = IdentityProvider<TokenIdentity>;

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,4 +1,4 @@
-import { AuthScheme, HttpAuthDefinition } from "./auth";
+import { AuthScheme, HttpAuthDefinition } from "./auth/auth";
 import { EndpointV2 } from "./endpoint";
 import { Logger } from "./logger";
 import { UserAgent } from "./util";

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenUtils.java
@@ -284,9 +284,9 @@ public final class CodegenUtils {
                 if (value instanceof Symbol) {
                     String symbolName = ((Symbol) value).getName();
                     if (key.equals(symbolName)) {
-                        functionParametersList.add(key);
+                        functionParametersList.add(String.format("$%s:T", symbolName));
                     } else {
-                        functionParametersList.add(String.format("%s: %s", key, symbolName));
+                        functionParametersList.add(String.format("%s: $%s:T", key, key));
                     }
                 } else if (value instanceof String) {
                     functionParametersList.add(String.format("%s: '%s'", key, value));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -218,11 +218,10 @@ final class RuntimeConfigGenerator {
         // feat(experimentalIdentityAndAuth): write the default imported HttpAuthSchemeProvider
         if (target.equals(LanguageTarget.SHARED)) {
             configs.put("httpAuthSchemeProvider", w -> {
-                w.write("$T", authIndex.getDefaultHttpAuthSchemeProvider()
-                    .orElse(Symbol.builder()
+                w.write("$T", Symbol.builder()
                         .name("default" + service.toShapeId().getName() + "HttpAuthSchemeProvider")
                         .namespace(AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY.getPackageName(), "/")
-                        .build()));
+                        .build());
             });
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -253,8 +253,8 @@ final class RuntimeConfigGenerator {
 
         // feat(experimentalIdentityAndAuth): write the default httpAuthSchemes
         configs.put("httpAuthSchemes", w -> {
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-            w.addImport("IdentityProviderConfig", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.addImport("IdentityProviderConfig", null, TypeScriptDependency.SMITHY_TYPES);
             w.openBlock("[", "]", () -> {
                 Iterator<HttpAuthSchemeTarget> iter = targetAuthSchemes.iterator();
                 while (iter.hasNext()) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java
@@ -38,6 +38,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public enum TypeScriptDependency implements Dependency {
 
+    SMITHY_CORE("dependencies", "@smithy/core", false),
     AWS_SDK_CLIENT_DOCGEN("devDependencies", "@smithy/service-client-documentation-generator", true),
     AWS_SDK_TYPES("dependencies", "@aws-sdk/types", true),
     SMITHY_TYPES("dependencies", "@smithy/types", true),
@@ -122,7 +123,8 @@ public enum TypeScriptDependency implements Dependency {
 
     // feat(experimentalIdentityAndAuth): Conditionally added dependencies for `experimentalIdentityAndAuth`.
     // This package should never have a major version, and should only use minor and patch versions in development.
-    EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", false),
+    // Exports are located between @smithy/types and @smithy/core
+    @Deprecated EXPERIMENTAL_IDENTITY_AND_AUTH("dependencies", "@smithy/experimental-identity-and-auth", false),
 
     // Conditionally added when specs have been generated.
     VITEST("devDependencies", "vitest", "^0.33.0", false),

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSSDKCodegenPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSSDKCodegenPlugin.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 @Deprecated
+@SuppressWarnings("AbbreviationAsWordInName")
 public class TypeScriptSSDKCodegenPlugin extends TypeScriptServerCodegenPlugin {
     @Override
     public String getName() {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/AuthUtils.java
@@ -54,7 +54,7 @@ public final class AuthUtils {
     public static final String HTTP_AUTH_SCHEME_EXTENSION_MODULE =
         Paths.get(".", CodegenUtils.SOURCE_FOLDER, HTTP_AUTH_FOLDER, "httpAuthExtensionConfiguration").toString();
 
-        public static final String HTTP_AUTH_SCHEME_EXTENSION_PATH = HTTP_AUTH_SCHEME_EXTENSION_MODULE + ".ts";
+    public static final String HTTP_AUTH_SCHEME_EXTENSION_PATH = HTTP_AUTH_SCHEME_EXTENSION_MODULE + ".ts";
 
     public static final Dependency AUTH_HTTP_EXTENSION_DEPENDENCY = new Dependency() {
         @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthOptionProperty.java
@@ -25,7 +25,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
 public final record HttpAuthOptionProperty(
     String name,
     Type type,
-    Function<Trait, Consumer<TypeScriptWriter>> source
+    Function<Source, Consumer<TypeScriptWriter>> source
 ) implements ToSmithyBuilder<HttpAuthOptionProperty> {
     /**
      * Defines the type of the auth option property.
@@ -41,12 +41,50 @@ public final record HttpAuthOptionProperty(
         SIGNING
     }
 
+    public static final record Source(
+        HttpAuthScheme httpAuthScheme,
+        Trait trait
+    ) implements ToSmithyBuilder<Source> {
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder toBuilder() {
+            return builder()
+                .httpAuthScheme(httpAuthScheme)
+                .trait(trait);
+        }
+
+        public static final class Builder implements SmithyBuilder<Source> {
+            HttpAuthScheme httpAuthScheme;
+            Trait trait;
+
+            @Override
+            public Source build() {
+                return new Source(
+                    SmithyBuilder.requiredState("httpAuthScheme", httpAuthScheme),
+                    SmithyBuilder.requiredState("trait", trait));
+            }
+
+            public Builder httpAuthScheme(HttpAuthScheme httpAuthScheme) {
+                this.httpAuthScheme = httpAuthScheme;
+                return this;
+            }
+
+            public Builder trait(Trait trait) {
+                this.trait = trait;
+                return this;
+            }
+        }
+    }
+
     public static Builder builder() {
         return new Builder();
     }
 
     @Override
-    public SmithyBuilder<HttpAuthOptionProperty> toBuilder() {
+    public Builder toBuilder() {
         return builder()
             .name(name)
             .type(type)
@@ -56,7 +94,7 @@ public final record HttpAuthOptionProperty(
     public static final class Builder implements SmithyBuilder<HttpAuthOptionProperty> {
         private String name;
         private Type type;
-        private Function<Trait, Consumer<TypeScriptWriter>> source;
+        private Function<Source, Consumer<TypeScriptWriter>> source;
 
         @Override
         public HttpAuthOptionProperty build() {
@@ -76,7 +114,7 @@ public final record HttpAuthOptionProperty(
             return this;
         }
 
-        public Builder source(Function<Trait, Consumer<TypeScriptWriter>> source) {
+        public Builder source(Function<Source, Consumer<TypeScriptWriter>> source) {
             this.source = source;
             return this;
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthScheme.java
@@ -7,7 +7,9 @@ package software.amazon.smithy.typescript.codegen.auth.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.ConfigField;
@@ -35,6 +37,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     private final List<ConfigField> configFields;
     private final List<HttpAuthSchemeParameter> httpAuthSchemeParameters;
     private final List<HttpAuthOptionProperty> httpAuthOptionProperties;
+    private final Function<String, Consumer<TypeScriptWriter>> propertiesExtractor;
 
     private HttpAuthScheme(Builder builder) {
         this.schemeId = SmithyBuilder.requiredState(
@@ -52,6 +55,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             "httpAuthSchemeParameters", builder.httpAuthSchemeParameters.copy());
         this.httpAuthOptionProperties = SmithyBuilder.requiredState(
             "httpAuthOptionProperties", builder.httpAuthOptionProperties.copy());
+        this.propertiesExtractor =
+            builder.propertiesExtractor;
     }
 
     /**
@@ -128,6 +133,15 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
     }
 
     /**
+     * Gets the writer for the config properties extractor.
+     * @return optional of config properties extractor
+     */
+    public Optional<Function<String, Consumer<TypeScriptWriter>>> getPropertiesExtractor() {
+        return Optional.ofNullable(propertiesExtractor);
+    }
+
+
+    /**
      * Creates a {@link Builder}.
      * @return a builder
      */
@@ -149,7 +163,8 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             .defaultSigners(defaultSigners)
             .configFields(configFields)
             .httpAuthSchemeParameters(httpAuthSchemeParameters)
-            .httpAuthOptionProperties(httpAuthOptionProperties);
+            .httpAuthOptionProperties(httpAuthOptionProperties)
+            .propertiesExtractor(propertiesExtractor);
     }
 
     /**
@@ -169,6 +184,7 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
             BuilderRef.forList();
         private BuilderRef<List<HttpAuthOptionProperty>> httpAuthOptionProperties =
             BuilderRef.forList();
+        private Function<String, Consumer<TypeScriptWriter>> propertiesExtractor;
 
         private Builder() {}
 
@@ -341,6 +357,17 @@ public final class HttpAuthScheme implements ToSmithyBuilder<HttpAuthScheme> {
          */
         public Builder addHttpAuthOptionProperty(HttpAuthOptionProperty httpAuthOptionProperty) {
             this.httpAuthOptionProperties.get().add(httpAuthOptionProperty);
+            return this;
+        }
+
+        /**
+         * Sets the propertiesExtractor.
+         * @param propertiesExtractor writer for properties extractor
+         * @return the builder
+         */
+        public Builder propertiesExtractor(
+            Function<String, Consumer<TypeScriptWriter>> propertiesExtractor) {
+            this.propertiesExtractor = propertiesExtractor;
             return this;
         }
     }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/HttpAuthSchemeProviderGenerator.java
@@ -119,8 +119,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 .model(model)
                 .symbolProvider(symbolProvider)
                 .build());
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-            w.addImport("HttpAuthSchemeParameters", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.addImport("HttpAuthSchemeParameters", null, TypeScriptDependency.SMITHY_TYPES);
             w.openBlock("""
                 /**
                  * @internal
@@ -159,8 +159,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 .build());
             w.addRelativeImport(serviceSymbol.getName() + "ResolvedConfig", null,
                 Paths.get(".", serviceSymbol.getNamespace()));
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-            w.addImport("HttpAuthSchemeParametersProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.addImport("HttpAuthSchemeParametersProvider", null, TypeScriptDependency.SMITHY_TYPES);
             w.addDependency(TypeScriptDependency.SMITHY_TYPES);
             w.addImport("HandlerExecutionContext", null, TypeScriptDependency.SMITHY_TYPES);
             w.write("""
@@ -262,8 +262,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
         HttpAuthScheme authScheme
     ) {
         String normalizedAuthSchemeName = normalizeAuthSchemeName(shapeId);
-        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-        w.addImport("HttpAuthOption", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+        w.addImport("HttpAuthOption", null, TypeScriptDependency.SMITHY_TYPES);
         w.openBlock("""
             function create$LHttpAuthOption(authParameters: $LHttpAuthSchemeParameters): \
             HttpAuthOption {""", "};\n",
@@ -333,8 +333,8 @@ public class HttpAuthSchemeProviderGenerator implements Runnable {
                 .model(model)
                 .symbolProvider(symbolProvider)
                 .build());
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-            w.addImport("HttpAuthSchemeProvider", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+            w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+            w.addImport("HttpAuthSchemeProvider", null, TypeScriptDependency.SMITHY_TYPES);
             w.write("""
             /**
              * @internal

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/SupportedHttpAuthSchemesIndex.java
@@ -8,9 +8,6 @@ package software.amazon.smithy.typescript.codegen.auth.http;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.logging.Logger;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.auth.http.integration.HttpAuthTypeScriptIntegration;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -27,11 +24,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class SupportedHttpAuthSchemesIndex {
-    private static final Logger LOGGER = Logger.getLogger(SupportedHttpAuthSchemesIndex.class.getName());
-
     private final Map<ShapeId, HttpAuthScheme> supportedHttpAuthSchemes = new HashMap<>();
-    private Optional<Symbol> defaultHttpAuthSchemeProvider = Optional.empty();
-    private Optional<Symbol> defaultHttpAuthSchemeParametersProvider = Optional.empty();
 
     /**
      * Creates an index from registered {@link HttpAuthScheme}s in {@link TypeScriptIntegration}s.
@@ -48,30 +41,6 @@ public final class SupportedHttpAuthSchemesIndex {
                 this.putHttpAuthScheme(authScheme.getSchemeId(), authScheme);
             }
             httpAuthIntegration.customizeSupportedHttpAuthSchemes(this);
-            if (httpAuthIntegration.getDefaultHttpAuthSchemeProvider().isPresent()) {
-                Optional<Symbol> override =
-                    httpAuthIntegration.getDefaultHttpAuthSchemeProvider();
-                if (defaultHttpAuthSchemeProvider.isPresent()) {
-                    LOGGER.warning("An existing `HttpAuthSchemeProvider` registration `"
-                        + defaultHttpAuthSchemeProvider.get()
-                        + "` is being overwritten by `"
-                        + override.get()
-                        + "`");
-                }
-                defaultHttpAuthSchemeProvider = override;
-            }
-            if (httpAuthIntegration.getDefaultHttpAuthSchemeParametersProvider().isPresent()) {
-                Optional<Symbol> override =
-                    httpAuthIntegration.getDefaultHttpAuthSchemeParametersProvider();
-                if (defaultHttpAuthSchemeParametersProvider.isPresent()) {
-                    LOGGER.warning("An existing `HttpAuthSchemeParametersProvider` registration `"
-                        + defaultHttpAuthSchemeParametersProvider.get()
-                        + "` is being overwritten by `"
-                        + override.get()
-                        + "`");
-                }
-                defaultHttpAuthSchemeParametersProvider = override;
-            }
         }
     }
 
@@ -109,21 +78,5 @@ public final class SupportedHttpAuthSchemesIndex {
      */
     public Map<ShapeId, HttpAuthScheme> getSupportedHttpAuthSchemes() {
         return supportedHttpAuthSchemes;
-    }
-
-    /**
-     * Gets the default {@code HttpAuthSchemeProvider} symbol.
-     * @return an optional with the symbol or empty.
-     */
-    public Optional<Symbol> getDefaultHttpAuthSchemeProvider() {
-        return defaultHttpAuthSchemeProvider;
-    }
-
-    /**
-     * Gets the default {@code HttpAuthSchemeParametersProvider} symbol.
-     * @return an optional with the symbol or empty.
-     */
-    public Optional<Symbol> getDefaultHttpAuthSchemeParametersProvider() {
-        return defaultHttpAuthSchemeParametersProvider;
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -68,36 +68,36 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                 .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
                     .name("name")
                     .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(t -> w -> {
-                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                        w.write("$S", httpApiKeyAuthTrait.getName());
+                    .source(s -> w -> {
+                        HttpApiKeyAuthTrait t = (HttpApiKeyAuthTrait) s.trait();
+                        w.write("$S", t.getName());
                     })
                     .build())
                 .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
                     .name("in")
                     .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(t -> w -> {
+                    .source(s -> w -> {
                         w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
                         w.addImport("HttpApiKeyAuthLocation", null,
                             TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                        if (httpApiKeyAuthTrait.getIn().equals(Location.HEADER)) {
+                        HttpApiKeyAuthTrait t = (HttpApiKeyAuthTrait) s.trait();
+                        if (t.getIn().equals(Location.HEADER)) {
                             w.write("HttpApiKeyAuthLocation.HEADER");
-                        } else if (httpApiKeyAuthTrait.getIn().equals(Location.QUERY)) {
+                        } else if (t.getIn().equals(Location.QUERY)) {
                             w.write("HttpApiKeyAuthLocation.QUERY");
                         } else {
                             throw new CodegenException("Encountered invalid `in` property on `@httpApiKeyAuth`: "
-                            + httpApiKeyAuthTrait.getIn());
+                            + t.getIn());
                         }
                     })
                     .build())
                 .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
                     .name("scheme")
                     .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(t -> w -> {
-                        HttpApiKeyAuthTrait httpApiKeyAuthTrait = (HttpApiKeyAuthTrait) t;
-                        httpApiKeyAuthTrait.getScheme().ifPresentOrElse(
-                            s -> w.write("$S", s),
+                    .source(s -> w -> {
+                        HttpApiKeyAuthTrait t = (HttpApiKeyAuthTrait) s.trait();
+                        t.getScheme().ifPresentOrElse(
+                            scheme -> w.write("$S", scheme),
                             () -> w.write("undefined"));
                     })
                     .build())

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpApiKeyAuthPlugin.java
@@ -28,8 +28,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
     private static final Consumer<TypeScriptWriter> HTTP_API_KEY_AUTH_SIGNER = w -> {
-        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-        w.addImport("HttpApiKeyAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.addDependency(TypeScriptDependency.SMITHY_CORE);
+        w.addImport("HttpApiKeyAuthSigner", null, TypeScriptDependency.SMITHY_CORE);
         w.write("new HttpApiKeyAuthSigner()");
     };
 
@@ -51,17 +51,17 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                     .type(ConfigField.Type.MAIN)
                     .docs(w -> w.write("The API key to use when making requests."))
                     .inputType(w -> {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("ApiKeyIdentity", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("ApiKeyIdentityProvider", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.write("ApiKeyIdentity | ApiKeyIdentityProvider");
                     })
                     .resolvedType(w -> {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("ApiKeyIdentityProvider", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.write("ApiKeyIdentityProvider");
                     })
                     .build())
@@ -77,9 +77,9 @@ public class AddHttpApiKeyAuthPlugin implements HttpAuthTypeScriptIntegration {
                     .name("in")
                     .type(HttpAuthOptionProperty.Type.SIGNING)
                     .source(s -> w -> {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("HttpApiKeyAuthLocation", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         HttpApiKeyAuthTrait t = (HttpApiKeyAuthTrait) s.trait();
                         if (t.getIn().equals(Location.HEADER)) {
                             w.write("HttpApiKeyAuthLocation.HEADER");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpAuthSchemeMiddleware.java
@@ -49,7 +49,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
             RuntimeClientPlugin.builder()
                 .servicePredicate((m, s) -> s.hasTrait(EndpointRuleSetTrait.ID))
                 .withConventions(
-                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                    TypeScriptDependency.SMITHY_CORE.dependency,
                     "HttpAuthSchemeEndpointRuleSet",
                     Convention.HAS_MIDDLEWARE)
                 .additionalPluginFunctionParamsSupplier((model, service, operation) -> Map.of(
@@ -64,7 +64,7 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
             RuntimeClientPlugin.builder()
                 .servicePredicate((m, s) -> !s.hasTrait(EndpointRuleSetTrait.ID))
                 .withConventions(
-                    TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                    TypeScriptDependency.SMITHY_CORE.dependency,
                     "HttpAuthScheme",
                     Convention.HAS_MIDDLEWARE)
                 .additionalPluginFunctionParamsSupplier((model, service, operation) -> Map.of(
@@ -127,8 +127,8 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
             }
             */
             w.openBlock("private getIdentityProviderConfigProvider() {", "}\n", () -> {
-                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                w.addImport("DefaultIdentityProviderConfig", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addDependency(TypeScriptDependency.SMITHY_CORE);
+                w.addImport("DefaultIdentityProviderConfig", null, TypeScriptDependency.SMITHY_CORE);
                 w.openBlock("""
                     return async (config: $LResolvedConfig) => \
                     new DefaultIdentityProviderConfig({""", "});",
@@ -218,8 +218,8 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
              * @internal
              */
             export interface HttpAuthSchemeInputConfig {""", "}\n", () -> {
-                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
                 w.writeDocs("""
                     experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides \
                     default identity providers and signers per auth scheme.
@@ -265,8 +265,8 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
              * @internal
              */
             export interface HttpAuthSchemeResolvedConfig {""", "}\n", () -> {
-                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addDependency(TypeScriptDependency.SMITHY_TYPES);
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
                 w.writeDocs("""
                     experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides \
                     default identity providers and signers per auth scheme.
@@ -315,16 +315,16 @@ public final class AddHttpAuthSchemeMiddleware implements HttpAuthTypeScriptInte
             export const resolveHttpAuthSchemeConfig = (config: HttpAuthSchemeInputConfig): \
             HttpAuthSchemeResolvedConfig => {""", "};", () -> {
                 // TODO(experimentalIdentityAndAuth): figure out a better way to configure resolving identities
-                w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addDependency(TypeScriptDependency.SMITHY_CORE);
                 for (ConfigField configField : configFields.values()) {
                     if (configField.type().equals(ConfigField.Type.MAIN)) {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_CORE);
                         w.addImport("memoizeIdentityProvider", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_CORE);
                         w.addImport("isIdentityExpired", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_CORE);
                         w.addImport("doesIdentityRequireRefresh", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_CORE);
                         w.write("""
                             const $L = memoizeIdentityProvider(config.$L, isIdentityExpired, \
                             doesIdentityRequireRefresh);""",

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpBearerAuthPlugin.java
@@ -26,8 +26,8 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegration {
     private static final Consumer<TypeScriptWriter> HTTP_BEARER_AUTH_SIGNER = w -> {
-        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-        w.addImport("HttpBearerAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.addDependency(TypeScriptDependency.SMITHY_CORE);
+        w.addImport("HttpBearerAuthSigner", null, TypeScriptDependency.SMITHY_CORE);
         w.write("new HttpBearerAuthSigner()");
     };
 
@@ -49,17 +49,17 @@ public final class AddHttpBearerAuthPlugin implements HttpAuthTypeScriptIntegrat
                     .type(Type.MAIN)
                     .docs(w -> w.write("The token used to authenticate requests."))
                     .inputType(w -> {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("TokenIdentity", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("TokenIdentityProvider", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.write("TokenIdentity | TokenIdentityProvider");
                     })
                     .resolvedType(w -> {
-                        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                        w.addDependency(TypeScriptDependency.SMITHY_TYPES);
                         w.addImport("TokenIdentityProvider", null,
-                            TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                            TypeScriptDependency.SMITHY_TYPES);
                         w.write("TokenIdentityProvider");
                     })
                     .build())

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddHttpSigningMiddleware.java
@@ -33,7 +33,7 @@ public class AddHttpSigningMiddleware implements TypeScriptIntegration {
     public List<RuntimeClientPlugin> getClientPlugins() {
         return List.of(RuntimeClientPlugin.builder()
             .withConventions(
-                TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH.dependency,
+                TypeScriptDependency.SMITHY_CORE.dependency,
                 "HttpSigning",
                 HAS_MIDDLEWARE)
             .build());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddNoAuthPlugin.java
@@ -24,8 +24,8 @@ public final class AddNoAuthPlugin implements HttpAuthTypeScriptIntegration {
     private static final Consumer<TypeScriptWriter> NO_AUTH_IDENTITY_PROVIDER_WRITER =
         w -> w.write("async () => ({})");
     private static final Consumer<TypeScriptWriter> NO_AUTH_SIGNER_WRITER = w -> {
-        w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
-        w.addImport("NoAuthSigner", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+        w.addDependency(TypeScriptDependency.SMITHY_CORE);
+        w.addImport("NoAuthSigner", null, TypeScriptDependency.SMITHY_CORE);
         w.write("new NoAuthSigner()");
     };
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/AddSigV4AuthPlugin.java
@@ -91,8 +91,8 @@ public final class AddSigV4AuthPlugin implements HttpAuthTypeScriptIntegration {
                 .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()
                     .name("name")
                     .type(HttpAuthOptionProperty.Type.SIGNING)
-                    .source(t -> w -> {
-                        w.write("$S", t.toNode().expectObjectNode().getMember("name"));
+                    .source(s -> w -> {
+                        w.write("$S", s.trait().toNode().expectObjectNode().getMember("name"));
                     })
                     .build())
                 .addHttpAuthOptionProperty(HttpAuthOptionProperty.builder()

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -223,7 +223,12 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
       let _token = runtimeConfig.token;
       return {
         setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-          _httpAuthSchemes.push(httpAuthScheme);
+          const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
+          if (index === -1) {
+            _httpAuthSchemes.push(httpAuthScheme);
+          } else {
+            _httpAuthSchemes.splice(index, 1, httpAuthScheme);
+          }
         },
         httpAuthSchemes(): HttpAuthScheme[] {
           return _httpAuthSchemes;
@@ -285,7 +290,13 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                 () -> {
                     w.write("""
                         setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-                          _httpAuthSchemes.push(httpAuthScheme);
+                          const index = _httpAuthSchemes.findIndex(scheme => \
+                        scheme.schemeId === httpAuthScheme.schemeId);
+                          if (index === -1) {
+                            _httpAuthSchemes.push(httpAuthScheme);
+                          } else {
+                            _httpAuthSchemes.splice(index, 1, httpAuthScheme);
+                          }
                         },
                         httpAuthSchemes(): HttpAuthScheme[] {
                           return _httpAuthSchemes;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthRuntimeExtensionIntegration.java
@@ -114,7 +114,6 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
         String serviceName
     ) {
         delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addDependency(TypeScriptDependency.SMITHY_TYPES);
             w.openBlock("""
                 /**
@@ -122,7 +121,7 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                  */
                 export interface HttpAuthExtensionConfiguration {""", "}",
                 () -> {
-                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
                 w.write("setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void;");
                 w.write("httpAuthSchemes(): HttpAuthScheme[];");
 
@@ -176,7 +175,6 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
         String serviceName
     ) {
         delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addDependency(TypeScriptDependency.SMITHY_TYPES);
             w.openBlock("""
                 /**
@@ -184,7 +182,7 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                  */
                 export type HttpAuthRuntimeConfig = Partial<{""", "}>;",
                 () -> {
-                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
                 w.write("httpAuthSchemes: HttpAuthScheme[];");
                 w.addImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
                 w.write("httpAuthSchemeProvider: $LHttpAuthSchemeProvider;", serviceName);
@@ -267,7 +265,6 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
         String serviceName
     ) {
         delegator.useFileWriter(AuthUtils.HTTP_AUTH_SCHEME_EXTENSION_PATH, w -> {
-            w.addDependency(TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
             w.addDependency(TypeScriptDependency.SMITHY_TYPES);
             w.openBlock("""
                 /**
@@ -276,7 +273,7 @@ public class HttpAuthRuntimeExtensionIntegration implements TypeScriptIntegratio
                 export const getHttpAuthExtensionConfiguration = (runtimeConfig: HttpAuthRuntimeConfig): \
                 HttpAuthExtensionConfiguration => {""", "};",
                 () -> {
-                w.addImport("HttpAuthScheme", null, TypeScriptDependency.EXPERIMENTAL_IDENTITY_AND_AUTH);
+                w.addImport("HttpAuthScheme", null, TypeScriptDependency.SMITHY_TYPES);
                 w.write("let _httpAuthSchemes = runtimeConfig.httpAuthSchemes!;");
                 w.addImport(serviceName + "HttpAuthSchemeProvider", null, AuthUtils.AUTH_HTTP_PROVIDER_DEPENDENCY);
                 w.write("let _httpAuthSchemeProvider = runtimeConfig.httpAuthSchemeProvider!;");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/integration/HttpAuthTypeScriptIntegration.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.typescript.codegen.auth.http.integration;
 
 import java.util.Optional;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
 import software.amazon.smithy.typescript.codegen.auth.http.SupportedHttpAuthSchemesIndex;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -34,23 +33,5 @@ public interface HttpAuthTypeScriptIntegration extends TypeScriptIntegration {
      * @param supportedHttpAuthSchemesIndex index to mutate.
      */
     default void customizeSupportedHttpAuthSchemes(SupportedHttpAuthSchemesIndex supportedHttpAuthSchemesIndex) {
-    }
-
-    /**
-     * feat(experimentalIdentityAndAuth): Register an {@link Symbol} that points to an {@code HttpAuthSchemeProvider}
-     * implementation.
-     * @return an empty optional.
-     */
-    default Optional<Symbol> getDefaultHttpAuthSchemeProvider() {
-        return Optional.empty();
-    }
-
-    /**
-     * feat(experimentalIdentityAndAuth): Register an {@link Symbol} that points to an
-     * {@code HttpAuthSchemeParametersProvider} implementation.
-     * @return an empty optional.
-     */
-    default Optional<Symbol> getDefaultHttpAuthSchemeParametersProvider() {
-        return Optional.empty();
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/DefaultHttpAuthSchemeParametersProviderFunctionCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/DefaultHttpAuthSchemeParametersProviderFunctionCodeSection.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeParameter;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class DefaultHttpAuthSchemeParametersProviderFunctionCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+    private final Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters;
+
+    private DefaultHttpAuthSchemeParametersProviderFunctionCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+        httpAuthSchemeParameters =
+            SmithyBuilder.requiredState("httpAuthSchemeParameters", builder.httpAuthSchemeParameters);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public Map<String, HttpAuthSchemeParameter> getHttpAuthSchemeParameters() {
+        return httpAuthSchemeParameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<DefaultHttpAuthSchemeParametersProviderFunctionCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+        private Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters;
+
+        @Override
+        public DefaultHttpAuthSchemeParametersProviderFunctionCodeSection build() {
+            return new DefaultHttpAuthSchemeParametersProviderFunctionCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+
+        public Builder httpAuthSchemeParameters(Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters) {
+            this.httpAuthSchemeParameters = httpAuthSchemeParameters;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/DefaultHttpAuthSchemeProviderFunctionCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/DefaultHttpAuthSchemeProviderFunctionCodeSection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class DefaultHttpAuthSchemeProviderFunctionCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+
+    private DefaultHttpAuthSchemeProviderFunctionCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<DefaultHttpAuthSchemeProviderFunctionCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+
+        @Override
+        public DefaultHttpAuthSchemeProviderFunctionCodeSection build() {
+            return new DefaultHttpAuthSchemeProviderFunctionCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthOptionFunctionsCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthOptionFunctionsCodeSection.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthScheme;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class HttpAuthOptionFunctionsCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+    private final Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes;
+
+
+    private HttpAuthOptionFunctionsCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+        effectiveHttpAuthSchemes =
+            SmithyBuilder.requiredState("effectiveHttpAuthSchemes", builder.effectiveHttpAuthSchemes);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<HttpAuthOptionFunctionsCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+        private Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes;
+
+        @Override
+        public HttpAuthOptionFunctionsCodeSection build() {
+            return new HttpAuthOptionFunctionsCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+
+        public Builder effectiveHttpAuthSchemes(Map<ShapeId, HttpAuthScheme> effectiveHttpAuthSchemes) {
+            this.effectiveHttpAuthSchemes = effectiveHttpAuthSchemes;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeParametersInterfaceCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeParametersInterfaceCodeSection.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import java.util.Map;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.auth.http.HttpAuthSchemeParameter;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class HttpAuthSchemeParametersInterfaceCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+    private final Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters;
+
+    private HttpAuthSchemeParametersInterfaceCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+        httpAuthSchemeParameters =
+            SmithyBuilder.requiredState("httpAuthSchemeParameters", builder.httpAuthSchemeParameters);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public Map<String, HttpAuthSchemeParameter> getHttpAuthSchemeParameters() {
+        return httpAuthSchemeParameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<HttpAuthSchemeParametersInterfaceCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+        private Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters;
+
+        @Override
+        public HttpAuthSchemeParametersInterfaceCodeSection build() {
+            return new HttpAuthSchemeParametersInterfaceCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+
+        public Builder httpAuthSchemeParameters(Map<String, HttpAuthSchemeParameter> httpAuthSchemeParameters) {
+            this.httpAuthSchemeParameters = httpAuthSchemeParameters;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeParametersProviderInterfaceCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeParametersProviderInterfaceCodeSection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class HttpAuthSchemeParametersProviderInterfaceCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+
+    private HttpAuthSchemeParametersProviderInterfaceCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<HttpAuthSchemeParametersProviderInterfaceCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+
+        @Override
+        public HttpAuthSchemeParametersProviderInterfaceCodeSection build() {
+            return new HttpAuthSchemeParametersProviderInterfaceCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeProviderInterfaceCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/auth/http/sections/HttpAuthSchemeProviderInterfaceCodeSection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.auth.http.sections;
+
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+public final class HttpAuthSchemeProviderInterfaceCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final TypeScriptSettings settings;
+    private final Model model;
+    private final SymbolProvider symbolProvider;
+
+    private HttpAuthSchemeProviderInterfaceCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        settings = SmithyBuilder.requiredState("settings", builder.settings);
+        model = SmithyBuilder.requiredState("model", builder.model);
+        symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public TypeScriptSettings getSettings() {
+        return settings;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public SymbolProvider getSymbolProvider() {
+        return symbolProvider;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SmithyBuilder<HttpAuthSchemeProviderInterfaceCodeSection> {
+        private ServiceShape service;
+        private TypeScriptSettings settings;
+        private Model model;
+        private SymbolProvider symbolProvider;
+
+        @Override
+        public HttpAuthSchemeProviderInterfaceCodeSection build() {
+            return new HttpAuthSchemeProviderInterfaceCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder settings(TypeScriptSettings settings) {
+            this.settings = settings;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder symbolProvider(SymbolProvider symbolProvider) {
+            this.symbolProvider = symbolProvider;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientBodyExtraCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientBodyExtraCodeSection.java
@@ -6,38 +6,34 @@
 package software.amazon.smithy.typescript.codegen.sections;
 
 import java.util.List;
-import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.CodeSection;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class ClientBodyExtraCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
-    private final OperationShape operation;
     private final SymbolProvider symbolProvider;
+    private final List<TypeScriptIntegration> integrations;
     private final List<RuntimeClientPlugin> runtimeClientPlugins;
-    private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private ClientBodyExtraCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
-        operation = SmithyBuilder.requiredState("operation", builder.operation);
         symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+        integrations = SmithyBuilder.requiredState("integrations", builder.integrations);
         runtimeClientPlugins = SmithyBuilder.requiredState("runtimeClientPlugins", builder.runtimeClientPlugins);
-        protocolGenerator = builder.protocolGenerator;
         applicationProtocol = SmithyBuilder.requiredState("applicationProtocol", builder.applicationProtocol);
     }
 
@@ -57,39 +53,34 @@ public final class SmithyContextCodeSection implements CodeSection {
         return service;
     }
 
-    public OperationShape getOperation() {
-        return operation;
-    }
-
     public SymbolProvider getSymbolProvider() {
         return symbolProvider;
+    }
+
+    public List<TypeScriptIntegration> getIntegrations() {
+        return integrations;
     }
 
     public List<RuntimeClientPlugin> getRuntimeClientPlugins() {
         return runtimeClientPlugins;
     }
 
-    public Optional<ProtocolGenerator> getProtocolGenerator() {
-        return Optional.ofNullable(protocolGenerator);
-    }
-
     public ApplicationProtocol getApplicationProtocol() {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<ClientBodyExtraCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
-        private OperationShape operation;
         private SymbolProvider symbolProvider;
+        private List<TypeScriptIntegration> integrations;
         private List<RuntimeClientPlugin> runtimeClientPlugins;
-        private ProtocolGenerator protocolGenerator;
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public ClientBodyExtraCodeSection build() {
+            return new ClientBodyExtraCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {
@@ -107,23 +98,18 @@ public final class SmithyContextCodeSection implements CodeSection {
             return this;
         }
 
-        public Builder operation(OperationShape operation) {
-            this.operation = operation;
-            return this;
-        }
-
         public Builder symbolProvider(SymbolProvider symbolProvider) {
             this.symbolProvider = symbolProvider;
             return this;
         }
 
-        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
-            this.runtimeClientPlugins = runtimeClientPlugins;
+        public Builder integrations(List<TypeScriptIntegration> integrations) {
+            this.integrations = integrations;
             return this;
         }
 
-        public Builder protocolGenerator(ProtocolGenerator protocolGenerator) {
-            this.protocolGenerator = protocolGenerator;
+        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
+            this.runtimeClientPlugins = runtimeClientPlugins;
             return this;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientConfigCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientConfigCodeSection.java
@@ -6,38 +6,34 @@
 package software.amazon.smithy.typescript.codegen.sections;
 
 import java.util.List;
-import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.CodeSection;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class ClientConfigCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
-    private final OperationShape operation;
     private final SymbolProvider symbolProvider;
+    private final List<TypeScriptIntegration> integrations;
     private final List<RuntimeClientPlugin> runtimeClientPlugins;
-    private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private ClientConfigCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
-        operation = SmithyBuilder.requiredState("operation", builder.operation);
         symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
+        integrations = SmithyBuilder.requiredState("integrations", builder.integrations);
         runtimeClientPlugins = SmithyBuilder.requiredState("runtimeClientPlugins", builder.runtimeClientPlugins);
-        protocolGenerator = builder.protocolGenerator;
         applicationProtocol = SmithyBuilder.requiredState("applicationProtocol", builder.applicationProtocol);
     }
 
@@ -57,39 +53,34 @@ public final class SmithyContextCodeSection implements CodeSection {
         return service;
     }
 
-    public OperationShape getOperation() {
-        return operation;
-    }
-
     public SymbolProvider getSymbolProvider() {
         return symbolProvider;
+    }
+
+    public List<TypeScriptIntegration> getIntegrations() {
+        return integrations;
     }
 
     public List<RuntimeClientPlugin> getRuntimeClientPlugins() {
         return runtimeClientPlugins;
     }
 
-    public Optional<ProtocolGenerator> getProtocolGenerator() {
-        return Optional.ofNullable(protocolGenerator);
-    }
-
     public ApplicationProtocol getApplicationProtocol() {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<ClientConfigCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
-        private OperationShape operation;
         private SymbolProvider symbolProvider;
+        private List<TypeScriptIntegration> integrations;
         private List<RuntimeClientPlugin> runtimeClientPlugins;
-        private ProtocolGenerator protocolGenerator;
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public ClientConfigCodeSection build() {
+            return new ClientConfigCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {
@@ -107,23 +98,18 @@ public final class SmithyContextCodeSection implements CodeSection {
             return this;
         }
 
-        public Builder operation(OperationShape operation) {
-            this.operation = operation;
-            return this;
-        }
-
         public Builder symbolProvider(SymbolProvider symbolProvider) {
             this.symbolProvider = symbolProvider;
             return this;
         }
 
-        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
-            this.runtimeClientPlugins = runtimeClientPlugins;
+        public Builder integrations(List<TypeScriptIntegration> integrations) {
+            this.integrations = integrations;
             return this;
         }
 
-        public Builder protocolGenerator(ProtocolGenerator protocolGenerator) {
-            this.protocolGenerator = protocolGenerator;
+        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
+            this.runtimeClientPlugins = runtimeClientPlugins;
             return this;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientConstructorCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientConstructorCodeSection.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.sections;
+
+import java.util.List;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public final class ClientConstructorCodeSection implements CodeSection {
+    private final ServiceShape service;
+    private final List<RuntimeClientPlugin> runtimeClientPlugins;
+    private final Model model;
+
+    private ClientConstructorCodeSection(Builder builder) {
+        service = SmithyBuilder.requiredState("service", builder.service);
+        runtimeClientPlugins = SmithyBuilder.requiredState("runtimePlugins", builder.runtimeClientPlugins);
+        model = SmithyBuilder.requiredState("model", builder.model);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public ServiceShape getService() {
+        return service;
+    }
+
+    public List<RuntimeClientPlugin> getRuntimeClientPlugins() {
+        return runtimeClientPlugins;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public static class Builder implements SmithyBuilder<ClientConstructorCodeSection> {
+        private ServiceShape service;
+        private List<RuntimeClientPlugin> runtimeClientPlugins;
+        private Model model;
+
+        @Override
+        public ClientConstructorCodeSection build() {
+            return new ClientConstructorCodeSection(this);
+        }
+
+        public Builder service(ServiceShape service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
+            this.runtimeClientPlugins = runtimeClientPlugins;
+            return this;
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientDestroyCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientDestroyCodeSection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.typescript.codegen.sections;
+
+import java.util.List;
+import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+@SmithyUnstableApi
+public final class ClientDestroyCodeSection implements CodeSection {
+    private final List<RuntimeClientPlugin> runtimeClientPlugins;
+
+    private ClientDestroyCodeSection(Builder builder) {
+        runtimeClientPlugins = SmithyBuilder.requiredState("runtimePlugins", builder.runtimeClientPlugins);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public List<RuntimeClientPlugin> getRuntimeClientPlugins() {
+        return runtimeClientPlugins;
+    }
+
+    public static class Builder implements SmithyBuilder<ClientDestroyCodeSection> {
+        private List<RuntimeClientPlugin> runtimeClientPlugins;
+
+        @Override
+        public ClientDestroyCodeSection build() {
+            return new ClientDestroyCodeSection(this);
+        }
+
+        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
+            this.runtimeClientPlugins = runtimeClientPlugins;
+            return this;
+        }
+    }
+}

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientPropertiesCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/ClientPropertiesCodeSection.java
@@ -6,38 +6,31 @@
 package software.amazon.smithy.typescript.codegen.sections;
 
 import java.util.List;
-import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
-import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
-import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
 import software.amazon.smithy.utils.CodeSection;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class ClientPropertiesCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
-    private final OperationShape operation;
     private final SymbolProvider symbolProvider;
-    private final List<RuntimeClientPlugin> runtimeClientPlugins;
-    private final ProtocolGenerator protocolGenerator;
+    private final List<TypeScriptIntegration> integrations;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private ClientPropertiesCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
-        operation = SmithyBuilder.requiredState("operation", builder.operation);
         symbolProvider = SmithyBuilder.requiredState("symbolProvider", builder.symbolProvider);
-        runtimeClientPlugins = SmithyBuilder.requiredState("runtimeClientPlugins", builder.runtimeClientPlugins);
-        protocolGenerator = builder.protocolGenerator;
+        integrations = SmithyBuilder.requiredState("integrations", builder.integrations);
         applicationProtocol = SmithyBuilder.requiredState("applicationProtocol", builder.applicationProtocol);
     }
 
@@ -57,39 +50,29 @@ public final class SmithyContextCodeSection implements CodeSection {
         return service;
     }
 
-    public OperationShape getOperation() {
-        return operation;
-    }
-
     public SymbolProvider getSymbolProvider() {
         return symbolProvider;
     }
 
-    public List<RuntimeClientPlugin> getRuntimeClientPlugins() {
-        return runtimeClientPlugins;
-    }
-
-    public Optional<ProtocolGenerator> getProtocolGenerator() {
-        return Optional.ofNullable(protocolGenerator);
+    public List<TypeScriptIntegration> getIntegrations() {
+        return integrations;
     }
 
     public ApplicationProtocol getApplicationProtocol() {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<ClientPropertiesCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
-        private OperationShape operation;
         private SymbolProvider symbolProvider;
-        private List<RuntimeClientPlugin> runtimeClientPlugins;
-        private ProtocolGenerator protocolGenerator;
+        private List<TypeScriptIntegration> integrations;
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public ClientPropertiesCodeSection build() {
+            return new ClientPropertiesCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {
@@ -107,23 +90,13 @@ public final class SmithyContextCodeSection implements CodeSection {
             return this;
         }
 
-        public Builder operation(OperationShape operation) {
-            this.operation = operation;
-            return this;
-        }
-
         public Builder symbolProvider(SymbolProvider symbolProvider) {
             this.symbolProvider = symbolProvider;
             return this;
         }
 
-        public Builder runtimeClientPlugins(List<RuntimeClientPlugin> runtimeClientPlugins) {
-            this.runtimeClientPlugins = runtimeClientPlugins;
-            return this;
-        }
-
-        public Builder protocolGenerator(ProtocolGenerator protocolGenerator) {
-            this.protocolGenerator = protocolGenerator;
+        public Builder integrations(List<TypeScriptIntegration> integrations) {
+            this.integrations = integrations;
             return this;
         }
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandBodyExtraCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandBodyExtraCodeSection.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class CommandBodyExtraCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
@@ -30,7 +30,7 @@ public final class SmithyContextCodeSection implements CodeSection {
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private CommandBodyExtraCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
@@ -77,7 +77,7 @@ public final class SmithyContextCodeSection implements CodeSection {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<CommandBodyExtraCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
@@ -88,8 +88,8 @@ public final class SmithyContextCodeSection implements CodeSection {
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public CommandBodyExtraCodeSection build() {
+            return new CommandBodyExtraCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandConstructorCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandConstructorCodeSection.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class CommandConstructorCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
@@ -30,7 +30,7 @@ public final class SmithyContextCodeSection implements CodeSection {
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private CommandConstructorCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
@@ -77,7 +77,7 @@ public final class SmithyContextCodeSection implements CodeSection {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<CommandConstructorCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
@@ -88,8 +88,8 @@ public final class SmithyContextCodeSection implements CodeSection {
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public CommandConstructorCodeSection build() {
+            return new CommandConstructorCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandContextCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandContextCodeSection.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class CommandContextCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
@@ -30,7 +30,7 @@ public final class SmithyContextCodeSection implements CodeSection {
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private CommandContextCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
@@ -77,7 +77,7 @@ public final class SmithyContextCodeSection implements CodeSection {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<CommandContextCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
@@ -88,8 +88,8 @@ public final class SmithyContextCodeSection implements CodeSection {
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public CommandContextCodeSection build() {
+            return new CommandContextCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandPropertiesCodeSection.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/sections/CommandPropertiesCodeSection.java
@@ -20,7 +20,7 @@ import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 @SmithyUnstableApi
-public final class SmithyContextCodeSection implements CodeSection {
+public final class CommandPropertiesCodeSection implements CodeSection {
     private final TypeScriptSettings settings;
     private final Model model;
     private final ServiceShape service;
@@ -30,7 +30,7 @@ public final class SmithyContextCodeSection implements CodeSection {
     private final ProtocolGenerator protocolGenerator;
     private final ApplicationProtocol applicationProtocol;
 
-    private SmithyContextCodeSection(Builder builder) {
+    private CommandPropertiesCodeSection(Builder builder) {
         settings = SmithyBuilder.requiredState("settings", builder.settings);
         model = SmithyBuilder.requiredState("model", builder.model);
         service = SmithyBuilder.requiredState("service", builder.service);
@@ -77,7 +77,7 @@ public final class SmithyContextCodeSection implements CodeSection {
         return applicationProtocol;
     }
 
-    public static class Builder implements SmithyBuilder<SmithyContextCodeSection> {
+    public static class Builder implements SmithyBuilder<CommandPropertiesCodeSection> {
         private TypeScriptSettings settings;
         private Model model;
         private ServiceShape service;
@@ -88,8 +88,8 @@ public final class SmithyContextCodeSection implements CodeSection {
         private ApplicationProtocol applicationProtocol;
 
         @Override
-        public SmithyContextCodeSection build() {
-            return new SmithyContextCodeSection(this);
+        public CommandPropertiesCodeSection build() {
+            return new CommandPropertiesCodeSection(this);
         }
 
         public Builder settings(TypeScriptSettings settings) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/integration/AddHttpApiKeyAuthPluginTest.java
@@ -31,20 +31,20 @@ import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 public class AddHttpApiKeyAuthPluginTest {
     @Test
     public void httpApiKeyAuthClientOnService() {
-        testInjects("http-api-key-auth-trait.smithy", ", { scheme: 'ApiKey', in: 'header', name: 'Authorization'}");
+        testInjects("http-api-key-auth-trait.smithy", ", { scheme: 'ApiKey', in: 'header', name: 'Authorization' }");
     }
 
     @Test
     public void httpApiKeyAuthClientOnOperation() {
         testInjects("http-api-key-auth-trait-on-operation.smithy",
-                ", { scheme: 'ApiKey', in: 'header', name: 'Authorization'}");
+                ", { scheme: 'ApiKey', in: 'header', name: 'Authorization' }");
     }
 
     // This should be identical to the httpApiKeyAuthClient test except for the parameters provided
     // to the middleware.
     @Test
     public void httpApiKeyAuthClientNoScheme() {
-        testInjects("http-api-key-auth-trait-no-scheme.smithy", ", { in: 'header', name: 'Authorization'}");
+        testInjects("http-api-key-auth-trait-no-scheme.smithy", ", { in: 'header', name: 'Authorization' }");
     }
 
     private void testInjects(String filename, String extra) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@smithy/core@workspace:packages/core":
+  version: 0.0.0-use.local
+  resolution: "@smithy/core@workspace:packages/core"
+  dependencies:
+    "@smithy/middleware-endpoint": "workspace:^"
+    "@smithy/middleware-retry": "workspace:^"
+    "@smithy/middleware-serde": "workspace:^"
+    "@smithy/protocol-http": "workspace:^"
+    "@smithy/types": "workspace:^"
+    "@tsconfig/recommended": 1.0.1
+    concurrently: 7.0.0
+    downlevel-dts: 0.10.1
+    rimraf: 3.0.2
+    tslib: ^2.5.0
+    typedoc: 0.23.23
+  languageName: unknown
+  linkType: soft
+
 "@smithy/credential-provider-imds@workspace:^, @smithy/credential-provider-imds@workspace:packages/credential-provider-imds":
   version: 0.0.0-use.local
   resolution: "@smithy/credential-provider-imds@workspace:packages/credential-provider-imds"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

***Tests CI will fail since there are new packages and breaking changes to the `@smithy/experimental-identity-and-auth` package. These were tested locally, see the testing section towards the bottom of the PR description.***

The main changes in this PR are:

- TypeScript
  - Updating the HTTP identity and auth flow to pass in the default http auth scheme parameters provider and identity provider config provider functions as properties of the client: https://github.com/awslabs/smithy-typescript/pull/1068/commits/cf28bc916712259635f809287a20d9837be9c8dc
  - Bug fix for the extension configuration when setting http auth schemes
  - Populate signing properties from endpoint middleware: https://github.com/awslabs/smithy-typescript/pull/1068/commits/4fe9c2f4af1dae781662101736e5fb3892300220
  - Move `@smithy/experimental-identity-and-auth` types, interfaces, implementations to `@smithy/types` and a *new* `@smithy/core` package: https://github.com/awslabs/smithy-typescript/pull/1068/commits/2f5cd608dcca0cbf30a080ee5ad07e85843f8f9b
- Codegen
  - Quality of life: https://github.com/awslabs/smithy-typescript/pull/1068/commits/fe2556225307397f6b6ec1bf6351acd412c516b8
  - BIG codegen refactoring: https://github.com/awslabs/smithy-typescript/pull/1068/commits/668d7b1e09c468d4f19cd63e508c23aee6131f79
    - This includes leveraging DirectedCodegen code sections and interceptors, so most of this is boilerplate

*Codegen Diff*

New `@smithy/core` package added:

```diff
diff --color -Nur og/package.json new/package.json
--- og/package.json	2023-11-13 10:41:32
+++ new/package.json	2023-11-13 10:42:47
@@ -22,6 +22,7 @@
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/types": "latest",
         "@smithy/config-resolver": "^2.0.17",
+        "@smithy/core": "^0.0.1",
         "@smithy/eventstream-serde-browser": "^2.0.12",
         "@smithy/eventstream-serde-config-resolver": "^2.0.12",
         "@smithy/eventstream-serde-node": "^2.0.12",
```

`httpAuthSchemes` and `httpAuthSchemeProvider` are now part of the input / resolved config of `resolveHttpAuthSchemeConfig`. The http auth scheme parameters provider and identity provider config provider functions as properties of the client are passed into the auth middleware plugin too.

```diff
diff --color -Nur og/src/WeatherClient.ts new/src/WeatherClient.ts
--- og/src/WeatherClient.ts	2023-11-13 10:41:32
+++ new/src/WeatherClient.ts	2023-11-13 10:42:47
@@ -2,7 +2,7 @@
 import {
   HttpAuthSchemeInputConfig,
   HttpAuthSchemeResolvedConfig,
-  WeatherHttpAuthSchemeProvider,
+  defaultWeatherHttpAuthSchemeParametersProvider,
   resolveHttpAuthSchemeConfig,
 } from "./auth/httpAuthSchemeProvider";
 import {
@@ -104,15 +104,15 @@
   resolveCustomEndpointsConfig,
 } from "@smithy/config-resolver";
 import {
+  DefaultIdentityProviderConfig,
+  getHttpAuthSchemeEndpointRuleSetPlugin,
+  getHttpSigningPlugin,
+} from "@smithy/core";
+import {
   EventStreamSerdeInputConfig,
   EventStreamSerdeResolvedConfig,
   resolveEventStreamSerdeConfig,
 } from "@smithy/eventstream-serde-config-resolver";
-import {
-  HttpAuthScheme,
-  getHttpAuthSchemeEndpointRuleSetPlugin,
-  getHttpSigningPlugin,
-} from "@smithy/experimental-identity-and-auth";
 import { getContentLengthPlugin } from "@smithy/middleware-content-length";
 import {
   EndpointInputConfig,
@@ -320,18 +320,6 @@
   defaultsMode?: __DefaultsMode | __Provider<__DefaultsMode>;
 
   /**
-   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
-   * @internal
-   */
-  httpAuthSchemes?: HttpAuthScheme[];
-
-  /**
-   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
-   * @internal
-   */
-  httpAuthSchemeProvider?: WeatherHttpAuthSchemeProvider;
-
-  /**
    * The internal function that inject utilities to runtime-specific stream to help users consume the data
    * @internal
    */
@@ -393,6 +381,18 @@
    */
   readonly config: WeatherClientResolvedConfig;
 
+  private getDefaultHttpAuthSchemeParametersProvider() {
+    return defaultWeatherHttpAuthSchemeParametersProvider;
+  }
+
+  private getIdentityProviderConfigProvider() {
+    return async (config: WeatherClientResolvedConfig) => new DefaultIdentityProviderConfig({
+      "aws.auth#sigv4": config.credentials,
+      "smithy.api#httpApiKeyAuth": config.apiKey,
+      "smithy.api#httpBearerAuth": config.token,
+    });
+  }
+
   constructor(...[configuration]: __CheckOptionalClientConfig<WeatherClientConfig>) {
     let _config_0 = __getRuntimeConfig(configuration || {});
     let _config_1 = resolveClientEndpointParameters(_config_0);
@@ -407,7 +407,7 @@
     this.config = _config_8;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
-    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config));
+    this.middlewareStack.use(getHttpAuthSchemeEndpointRuleSetPlugin(this.config, { httpAuthSchemeParametersProvider: this.getDefaultHttpAuthSchemeParametersProvider(), identityProviderConfigProvider: this.getIdentityProviderConfigProvider() }));
     this.middlewareStack.use(getHttpSigningPlugin(this.config));
   }
```

Extension configuration bug fix:

```diff
diff --color -Nur og/src/auth/httpAuthExtensionConfiguration.ts new/src/auth/httpAuthExtensionConfiguration.ts
--- og/src/auth/httpAuthExtensionConfiguration.ts	2023-11-13 10:41:32
+++ new/src/auth/httpAuthExtensionConfiguration.ts	2023-11-13 10:42:47
@@ -3,13 +3,11 @@
 import {
   ApiKeyIdentity,
   ApiKeyIdentityProvider,
+  AwsCredentialIdentity,
+  AwsCredentialIdentityProvider,
   HttpAuthScheme,
   TokenIdentity,
   TokenIdentityProvider,
-} from "@smithy/experimental-identity-and-auth";
-import {
-  AwsCredentialIdentity,
-  AwsCredentialIdentityProvider,
 } from "@smithy/types";
 
 /**
@@ -50,7 +48,12 @@
   let _token = runtimeConfig.token;
   return {
     setHttpAuthScheme(httpAuthScheme: HttpAuthScheme): void {
-      _httpAuthSchemes.push(httpAuthScheme);
+      const index = _httpAuthSchemes.findIndex(scheme => scheme.schemeId === httpAuthScheme.schemeId);
+      if (index === -1) {
+        _httpAuthSchemes.push(httpAuthScheme);
+      } else {
+        _httpAuthSchemes.splice(index, 1, httpAuthScheme);
+      }
     },
     httpAuthSchemes(): HttpAuthScheme[] {
       return _httpAuthSchemes;
```

`httpAuthSchemes` and `httpAuthSchemeProvider` are now part of the input / resolved config of `resolveHttpAuthSchemeConfig`, and will only resolve configured identity providers.

```diff
diff --color -Nur og/src/auth/httpAuthSchemeProvider.ts new/src/auth/httpAuthSchemeProvider.ts
--- og/src/auth/httpAuthSchemeProvider.ts	2023-11-13 10:41:32
+++ new/src/auth/httpAuthSchemeProvider.ts	2023-11-13 10:42:47
@@ -1,25 +1,24 @@
 // smithy-typescript generated code
 import { WeatherClientResolvedConfig } from "../WeatherClient";
 import {
+  doesIdentityRequireRefresh,
+  isIdentityExpired,
+  memoizeIdentityProvider,
+} from "@smithy/core";
+import {
   ApiKeyIdentity,
   ApiKeyIdentityProvider,
-  DefaultIdentityProviderConfig,
+  AwsCredentialIdentity,
+  AwsCredentialIdentityProvider,
+  HandlerExecutionContext,
   HttpApiKeyAuthLocation,
   HttpAuthOption,
+  HttpAuthScheme,
   HttpAuthSchemeParameters,
   HttpAuthSchemeParametersProvider,
   HttpAuthSchemeProvider,
-  IdentityProviderConfig,
   TokenIdentity,
   TokenIdentityProvider,
-  doesIdentityRequireRefresh,
-  isIdentityExpired,
-  memoizeIdentityProvider,
-} from "@smithy/experimental-identity-and-auth";
-import {
-  AwsCredentialIdentity,
-  AwsCredentialIdentityProvider,
-  HandlerExecutionContext,
   Provider as __Provider,
 } from "@smithy/types";
 import {
@@ -155,6 +154,18 @@
  */
 export interface HttpAuthSchemeInputConfig {
   /**
+   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
+   * @internal
+   */
+  httpAuthSchemes?: HttpAuthScheme[];
+
+  /**
+   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
+   * @internal
+   */
+  httpAuthSchemeProvider?: WeatherHttpAuthSchemeProvider;
+
+  /**
    * The API key to use when making requests.
    */
   apiKey?: ApiKeyIdentity | ApiKeyIdentityProvider;
@@ -177,6 +188,18 @@
  */
 export interface HttpAuthSchemeResolvedConfig {
   /**
+   * experimentalIdentityAndAuth: Configuration of HttpAuthSchemes for a client which provides default identity providers and signers per auth scheme.
+   * @internal
+   */
+  readonly httpAuthSchemes: HttpAuthScheme[];
+
+  /**
+   * experimentalIdentityAndAuth: Configuration of an HttpAuthSchemeProvider for a client which resolves which HttpAuthScheme to use.
+   * @internal
+   */
+  readonly httpAuthSchemeProvider: WeatherHttpAuthSchemeProvider;
+
+  /**
    * The API key to use when making requests.
    */
   readonly apiKey?: ApiKeyIdentityProvider;
@@ -192,16 +215,6 @@
    * The token used to authenticate requests.
    */
   readonly token?: TokenIdentityProvider;
-  /**
-   * experimentalIdentityAndAuth: provides parameters for HttpAuthSchemeProvider.
-   * @internal
-   */
-  readonly httpAuthSchemeParametersProvider: WeatherHttpAuthSchemeParametersProvider;
-  /**
-   * experimentalIdentityAndAuth: abstraction around identity configuration fields
-   * @internal
-   */
-  readonly identityProviderConfig: IdentityProviderConfig;
 }
 
 /**
@@ -218,11 +231,5 @@
     credentials,
     region,
     token,
-    httpAuthSchemeParametersProvider: defaultWeatherHttpAuthSchemeParametersProvider,
-    identityProviderConfig: new DefaultIdentityProviderConfig({
-      "aws.auth#sigv4": credentials,
-      "smithy.api#httpApiKeyAuth": apiKey,
-      "smithy.api#httpBearerAuth": token,
-    }),
-  };
+  } as HttpAuthSchemeResolvedConfig;
 };
```

And remove all references to `@smithy/experimental-identity-and-auth` for things that are stable, e.g.

```diff
diff --color -Nur og/src/runtimeConfig.shared.ts new/src/runtimeConfig.shared.ts
--- og/src/runtimeConfig.shared.ts	2023-11-13 10:41:32
+++ new/src/runtimeConfig.shared.ts	2023-11-13 10:42:47
@@ -3,11 +3,11 @@
 import {
   HttpApiKeyAuthSigner,
   HttpBearerAuthSigner,
-  IdentityProviderConfig,
   NoAuthSigner,
-  SigV4Signer,
-} from "@smithy/experimental-identity-and-auth";
+} from "@smithy/core";
+import { SigV4Signer } from "@smithy/experimental-identity-and-auth";
 import { NoOpLogger } from "@smithy/smithy-client";
+import { IdentityProviderConfig } from "@smithy/types";
 import { parseUrl } from "@smithy/url-parser";
 import {
   fromBase64,
```

Also, the code section comments for operations are now removed as they aren't really necessary, e.g.

```diff
diff --color -Nur og/src/commands/CreateCityCommand.ts new/src/commands/CreateCityCommand.ts
--- og/src/commands/CreateCityCommand.ts	2023-11-13 10:41:32
+++ new/src/commands/CreateCityCommand.ts	2023-11-13 10:42:47
@@ -91,8 +91,6 @@
  *
  */
 export class CreateCityCommand extends $Command<CreateCityCommandInput, CreateCityCommandOutput, WeatherClientResolvedConfig> {
-  // Start section: command_properties
-  // End section: command_properties
 
   public static getEndpointParameterInstructions(): EndpointParameterInstructions {
     return {
@@ -104,9 +102,7 @@
    * @public
    */
   constructor(readonly input: CreateCityCommandInput) {
-    // Start section: command_constructor
     super();
-    // End section: command_constructor
   }
 
   /**
@@ -168,6 +164,4 @@
     return de_CreateCityCommand(output, context);
   }
 
-  // Start section: command_body_extra
-  // End section: command_body_extra
 }
```

*Testing*

Testing was done on this branch: https://github.com/syall/smithy-typescript/tree/ts-ia-finalize-staging

To get it to work with the unpublished NPM changes for `@smithy/core`, the following was done:

- Run `./gradlew :smithy-typescript-codegen-test:clean :smithy-typescript-codegen-test:build` to generate the clients
- Remove `@smithy/core` from the generated clients' `package.json`s
- Replace `import { ... } from "@smithy/core"` with an absolute path to the repository's node modules of `@smithy/core`
- Run `node scripts/build-generated-test-packages.js`
- Run `yarn turbo run test:integration`

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
