### PR TITLE
fix(util-utf8): use Node.js implementations in react-native

### DIFF
--- a/.changeset/red-kiwis-prove.md
+++ b/.changeset/red-kiwis-prove.md
@@ -1,0 +1,5 @@
+---
+"@smithy/util-utf8": patch
+---
+
+Use Node.js implementations in react-native

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -50,12 +50,7 @@
     "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
     "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
   },
-  "react-native": {
-    "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
-    "./dist-es/toUtf8": "./dist-es/toUtf8.browser",
-    "./dist-cjs/fromUtf8": "./dist-cjs/fromUtf8.browser",
-    "./dist-cjs/toUtf8": "./dist-cjs/toUtf8.browser"
-  },
+  "react-native": {},
   "homepage": "https://github.com/awslabs/smithy-typescript/tree/main/packages/util-utf8",
   "repository": {
     "type": "git",


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/smithy-typescript/issues/1069

*Description of changes:*
Use Node.js implementations in react-native

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
