### PR TITLE
Fix `@smithy/core` test script

### DIFF
--- a/.changeset/eight-files-battle.md
+++ b/.changeset/eight-files-battle.md
@@ -1,0 +1,5 @@
+---
+"@smithy/core": patch
+---
+
+Fix test script.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "lint": "eslint -c ../../.eslintrc.js \"src/**/*.ts\"",
     "format": "prettier --config ../../prettier.config.js --ignore-path ../.prettierignore --write \"**/*.{ts,md,json}\"",
-    "test": "yarn g:jest"
+    "test": "yarn g:jest --passWithNoTests"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",


### PR DESCRIPTION
*Issue #, if available:*

CI is failing due to `jest` running with no tests, e.g. https://github.com/awslabs/smithy-typescript/actions/runs/6856857747/job/18645531179#step:8:69

*Description of changes:*

Fix `@smithy/core` test script.

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
