### PR TITLE
feat(experimentalIdentityAndAuth): rename `IdentityProviderConfig` name to `ipc`

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/RuntimeConfigGenerator.java
@@ -263,8 +263,8 @@ final class RuntimeConfigGenerator {
                         w.write("""
                             {
                               schemeId: $S,
-                              identityProvider: (config: IdentityProviderConfig) =>
-                                config.getIdentityProvider($S),
+                              identityProvider: (ipc: IdentityProviderConfig) =>
+                                ipc.getIdentityProvider($S),
                               signer: $C,
                             }""",
                             entry.httpAuthScheme.getSchemeId(),
@@ -274,8 +274,8 @@ final class RuntimeConfigGenerator {
                         w.write("""
                             {
                               schemeId: $S,
-                              identityProvider: (config: IdentityProviderConfig) =>
-                                config.getIdentityProvider($S) || ($C),
+                              identityProvider: (ipc: IdentityProviderConfig) =>
+                                ipc.getIdentityProvider($S) || ($C),
                               signer: $C,
                             }""",
                             entry.httpAuthScheme.getSchemeId(),


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

***Unrelated, TypeScript Test CI fails, fix is in another PR: https://github.com/awslabs/smithy-typescript/pull/1072***

Rename `IdentityProviderConfig` variable name `config` to `ipc` since `config` is already used as a top-level function parameter, e.g.

```diff
diff --color -Nur og/src/runtimeConfig.shared.ts new/src/runtimeConfig.shared.ts
--- og/src/runtimeConfig.shared.ts	2023-11-13 19:57:07
+++ new/src/runtimeConfig.shared.ts	2023-11-13 19:57:56
@@ -33,23 +33,23 @@
   httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultWeatherHttpAuthSchemeProvider,
   httpAuthSchemes: config?.httpAuthSchemes ?? [{
         schemeId: "aws.auth#sigv4",
-        identityProvider: (config: IdentityProviderConfig) =>
-          config.getIdentityProvider("aws.auth#sigv4"),
+        identityProvider: (ipc: IdentityProviderConfig) =>
+          ipc.getIdentityProvider("aws.auth#sigv4"),
         signer: new SigV4Signer(),
       }, {
         schemeId: "smithy.api#httpApiKeyAuth",
-        identityProvider: (config: IdentityProviderConfig) =>
-          config.getIdentityProvider("smithy.api#httpApiKeyAuth"),
+        identityProvider: (ipc: IdentityProviderConfig) =>
+          ipc.getIdentityProvider("smithy.api#httpApiKeyAuth"),
         signer: new HttpApiKeyAuthSigner(),
       }, {
         schemeId: "smithy.api#httpBearerAuth",
-        identityProvider: (config: IdentityProviderConfig) =>
-          config.getIdentityProvider("smithy.api#httpBearerAuth"),
+        identityProvider: (ipc: IdentityProviderConfig) =>
+          ipc.getIdentityProvider("smithy.api#httpBearerAuth"),
         signer: new HttpBearerAuthSigner(),
       }, {
         schemeId: "smithy.api#noAuth",
-        identityProvider: (config: IdentityProviderConfig) =>
-          config.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
+        identityProvider: (ipc: IdentityProviderConfig) =>
+          ipc.getIdentityProvider("smithy.api#noAuth") || (async () => ({})),
         signer: new NoAuthSigner(),
       }],
   logger: config?.logger ?? new NoOpLogger(),

```

If one or more of the packages in the `/packages` directory has been modified, be sure `yarn changeset add` has been run and its output has
been committed and included in this pull request. See CONTRIBUTING.md.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
